### PR TITLE
docs(security): document gosec exclusion configuration limitation (PR #19)

### DIFF
--- a/docs/GOSEC_PHASE2.md
+++ b/docs/GOSEC_PHASE2.md
@@ -185,18 +185,32 @@ linters-settings:
 - ✅ **All test code** uses bounded operations
 - ✅ **Hardcoded credentials** limited to test fixtures
 
-### Remaining Work
+### Re-enablement Status
+
+**Current Limitation** (golangci-lint 2.8.0):
+- `linters-settings.gosec.excludes` configuration is not recognized by golangci-lint
+- `issues.exclude-rules` with text matching also does not apply to gosec
+- This appears to be a version-specific limitation
+
+**Pending Resolution**:
+1. **Test with alternative approaches**:
+   - Try newer golangci-lint version if available
+   - Check if different configuration syntax is supported
+   - Investigate if native gosec configuration works differently
+
+2. **Once exclusion mechanism works**:
+   - Uncomment gosec in `.golangci.yml` linters.enable section
+   - Verify `make lint` passes with 0 issues (all exclusions working)
+   - Add gosec to CI/CD pipeline
+
+3. **Fallback approach**:
+   - Add `// nolint:gosec` suppression comments in specific files if needed
+   - Less maintainable than global rules but ensures linter compliance
 
 **Phase 2c - Not Yet Started**:
 - G404: Weak random number generation (in auth/config packages)
   - Determine if weak random is acceptable for non-security operations
   - Consider crypto/rand migration if needed
-
-**Re-enablement**:
-1. Validate exclusion rules work correctly
-2. Run `golangci-lint run --enable=gosec` - should show 0 issues
-3. Merge PR to re-enable gosec in CI/CD
-4. Monitor CI for any new gosec findings
 
 ---
 


### PR DESCRIPTION
## Issue

Attempted to re-enable gosec linter (PR #18 prepared the exclusion rules), but discovered that golangci-lint 2.8.0 does not properly apply gosec exclusion rules.

## Investigation

Tested multiple approaches:
1. **linters-settings.gosec.excludes**: Not recognized by golangci-lint
2. **issues.exclude-rules with text matching**: Does not apply to gosec
3. **Direct rule codes in excludes**: Still not filtered

## Status

- gosec remains disabled in 
- All 24 security issues properly analyzed and documented (PR #18)
- Exclusion rationale documented in docs/GOSEC_PHASE2.md
- Re-enablement blocked pending resolution of configuration mechanism

## Next Steps

1. Investigate newer golangci-lint versions
2. Check alternative configuration syntax or native gosec options
3. Fallback: use `// nolint:gosec` suppression comments if needed
4. Update configuration once mechanism is working

This is a non-blocking documentation update clarifying the current state.

## Test Plan

- [x] Run `make lint` - passes with 0 issues (gosec disabled)
- [x] Documentation updated with limitation details

Relates to: s9s-9o8 (gosec re-enablement)