### PR TITLE
fix(ci): enable GitHub Pages automatically

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -22,6 +22,8 @@ jobs:
     
     - name: Setup Pages
       uses: actions/configure-pages@v4
+      with:
+        enablement: true
       
     - name: Prepare installation endpoint
       run: |


### PR DESCRIPTION
## Summary

The deploy-pages workflow was failing with:
```
Get Pages site failed. Please verify that the repository has Pages enabled and configured to build using GitHub Actions
```

## Root Cause

GitHub Pages wasn't enabled in the repository settings.

## Fix

Add `enablement: true` to `actions/configure-pages@v4` to automatically enable GitHub Pages when the workflow runs.

## Changes

- `.github/workflows/deploy-pages.yml`: Added `enablement: true` parameter

## Testing

After merging, the Pages deployment should work automatically.