### PR TITLE
chore: add local documentation files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 
+# Planning & Temporary Files
+plan/
+AGENTS.md
+
 # Claude Flow generated files
 .claude/settings.local.json
 .mcp.json


### PR DESCRIPTION
## Summary

Updates `.gitignore` to exclude local agent workflow documentation and planning files from version control.

## Changes

Added to `.gitignore`:
- `AGENTS.md` - Local agent workflow documentation (bd/beads)
- `plan/` - Temporary planning and task organization directory

## Rationale

These files are environment-specific and should remain local:

**AGENTS.md:**
- Auto-generated or maintained locally via `bd onboard`
- Contains workflow context specific to each developer's setup
- Can be regenerated with `bd prime`

**plan/:**
- Temporary task planning and organization files
- Development scratchpad, not for repository

## Impact

- ✅ Prevents accidental commits of local workflow files
- ✅ Keeps repository clean of environment-specific documentation
- ✅ Each developer can maintain their own AGENTS.md locally

## Related

Closes #14 (which attempted to commit AGENTS.md - now properly ignored)

Completes bd doctor setup with local-only agent documentation approach.