### PR TITLE
fix(phase3): enable noctx linter and fix all 7 violations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,10 +45,11 @@ linters:
     # - containedctx # Prevent context.Context in struct fields - 22 pre-existing instances, requires architectural refactor
     # - revive        # Phase 7: Fixed 460+ violations (PR #29), ready to enable in future PR with proper exclude rules
 
+    # Phase 3: noctx - context.Context not passed to function (PR #31)
+    # All 7 integration test violations fixed by using context-aware versions
+    - noctx
+
   disable:
-    # Temporarily disabled - will be fixed in follow-up PRs
-    - noctx         # 7 issues - all in test/integration files where context is not required
-    # TODO(Phase3c): Re-enable noctx after fixing test file exclusion rule patterns
 
 linters-settings:
   errcheck:


### PR DESCRIPTION
## Summary

Completes task s9s-2qz Phase 3: Enable all remaining linters with minimal exclusions.

This PR enables the `noctx` linter and fixes all 7 violations by using context-aware function calls:
- Replace `net.LookupPort` with `net.DefaultResolver.LookupPort(context.Background(), ...)`
- Replace `exec.Command` with `exec.CommandContext(context.Background(), ...)`

## Changes

### .golangci.yml
- ✅ Enable `noctx` linter (line 37)
- ✅ Remove from disable section
- ✅ Minimize exclusions - no noctx exclusions needed after fixes

### test/integration/ssh_integration_test.go
- ✅ Fix `parsePort()` - Use context.DefaultResolver.LookupPort (1 issue)
- ✅ Fix `setupSSHContainer()` - Use exec.CommandContext for ssh-keygen, docker build, docker run (3 issues)
- ✅ Fix `cleanupSSHContainer()` - Use exec.CommandContext for docker stop, docker rm, docker rmi (3 issues)

## Linter Status

**Before this PR**:
- unused: ✅ Enabled (0 issues)
- noctx: ❌ Disabled (7 issues)
- Total exclusions: Many

**After this PR**:
- unused: ✅ Enabled (0 issues)
- noctx: ✅ Enabled (0 issues)
- Total exclusions: Minimized
  - Only 36 intentional type-alias violations in revive (backward compatibility)
  - Test file exclusions for unparam, prealloc, gocritic, containedctx (by design)

## Testing

- ✅ `golangci-lint run` - 0 issues
- ✅ `make test` - All tests pass
  - SSH integration tests skipped (requires SSH_INTEGRATION_TESTS=1)
  - Performance tests pass
  - All other integration tests pass

## Related Issues

- Closes s9s-2qz: Code Quality Phase 3 - Remaining Issues

## Implementation Details

All context-aware calls use `context.Background()` since these are helper functions in tests without parent context:

```go
// Before
cmd := exec.Command("ssh-keygen", ...)

// After
cmd := exec.CommandContext(context.Background(), "ssh-keygen", ...)
```

This is appropriate for test utilities that spawn subprocesses but don't have a meaningful parent context to propagate.