### PR TITLE
feat: enable s9s to work without configuration file using auto-discovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,11 +42,11 @@ version:
 	@echo "Built:     $(DATE)"
 	@echo "Built by:  $(BUILT_BY)"
 
-# Build the application
+# Build the application (static binary for portability)
 build:
 	@echo "Building $(BINARY_NAME) $(VERSION)..."
 	@mkdir -p $(BUILD_DIR)
-	$(GOBUILD) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME) ./cmd/s9s
+	CGO_ENABLED=0 $(GOBUILD) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME) ./cmd/s9s
 
 # Clean build artifacts
 clean:

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -161,11 +161,19 @@ func createSlurmClient(appCtx context.Context, cfg *config.Config, cancel contex
 }
 
 func findClusterConfig(cfg *config.Config) *config.ClusterConfig {
+	// First check if there's a matching context
 	for _, ctx := range cfg.Contexts {
 		if ctx.Name == cfg.CurrentContext {
 			return &ctx.Cluster
 		}
 	}
+
+	// Fall back to cfg.Cluster if no contexts exist (e.g., auto-discovery without config file)
+	// Don't check for endpoint here as it may be populated later by discovery
+	if len(cfg.Contexts) == 0 {
+		return &cfg.Cluster
+	}
+
 	return nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -408,6 +408,16 @@ func (c *Config) setCurrentCluster() error {
 		return nil
 	}
 
+	// If no contexts exist and discovery is enabled, allow startup with empty cluster
+	// Auto-discovery will populate the cluster configuration
+	if len(c.Contexts) == 0 && c.Discovery.Enabled {
+		c.Cluster = ClusterConfig{
+			// Leave APIVersion empty to enable auto-detection from slurmrestd
+			Timeout: "30s",
+		}
+		return nil
+	}
+
 	return fmt.Errorf("context %q not found", c.CurrentContext)
 }
 

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -2,23 +2,42 @@
 package debug
 
 import (
+	"io"
 	"log"
 	"os"
 
 	"github.com/jontk/s9s/internal/fileperms"
-	"github.com/jontk/s9s/internal/logging"
 )
 
 // Logger is the debug logger instance used for debug output.
 var Logger *log.Logger
 
+// debugEnabled controls whether debug logging is active
+var debugEnabled = false
+
 func init() {
-	// Create debug log file
+	// By default, disable debug logging by writing to io.Discard
+	// This prevents debug messages from interfering with the TUI
+	Logger = log.New(io.Discard, "[DEBUG] ", log.LstdFlags|log.Lmicroseconds)
+}
+
+// Enable turns on debug logging to a file
+func Enable() {
+	debugEnabled = true
+
+	// Try to create debug log file
 	logFile, err := os.OpenFile("s9s-debug.log", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, fileperms.LogFile)
 	if err != nil {
-		logging.Errorf("Failed to create debug log file: %v", err)
-		Logger = log.New(os.Stderr, "[DEBUG] ", log.LstdFlags|log.Lmicroseconds)
-	} else {
-		Logger = log.New(logFile, "[DEBUG] ", log.LstdFlags|log.Lmicroseconds)
+		// If we can't create the log file, keep writing to io.Discard
+		// NEVER write to stderr/stdout as it interferes with the TUI
+		return
 	}
+
+	// Successfully created log file, write debug output there
+	Logger = log.New(logFile, "[DEBUG] ", log.LstdFlags|log.Lmicroseconds)
+}
+
+// IsEnabled returns whether debug logging is enabled
+func IsEnabled() bool {
+	return debugEnabled
 }


### PR DESCRIPTION
## Summary

Enables s9s to work out-of-the-box on SLURM systems without requiring manual configuration.

- **Static binary builds**: Add `CGO_ENABLED=0` to Makefile for cross-distribution compatibility (NixOS, Rocky, Ubuntu, etc.)
- **Config-free startup**: Allow s9s to start with no config file when auto-discovery is enabled
- **API version auto-detection**: Remove hardcoded `v0.0.43`, let slurm-client detect the latest version from slurmrestd
- **Authentication fix**: Switch from `auth.NewTokenAuth()` to `slurm.WithUserToken()` to set both `X-SLURM-USER-NAME` and `X-SLURM-USER-TOKEN` headers (fixes 401 errors)
- **Discovery order fix**: Discover endpoint → token → create context (previously context was created too early, losing the token)
- **Debug system rewrite**: Use `io.Discard` by default, only log to file with `--debug` flag (fixes debug messages overlaying TUI)
- **Config fallback**: Fix `findClusterConfig()` to fall back to `cfg.Cluster` when no contexts exist

## Test Plan

- [x] `TestLoadWithNoConfigNoContextsButDiscoveryEnabled` — verifies config-free startup with discovery
- [x] `TestConfigFileWithContextsTakesPrecedenceOverDiscovery` — verifies config file values are not overridden by discovery
- [ ] Manual test on SLURM system without config file