### PR TITLE
fix(jobs): remove aggressive loading modal from refresh

### DIFF
--- a/internal/views/jobs.go
+++ b/internal/views/jobs.go
@@ -43,8 +43,6 @@ type JobsView struct {
 	batchOpsView        *BatchOperationsView
 	multiSelectMode     bool
 	selectionStatusText *tview.TextView
-	loadingManager      *components.LoadingManager
-	loadingWrapper      *components.LoadingWrapper
 	mainStatusBar       *components.StatusBar // Reference to main app status bar
 }
 
@@ -67,12 +65,6 @@ func (v *JobsView) SetPages(pages *tview.Pages) {
 // SetApp sets the application reference
 func (v *JobsView) SetApp(app *tview.Application) {
 	v.app = app
-
-	// Initialize loading manager
-	if v.pages != nil {
-		v.loadingManager = components.NewLoadingManager(app, v.pages)
-		v.loadingWrapper = components.NewLoadingWrapper(v.loadingManager, "jobs")
-	}
 
 	// Create filter bar now that we have app reference
 	v.filterBar = components.NewFilterBar("jobs", app)
@@ -191,13 +183,7 @@ func (v *JobsView) Refresh() error {
 	v.SetRefreshing(true)
 	defer v.SetRefreshing(false)
 
-	// Show loading indicator for operations that might take time
-	if v.loadingWrapper != nil {
-		return v.loadingWrapper.WithLoading("Refreshing jobs...", func() error {
-			return v.refreshInternal()
-		})
-	}
-
+	// Refresh silently without modal - refreshes happen frequently and users don't need to see them
 	return v.refreshInternal()
 }
 


### PR DESCRIPTION
## Problem

The "Refreshing jobs..." modal appears too frequently since job refresh happens automatically every 30-60 seconds. This modal would:
- Obscure other UI elements and modals
- Interfere with user interaction
- Block view of important information during routine refreshes

## Solution

Remove the loading modal from the Refresh() method and let automatic refreshes happen silently.

## Changes

1. **Refresh()**: Removed `WithLoading()` call - now refreshes silently while maintaining internal state tracking
2. **SetApp()**: Removed loadingManager and loadingWrapper initialization (no longer needed)
3. **JobsView struct**: Removed unused fields: `loadingManager` and `loadingWrapper`

The `SetRefreshing()` calls remain to properly track refresh state internally for UI indicators.

## Testing

- ✅ Build successful
- ✅ All tests pass (11.639s)
- ✅ No functionality lost - refresh still works, just no modal

## User Impact

Automatic job refreshes now happen silently without disrupting:
- Open modals
- Dialog interactions
- User workflow

Users can still see refresh progress through the status bar if needed.

Fixes: "Refreshing jobs..." modal blocking UI