### PR TITLE
fix(observability): Prevent information disclosure in validation errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,11 @@ hive-mind-prompt-*.txt
 CLAUDE.md
 memory/
 # docs/ - Documentation is now tracked in git! Only ignore generated docs if needed.
+
+# Observability plugin documentation (local-only, not committed upstream)
+plugins/observability/docs/adr/*.md
+plugins/observability/docs/*.md
+
 s9s
 
 # Test artifacts

--- a/plugins/observability/security/validation.go
+++ b/plugins/observability/security/validation.go
@@ -3,6 +3,7 @@ package security
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -373,14 +374,19 @@ func parseTimeParameter(timeStr string) (time.Time, error) {
 }
 
 // writeValidationError writes a validation error response
+// Note: Does NOT expose internal error details for security reasons
+// (prevents information disclosure about validation rules/implementation)
 func writeValidationError(w http.ResponseWriter, err error) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusBadRequest)
 
+	// Security: Do not expose err.Error() details to clients
+	// Log internally for debugging, but return generic message
+	log.Printf("Validation error (not exposed to client): %v", err)
+
 	response := map[string]interface{}{
 		"status": "error",
-		"error":  "Validation failed",
-		"detail": err.Error(),
+		"error":  "Request validation failed",
 		"code":   "VALIDATION_ERROR",
 	}
 


### PR DESCRIPTION
## Summary

**Security Fix**: Remove internal error detail exposure from validation error responses.

## Problem

The validation middleware was exposing raw `err.Error()` messages in API responses, creating an information disclosure vulnerability.

**Example of exposed details**:
```json
{
  "detail": "query exceeds maximum length of 2048 characters (got 3000)"
}
```

This leaks:
- Validation rule thresholds (2048 char limit)
- Implementation details (character counting)
- Attack surface information (what patterns are blocked)
- Potentially file paths, regex patterns, or system info

## Solution

**Code Changes** (`plugins/observability/security/validation.go`):
- ✅ Removed `"detail"` field from error responses
- ✅ Added server-side logging: `log.Printf("Validation error (not exposed to client): %v", err)`
- ✅ Return generic message: `"Request validation failed"`
- ✅ Added security comments explaining rationale

**Configuration** (`.gitignore`):
- ✅ Added observability plugin docs to .gitignore (local-only development docs)

## Before & After

### Before (Vulnerable)
```json
{
  "status": "error",
  "error": "Validation failed",
  "detail": "query exceeds maximum length of 2048 characters (got 3000)",
  "code": "VALIDATION_ERROR"
}
```

### After (Secure)
```json
{
  "status": "error",
  "error": "Request validation failed",
  "code": "VALIDATION_ERROR"
}
```

Error details logged server-side only for debugging:
```
2026/02/08 Validation error (not exposed to client): query exceeds maximum length of 2048 characters (got 3000)
```

## Security Impact

**Severity**: Medium
- **Before**: Internal validation logic exposed to clients
- **After**: Generic error messages, details logged internally only

**Mitigates**:
- Information disclosure about validation rules
- Reconnaissance for attackers probing security boundaries
- Potential leakage of file paths or internal structure

## Testing

- ✅ Error logging verified (server-side only)
- ✅ API response format validated
- ✅ No internal details in response body
- ✅ Generic error message returned to client

## Related

- Task: s9s-50e
- Files: 2 changed (+13, -2)