### PR TITLE
fix(nodes): fix input field focus loss in drain and partition filter modals

### DIFF
--- a/internal/views/nodes.go
+++ b/internal/views/nodes.go
@@ -677,16 +677,33 @@ func (v *NodesView) drainSelectedNode() {
 			if reason == "" {
 				reason = "Manual drain"
 			}
+			if v.pages != nil {
+				v.pages.RemovePage("drain-input")
+			}
 			go v.performDrainNode(nodeName, reason)
 		}
-		v.app.SetRoot(v.container, true)
 	})
 
 	input.SetBorder(true).
 		SetTitle(" Drain Node ").
 		SetTitleAlign(tview.AlignCenter)
 
-	v.app.SetRoot(input, true)
+	// Handle ESC key to close modal
+	input.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		if event.Key() == tcell.KeyEsc {
+			if v.pages != nil {
+				v.pages.RemovePage("drain-input")
+			}
+			return nil
+		}
+		return event
+	})
+
+	// Use pages API instead of SetRoot for proper modal management
+	if v.pages != nil {
+		v.pages.AddPage("drain-input", input, true, true)
+		v.app.SetFocus(input)
+	}
 }
 
 // performDrainNode performs the node drain operation
@@ -1271,16 +1288,33 @@ func (v *NodesView) promptPartitionFilter() {
 	input.SetDoneFunc(func(key tcell.Key) {
 		if key == tcell.KeyEnter {
 			v.partFilter = input.GetText()
+			if v.pages != nil {
+				v.pages.RemovePage("partition-filter")
+			}
 			go func() { _ = v.Refresh() }()
 		}
-		v.app.SetRoot(v.container, true)
 	})
 
 	input.SetBorder(true).
 		SetTitle(" Partition Filter ").
 		SetTitleAlign(tview.AlignCenter)
 
-	v.app.SetRoot(input, true)
+	// Handle ESC key to close modal
+	input.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		if event.Key() == tcell.KeyEsc {
+			if v.pages != nil {
+				v.pages.RemovePage("partition-filter")
+			}
+			return nil
+		}
+		return event
+	})
+
+	// Use pages API instead of SetRoot for proper modal management
+	if v.pages != nil {
+		v.pages.AddPage("partition-filter", input, true, true)
+		v.app.SetFocus(input)
+	}
 }
 
 // groupNodes groups nodes based on the current groupBy setting


### PR DESCRIPTION
## Summary

Fixed issue where input fields in the Nodes view drain node and partition filter modals would quickly lose focus, making them effectively unusable.

## Root Cause

Both modals were using `v.app.SetRoot()` to display the input field instead of the `v.pages` API used by other modals. This caused:
1. Global keyboard handlers to interfere with the input field
2. No proper modal lifecycle management
3. Focus to be lost or transferred unexpectedly

## Solution

Refactored both modals to use the standard `v.pages` API:

### Changes Made

**drainSelectedNode() function:**
- Replace `v.app.SetRoot(input, true)` with `v.pages.AddPage("drain-input", input, true, true)`
- Add InputCapture handler to handle ESC key
- Explicitly call `v.app.SetFocus(input)` to ensure focus
- Properly remove page from pages when user presses Enter or ESC

**promptPartitionFilter() function:**
- Same fixes applied for consistency
- Replace `v.app.SetRoot(input, true)` with `v.pages.AddPage("partition-filter", input, true, true)`
- Add InputCapture handler for ESC key
- Set explicit focus on input field

## Benefits

- Input fields now maintain focus while modals are open
- Consistent modal handling across the application
- ESC key properly closes modals
- Global keyboard handlers no longer interfere with modal input

## Testing

- ✅ Build succeeds
- ✅ All unit tests pass (60+ tests)
- ✅ All integration tests pass

## User Experience Impact

Users can now:
- Type in drain reason field without losing focus
- Use partition filter without field losing focus
- Press ESC to cancel either operation