### PR TITLE
fix(ci): resolve workflow failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
 env:
   GO_VERSION: '1.24'
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -25,13 +25,16 @@ jobs:
       
     - name: Prepare installation endpoint
       run: |
+        # Ensure docs directory exists
+        mkdir -p docs
+
         # Copy installation script to docs root as index
         cp scripts/install.sh docs/index.sh
         chmod +x docs/index.sh
-        
+
         # Create proper MIME type handling
         echo 'text/x-shellscript sh' > docs/.htaccess
-        
+
         # Create redirect HTML for browsers
         cat > docs/index.html << 'EOF'
         <!DOCTYPE html>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,7 @@ jobs:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
     needs: goreleaser
+    if: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

This PR addresses three CI workflow failures that occurred after the v0.2.0 release:

### 1. Security Scan Failure ✅
**Issue**: CodeQL Action couldn't upload SARIF results due to missing permissions
**Error**: `Resource not accessible by integration`
**Fix**: Added `security-events: write` permission to CI workflow

### 2. Docker Build Failure ✅
**Issue**: Docker Hub login failed due to missing credentials
**Error**: `Username and password required`
**Fix**: Made Docker build conditional - only runs when `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets are available

### 3. GitHub Pages Deployment ✅
**Issue**: Potential failure if docs directory doesn't exist
**Fix**: Added `mkdir -p docs` to ensure directory exists before copying files

## Changes Made

- `.github/workflows/ci.yml`: Added permissions block with `security-events: write`
- `.github/workflows/release.yml`: Added conditional check for Docker Hub credentials
- `.github/workflows/deploy-pages.yml`: Added directory creation for robustness

## Testing

After this PR is merged:
- Security scans should complete successfully
- Docker build will be skipped until credentials are added (optional feature)
- Pages deployment should work reliably

## Related

Fixes workflow failures on main branch after v0.2.0 release (#2)