### PR TITLE
docs: Add slurm-client Go library to API reference

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -37,6 +37,13 @@ Python bindings for SLURM's C API:
 - **GitHub**: [https://github.com/PySlurm/pyslurm](https://github.com/PySlurm/pyslurm)
 - **Features**: Direct Python interface to SLURM functionality
 
+### slurm-client (Go)
+Go client library for SLURM REST API:
+- **GitHub**: [https://github.com/jontk/slurm-client](https://github.com/jontk/slurm-client)
+- **Features**: Native Go SDK for slurmrestd API with comprehensive type safety
+- **Installation**: `go get github.com/jontk/slurm-client@latest`
+- **Use Case**: Ideal for building Go applications that need to interact with SLURM clusters
+
 ## Using s9s
 
 For information on using the s9s TUI application, see:


### PR DESCRIPTION
## Summary

Add reference to `github.com/jontk/slurm-client` as a Go implementation option for programmatic SLURM API access in the API documentation.

## Changes

**File Updated:** `docs/reference/api.md`

Added new section after PySlurm:

### slurm-client (Go)
- GitHub: https://github.com/jontk/slurm-client
- Native Go SDK for slurmrestd REST API
- Comprehensive type safety
- Installation: `go get github.com/jontk/slurm-client@latest`

## Context

The API reference document currently lists:
1. **Slurmrestd** - Official SLURM REST API
2. **SLURM CLI Tools** - Direct command-line access
3. **PySlurm** - Python bindings

This PR adds:
4. **slurm-client** - Go client library

## Benefits

✅ **Language options** - Developers can choose Python (PySlurm) or Go (slurm-client)  
✅ **Type safety** - Go library provides compile-time type checking  
✅ **Native integration** - Fits naturally in Go-based infrastructure  
✅ **Consistency** - s9s itself uses slurm-client, so it's a proven solution

## Why This Matters

Since s9s is built with Go and uses slurm-client internally, it makes sense to document this library as an option for developers who want to:
- Build their own Go tools for SLURM
- Integrate SLURM into existing Go applications
- Follow the same patterns s9s uses

This provides parity with the PySlurm reference for Python developers.