### PR TITLE
chore: remove binary files (gotty, test-s9s) from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,14 @@ coverage.txt
 coverage.out
 coverage.html
 *.coverage
+
+# Build artifacts & binaries
+build/
+dist/
+s9s
+gotty
+test-s9s
+*.exe
+*.dll
+*.so
+*.dylib


### PR DESCRIPTION
## Summary

Removes large binary files that were accidentally committed to the repository.

## Changes

- **Removed gotty** (8.7 MB executable)
- **Removed test-s9s** (3.4 MB executable)
- **Updated .gitignore** to prevent future commits of:
  - Build artifacts: build/, dist/
  - Binary files: s9s, gotty, test-s9s
  - Common extensions: .exe, .dll, .so, .dylib

## Impact

- Significantly reduces repository size
- Prevents large binaries from being committed
- Repository is now cleaner and more efficient
