### PR TITLE
feat(export): implement comprehensive table export for all views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Table Export for All Views** (#85)
+  - Press `e` in any view to export the current data to a file
+  - Supported views: Jobs, Nodes, Partitions, Reservations, QoS, Accounts, Users
+  - Supported formats: CSV, JSON, Text (ASCII table), Markdown, HTML
+  - Export dialog shows record count, format picker, and configurable output path
+  - Files are written to `~/slurm_exports/` by default with timestamped filenames (e.g. `jobs_20260218_143022.csv`)
+  - JSON exports include a structured envelope with `title`, `exported_at`, `total`, and `records` keyed by column name
+  - Export paths are validated to prevent writes outside the user's home directory
+
 ### Changed
 
 ### Fixed

--- a/docs/user-guide/export.md
+++ b/docs/user-guide/export.md
@@ -1,259 +1,133 @@
-# Export & Reporting Guide
+# Export Guide
 
-Export S9S data in supported formats for analysis, reporting, and integration with other tools and workflows.
+Export data from any s9s view to a file for analysis, reporting, or integration with other tools.
 
-## Quick Export
+## Quick Start
 
-### Basic Export Commands
+In any supported view, press **`e`** to open the export dialog:
 
-```bash
-# Export current view to CSV
-:export csv
+1. Select a **format** (CSV is the default)
+2. Confirm or change the **output directory** (`~/slurm_exports` by default)
+3. Click **Export**
 
-# Export selected jobs to JSON
-/user:alice state:COMPLETED
-:export --selected json
+A confirmation modal shows the full path of the saved file when done.
 
-# Export with custom filename
-:export csv --output my-jobs.csv
+## Supported Views
 
-# Export to Markdown
-:export md --output report.md
+Export is available in all main data views:
 
-# Export to plain text
-:export txt --output jobs.txt
-```
+| View | Key | Exported Data |
+|------|-----|---------------|
+| Jobs | `e` | ID, Name, User, Account, State, Partition, Nodes, Time Used, Time Limit, Priority, Submit Time |
+| Nodes | `e` | Name, State, Partitions, CPU totals/allocated/idle/load, Memory totals, Features, Reason |
+| Partitions | `e` | Name, State, Total Nodes, Total CPUs, Default Time, Max Time, QoS, Nodes |
+| Reservations | `e` | Name, State, Start/End Time, Duration, Nodes, Node Count, Core Count, Users, Accounts |
+| QoS | `e` | Name, Priority, Preempt Mode, Flags, all per-user/account limits |
+| Accounts | `e` | Name, Description, Organization, Parent, QoS, Coordinators, resource limits |
+| Users | `e` | Name, UID, Default Account, Accounts, Admin Level, QoS, resource limits |
 
 ## Supported Formats
 
-S9S supports four export formats:
+| Format | Extension | Best for |
+|--------|-----------|----------|
+| **CSV** | `.csv` | Spreadsheets, data processing (default) |
+| **JSON** | `.json` | Programmatic processing, API integration |
+| **Text** | `.txt` | Human-readable ASCII tables, logs |
+| **Markdown** | `.md` | Documentation, GitHub reports |
+| **HTML** | `.html` | Sharing, browser viewing |
 
-### CSV (Comma-Separated Values)
-- Best for: Spreadsheet analysis, data processing
-- Features: Headers, UTF-8 encoding
-- Extension: `.csv`
+## Export Dialog
 
-**Example**:
-```bash
-:export csv --output jobs.csv
+```
+┌─────────────── Export Jobs (42 records) ───────────────┐
+│                                                         │
+│  Format:   [CSV           ▼]                           │
+│                                                         │
+│  Save to:  ~/slurm_exports                             │
+│                                                         │
+│  [ Export ]  [ Cancel ]                                 │
+│                                                         │
+└─────────────────────────────────────────────────────────┘
+  [Tab] Navigate  [Enter] Select  [Esc] Cancel
 ```
 
-### JSON (JavaScript Object Notation)
-- Best for: API integration, web applications, programmatic processing
-- Features: Structured data, nested information
-- Extension: `.json`
+- **Format** — dropdown with 5 options; press Enter to open
+- **Save to** — directory path; files are named automatically with a timestamp (e.g. `jobs_20260218_143022.csv`)
+- **Export** — writes the file and shows a result modal
+- **Cancel / Esc** — closes the dialog without writing anything
 
-**Example**:
-```bash
-:export json --output jobs.json
+## Output Files
+
+Files are written to the specified directory with timestamped names:
+
+```
+~/slurm_exports/
+  jobs_20260218_143022.csv
+  nodes_20260218_144501.json
+  partitions_20260218_150012.md
+```
+
+The directory is created automatically if it doesn't exist.
+
+## Format Examples
+
+### CSV
+
+```
+ID,Name,User,Account,State,Partition,Nodes,Time Used,Time Limit,Priority,Submit Time
+1234,train-bert,alice,ml,RUNNING,gpu,4,01:23:45,24:00:00,100,2026-02-18 12:00:00
+1235,preprocess,bob,eng,PENDING,cpu,1,,04:00:00,50,2026-02-18 12:05:00
+```
+
+### JSON
+
+```json
+{
+  "title": "Jobs",
+  "exported_at": "2026-02-18T14:30:22Z",
+  "total": 2,
+  "records": [
+    {"ID": "1234", "Name": "train-bert", "State": "RUNNING", ...},
+    {"ID": "1235", "Name": "preprocess", "State": "PENDING", ...}
+  ]
+}
 ```
 
 ### Markdown
-- Best for: Documentation, version control, readable reports
-- Features: Tables, formatting, human-readable
-- Extension: `.md`
 
-**Example**:
-```bash
-:export md --output report.md
+```markdown
+# Jobs Export
+
+_Exported at: 2026-02-18 14:30:22 — 2 records_
+
+| ID | Name | User | State | ...  |
+| --- | --- | --- | --- | --- |
+| 1234 | train-bert | alice | RUNNING | ... |
 ```
 
-### Plain Text
-- Best for: Simple logs, basic reporting, console output
-- Features: Simple formatting, universally readable
-- Extension: `.txt`
+### Text
 
-**Example**:
-```bash
-:export txt --output jobs.txt
+```
+Jobs Export
+Exported at: 2026-02-18 14:30:22
+Total records: 2
+
++------+------------+-------+---------+
+| ID   | Name       | User  | State   |
++------+------------+-------+---------+
+| 1234 | train-bert | alice | RUNNING |
+| 1235 | preprocess | bob   | PENDING |
++------+------------+-------+---------+
 ```
 
-## Export Options
+## Tips
 
-### Field Selection
+- **Filters are respected** — only the data currently loaded into the view is exported. Apply filters before exporting to narrow results.
+- **The data is a point-in-time snapshot** — exported at the moment you press Export.
+- **Path security** — export paths are validated; only paths within your home directory are allowed.
 
-Choose specific fields to export:
+## See Also
 
-```bash
-# Export specific job fields
-:export csv --fields=JobID,User,State,Runtime
-
-# Export all available fields
-:export json --fields=all
-
-# Export minimal fields
-:export csv --fields=minimal
-```
-
-### Time Range Filters
-
-```bash
-# Export jobs from specific time period
-:export csv --time-range="2023-12-01..2023-12-31"
-
-# Export recent data
-:export json --time-range="last-7d"
-
-# Export with relative time
-:export csv --submitted=">1h" --completed="<24h"
-```
-
-### Data Filtering
-
-```bash
-# Export with filters
-:export csv --filter="user:alice state:COMPLETED"
-
-# Complex filtering
-:export json --filter="partition:gpu nodes:>4 runtime:>2h"
-
-# Multiple conditions
-:export csv --user=alice,bob --state=RUNNING,COMPLETED
-```
-
-## Export Destinations
-
-### Local Files
-
-```bash
-# Export to specific directory
-:export csv --output="/data/exports/jobs.csv"
-
-# Export with timestamp
-:export json --output="jobs-{timestamp}.json"
-
-# Export to user directory
-:export md --output="~/reports/cluster-report.md"
-```
-
-## Export Configuration
-
-### Default Settings
-
-```yaml
-# ~/.s9s/config.yaml
-export:
-  # Default format
-  defaultFormat: csv
-
-  # Default output directory
-  outputDir: ~/s9s-exports
-
-  # Include headers in CSV
-  includeHeaders: true
-
-  # Date format in filenames
-  dateFormat: "2006-01-02"
-
-  # Field formatting
-  timeFormat: RFC3339
-  durationFormat: seconds
-
-  # Limits
-  maxRecords: 1000000
-  maxFileSize: 100MB
-```
-
-### Format-Specific Settings
-
-```yaml
-export:
-  formats:
-    csv:
-      delimiter: ","
-      quote: '"'
-      encoding: utf-8
-      lineEnding: unix
-
-    json:
-      indent: 2
-      sortKeys: true
-      includeSchema: false
-
-    markdown:
-      tableFormat: github
-      includeHeaders: true
-
-    txt:
-      lineFormat: simple
-      separator: " | "
-```
-
-## Security and Privacy
-
-### Data Sanitization
-
-```bash
-# Remove sensitive information
-:export csv --sanitize --fields=JobID,State,Runtime
-
-# Filter sensitive partitions
-:export csv --exclude-partitions=confidential,private
-```
-
-### Access Control
-
-```yaml
-export:
-  security:
-    requirePermission: true
-    allowedFormats: [csv, json, md, txt]
-    maxRecordsPerUser: 10000
-    auditExports: true
-    restrictFields: [script_path, environment]
-```
-
-## Best Practices
-
-### Performance Optimization
-
-1. **Use filters** to limit data volume
-2. **Export incrementally** for large historical data
-3. **Choose appropriate formats** (JSON for structured data, CSV for spreadsheets, Markdown for reports)
-4. **Limit field selection** to only needed columns
-
-### Data Management
-
-1. **Version your exports** with timestamps
-2. **Archive old exports** regularly
-3. **Document export schemas** for consistency
-4. **Validate exported data** before use
-5. **Monitor export jobs** for failures
-
-## Troubleshooting
-
-### Common Issues
-
-**Export fails with "Permission denied"**:
-- Check file/directory permissions
-- Verify export destination accessibility
-- Ensure sufficient disk space
-
-**Large exports timeout**:
-- Use smaller time ranges
-- Export in batches
-- Apply filters to reduce data volume
-
-**Invalid date formats**:
-- Check date format configuration
-- Verify timezone settings
-- Use ISO 8601 format for compatibility
-
-### Debug Mode
-
-```bash
-# Enable export debugging
-:config set export.debug true
-
-# Verbose export logging
-:export csv --debug --verbose
-
-# Dry run export
-:export json --dry-run --output=test.json
-```
-
-## Next Steps
-
-- Learn [Batch Operations](./batch-operations.md) for bulk exports
-- Explore [Node Operations](./node-operations.md) for node data analysis
-- Explore [Advanced Filtering](../filtering.md) to refine export data
+- [Filtering](./filtering.md) — narrow data before exporting
+- [Batch Operations](./batch-operations.md) — act on multiple jobs at once
+- [Keyboard Shortcuts](./keyboard-shortcuts.md) — full key reference

--- a/docs/user-guide/keyboard-shortcuts.md
+++ b/docs/user-guide/keyboard-shortcuts.md
@@ -93,6 +93,7 @@ These shortcuts work from any view:
 | `m/M` | Toggle auto-refresh | Enable/disable auto-refresh (30s) |
 | `F1` | Action menu | Show context-sensitive actions |
 | `S` | Sort modal | Open interactive sorting dialog |
+| `e/E` | Export | Export job list to CSV/JSON/Text/Markdown/HTML |
 
 ## Nodes View
 
@@ -127,6 +128,7 @@ These shortcuts work from any view:
 |-----|--------|-------------|
 | `R` | Manual refresh | Refresh nodes data |
 | `S` | Sort modal | Open interactive sorting dialog |
+| `e/E` | Export | Export node list to CSV/JSON/Text/Markdown/HTML |
 
 ## Partitions View
 
@@ -152,6 +154,7 @@ These shortcuts work from any view:
 |-----|--------|-------------|
 | `R` | Manual refresh | Refresh partitions data |
 | `S` | Sort modal | Open interactive sorting dialog |
+| `e/E` | Export | Export partition list to CSV/JSON/Text/Markdown/HTML |
 
 ## Users View
 
@@ -174,6 +177,7 @@ These shortcuts work from any view:
 |-----|--------|-------------|
 | `R` | Manual refresh | Refresh users data |
 | `S` | Sort modal | Open interactive sorting dialog |
+| `e/E` | Export | Export user list to CSV/JSON/Text/Markdown/HTML |
 
 ## Accounts View
 
@@ -196,6 +200,7 @@ These shortcuts work from any view:
 |-----|--------|-------------|
 | `R` | Manual refresh | Refresh accounts data |
 | `S` | Sort modal | Open interactive sorting dialog |
+| `e/E` | Export | Export account list to CSV/JSON/Text/Markdown/HTML |
 
 ## QoS View
 
@@ -217,6 +222,7 @@ These shortcuts work from any view:
 |-----|--------|-------------|
 | `R` | Manual refresh | Refresh QoS data |
 | `S` | Sort modal | Open interactive sorting dialog |
+| `e/E` | Export | Export QoS list to CSV/JSON/Text/Markdown/HTML |
 
 ## Reservations View
 
@@ -240,6 +246,7 @@ These shortcuts work from any view:
 |-----|--------|-------------|
 | `R` | Manual refresh | Refresh reservations data |
 | `S` | Sort modal | Open interactive sorting dialog |
+| `e/E` | Export | Export reservation list to CSV/JSON/Text/Markdown/HTML |
 
 ## Health View
 

--- a/internal/export/table_exporter.go
+++ b/internal/export/table_exporter.go
@@ -1,0 +1,351 @@
+package export
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/jontk/s9s/internal/fileperms"
+	"github.com/jontk/s9s/internal/security"
+)
+
+// TableData holds tabular data for export (headers + rows + metadata).
+type TableData struct {
+	Title     string     // e.g. "Jobs", "Nodes", "Partitions"
+	Headers   []string   // column names
+	Rows      [][]string // raw (uncolored) row values
+	ExportedAt time.Time
+}
+
+// TableExporter exports tabular data to various file formats.
+type TableExporter struct {
+	defaultPath string
+}
+
+// NewTableExporter creates a new TableExporter.
+// If defaultPath is empty it defaults to ~/slurm_exports.
+func NewTableExporter(defaultPath string) *TableExporter {
+	if defaultPath == "" {
+		homeDir, _ := os.UserHomeDir()
+		defaultPath = filepath.Join(homeDir, "slurm_exports")
+	}
+	_ = os.MkdirAll(defaultPath, fileperms.DirUserOnly)
+	return &TableExporter{defaultPath: defaultPath}
+}
+
+// SetDefaultPath updates the default export directory.
+func (e *TableExporter) SetDefaultPath(path string) {
+	e.defaultPath = path
+	_ = os.MkdirAll(path, fileperms.DirUserOnly)
+}
+
+// Export writes td to a file and returns a Result.
+// If customPath is non-empty it is used as the full output path;
+// otherwise a timestamped filename is generated in defaultPath.
+func (e *TableExporter) Export(td *TableData, format ExportFormat, customPath string) (*ExportResult, error) {
+	if td.ExportedAt.IsZero() {
+		td.ExportedAt = time.Now()
+	}
+
+	result := &ExportResult{
+		Format:    format,
+		Timestamp: td.ExportedAt,
+	}
+
+	filename := e.generateFilename(td.Title, format)
+	outputPath := e.determinePath(customPath, filename)
+
+	validPath, err := e.validatePath(result, outputPath)
+	if err != nil {
+		return result, err
+	}
+
+	if err := e.ensureDir(result, validPath); err != nil {
+		return result, err
+	}
+
+	if err := e.writeByFormat(result, td, format, validPath); err != nil {
+		return result, err
+	}
+
+	if stat, err := os.Stat(validPath); err == nil {
+		result.Size = stat.Size()
+	}
+	result.Success = true
+	return result, nil
+}
+
+func (e *TableExporter) generateFilename(title string, format ExportFormat) string {
+	clean := strings.ToLower(strings.ReplaceAll(title, " ", "_"))
+	ts := time.Now().Format("20060102_150405")
+	return fmt.Sprintf("%s_%s.%s", clean, ts, string(format))
+}
+
+func (e *TableExporter) determinePath(customPath, filename string) string {
+	if customPath != "" {
+		return customPath
+	}
+	return filepath.Join(e.defaultPath, filename)
+}
+
+func (e *TableExporter) validatePath(result *ExportResult, outputPath string) (string, error) {
+	homeDir, _ := os.UserHomeDir()
+	validPath, err := security.ValidatePathWithinBase(outputPath, e.defaultPath)
+	if err != nil && homeDir != "" {
+		validPath, err = security.ValidatePathWithinBase(outputPath, homeDir)
+	}
+	if err != nil {
+		result.Error = fmt.Errorf("invalid export path %q: %w", outputPath, err)
+		return "", result.Error
+	}
+	result.FilePath = validPath
+	return validPath, nil
+}
+
+func (e *TableExporter) ensureDir(result *ExportResult, path string) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, fileperms.DirUserOnly); err != nil {
+		result.Error = fmt.Errorf("failed to create directory %s: %w", dir, err)
+		return result.Error
+	}
+	return nil
+}
+
+func (e *TableExporter) writeByFormat(result *ExportResult, td *TableData, format ExportFormat, path string) error {
+	var err error
+	switch format {
+	case FormatText:
+		err = e.writeText(td, path)
+	case FormatJSON:
+		err = e.writeJSON(td, path)
+	case FormatCSV:
+		err = e.writeCSV(td, path)
+	case FormatMarkdown:
+		err = e.writeMarkdown(td, path)
+	case FormatHTML:
+		err = e.writeHTML(td, path)
+	default:
+		err = fmt.Errorf("unsupported format: %s", format)
+	}
+	if err != nil {
+		result.Error = err
+	}
+	return err
+}
+
+// writeText writes a plain-text table.
+func (e *TableExporter) writeText(td *TableData, path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	// Compute column widths.
+	widths := make([]int, len(td.Headers))
+	for i, h := range td.Headers {
+		widths[i] = len(h)
+	}
+	for _, row := range td.Rows {
+		for i, cell := range row {
+			if i < len(widths) && len(cell) > widths[i] {
+				widths[i] = len(cell)
+			}
+		}
+	}
+
+	separator := buildSeparator(widths)
+
+	header := fmt.Sprintf("%s Export\n", td.Title)
+	header += fmt.Sprintf("Exported at: %s\n", td.ExportedAt.Format("2006-01-02 15:04:05"))
+	header += fmt.Sprintf("Total records: %d\n\n", len(td.Rows))
+	if _, err := fmt.Fprint(f, header); err != nil {
+		return err
+	}
+
+	if _, err := fmt.Fprintln(f, separator); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(f, buildRow(td.Headers, widths)); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(f, separator); err != nil {
+		return err
+	}
+	for _, row := range td.Rows {
+		if _, err := fmt.Fprintln(f, buildRow(row, widths)); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprintln(f, separator); err != nil {
+		return err
+	}
+	return nil
+}
+
+func buildSeparator(widths []int) string {
+	parts := make([]string, len(widths))
+	for i, w := range widths {
+		parts[i] = strings.Repeat("-", w+2)
+	}
+	return "+" + strings.Join(parts, "+") + "+"
+}
+
+func buildRow(cells []string, widths []int) string {
+	parts := make([]string, len(widths))
+	for i, w := range widths {
+		cell := ""
+		if i < len(cells) {
+			cell = cells[i]
+		}
+		parts[i] = fmt.Sprintf(" %-*s ", w, cell)
+	}
+	return "|" + strings.Join(parts, "|") + "|"
+}
+
+// writeCSV writes a CSV file.
+func (e *TableExporter) writeCSV(td *TableData, path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	w := csv.NewWriter(f)
+	defer w.Flush()
+
+	if err := w.Write(td.Headers); err != nil {
+		return fmt.Errorf("write header: %w", err)
+	}
+	for _, row := range td.Rows {
+		if err := w.Write(row); err != nil {
+			return fmt.Errorf("write row: %w", err)
+		}
+	}
+	return nil
+}
+
+// writeJSON writes a JSON array of objects keyed by header name.
+func (e *TableExporter) writeJSON(td *TableData, path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	type envelope struct {
+		Title      string              `json:"title"`
+		ExportedAt string              `json:"exported_at"`
+		Total      int                 `json:"total"`
+		Records    []map[string]string `json:"records"`
+	}
+
+	records := make([]map[string]string, len(td.Rows))
+	for i, row := range td.Rows {
+		m := make(map[string]string, len(td.Headers))
+		for j, h := range td.Headers {
+			if j < len(row) {
+				m[h] = row[j]
+			}
+		}
+		records[i] = m
+	}
+
+	env := envelope{
+		Title:      td.Title,
+		ExportedAt: td.ExportedAt.Format(time.RFC3339),
+		Total:      len(td.Rows),
+		Records:    records,
+	}
+
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(env); err != nil {
+		return fmt.Errorf("encode JSON: %w", err)
+	}
+	return nil
+}
+
+// writeMarkdown writes a Markdown table.
+func (e *TableExporter) writeMarkdown(td *TableData, path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	fmt.Fprintf(f, "# %s Export\n\n", td.Title)
+	fmt.Fprintf(f, "_Exported at: %s — %d records_\n\n", td.ExportedAt.Format("2006-01-02 15:04:05"), len(td.Rows))
+
+	// Header row
+	fmt.Fprintf(f, "| %s |\n", strings.Join(td.Headers, " | "))
+	// Separator
+	seps := make([]string, len(td.Headers))
+	for i := range seps {
+		seps[i] = "---"
+	}
+	fmt.Fprintf(f, "| %s |\n", strings.Join(seps, " | "))
+	// Data rows
+	for _, row := range td.Rows {
+		// Pad row to match header count
+		cells := make([]string, len(td.Headers))
+		for i := range cells {
+			if i < len(row) {
+				cells[i] = row[i]
+			}
+		}
+		fmt.Fprintf(f, "| %s |\n", strings.Join(cells, " | "))
+	}
+	return nil
+}
+
+// writeHTML writes an HTML table.
+func (e *TableExporter) writeHTML(td *TableData, path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	const tmplStr = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>{{.Title}} Export</title>
+  <style>
+    body{font-family:monospace;background:#1e1e1e;color:#d4d4d4;margin:20px}
+    h1{color:#569cd6}
+    .meta{color:#808080;margin-bottom:16px}
+    table{border-collapse:collapse;width:100%}
+    th{background:#2d2d30;color:#9cdcfe;padding:8px 12px;text-align:left;border:1px solid #3c3c3c}
+    td{padding:6px 12px;border:1px solid #3c3c3c}
+    tr:nth-child(even){background:#252526}
+  </style>
+</head>
+<body>
+  <h1>{{.Title}} Export</h1>
+  <p class="meta">Exported at: {{.ExportedAt.Format "2006-01-02 15:04:05"}} &mdash; {{len .Rows}} records</p>
+  <table>
+    <thead><tr>{{range .Headers}}<th>{{.}}</th>{{end}}</tr></thead>
+    <tbody>
+      {{range .Rows}}<tr>{{range .}}<td>{{.}}</td>{{end}}</tr>
+      {{end}}
+    </tbody>
+  </table>
+</body>
+</html>`
+
+	tmpl, err := template.New("table").Parse(tmplStr)
+	if err != nil {
+		return fmt.Errorf("parse template: %w", err)
+	}
+	if err := tmpl.Execute(f, td); err != nil {
+		return fmt.Errorf("execute template: %w", err)
+	}
+	return nil
+}

--- a/internal/export/table_exporter_test.go
+++ b/internal/export/table_exporter_test.go
@@ -1,0 +1,183 @@
+package export
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jontk/s9s/internal/dao"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeTestTableData() *TableData {
+	return &TableData{
+		Title:      "TestTable",
+		Headers:    []string{"ID", "Name", "State"},
+		Rows:       [][]string{{"1", "job-one", "RUNNING"}, {"2", "job-two", "PENDING"}},
+		ExportedAt: time.Now(),
+	}
+}
+
+func TestTableExporterText(t *testing.T) {
+	dir := t.TempDir()
+	exp := NewTableExporter(dir)
+	result, err := exp.Export(makeTestTableData(), FormatText, "")
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	content, err := os.ReadFile(result.FilePath)
+	require.NoError(t, err)
+	s := string(content)
+	assert.Contains(t, s, "ID")
+	assert.Contains(t, s, "job-one")
+	assert.Contains(t, s, "RUNNING")
+}
+
+func TestTableExporterCSV(t *testing.T) {
+	dir := t.TempDir()
+	exp := NewTableExporter(dir)
+	result, err := exp.Export(makeTestTableData(), FormatCSV, "")
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	content, err := os.ReadFile(result.FilePath)
+	require.NoError(t, err)
+	s := string(content)
+	assert.Contains(t, s, "ID,Name,State")
+	assert.Contains(t, s, "job-one")
+}
+
+func TestTableExporterJSON(t *testing.T) {
+	dir := t.TempDir()
+	exp := NewTableExporter(dir)
+	result, err := exp.Export(makeTestTableData(), FormatJSON, "")
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	raw, err := os.ReadFile(result.FilePath)
+	require.NoError(t, err)
+
+	var envelope struct {
+		Title   string              `json:"title"`
+		Total   int                 `json:"total"`
+		Records []map[string]string `json:"records"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &envelope))
+	assert.Equal(t, "TestTable", envelope.Title)
+	assert.Equal(t, 2, envelope.Total)
+	assert.Equal(t, "job-one", envelope.Records[0]["Name"])
+}
+
+func TestTableExporterMarkdown(t *testing.T) {
+	dir := t.TempDir()
+	exp := NewTableExporter(dir)
+	result, err := exp.Export(makeTestTableData(), FormatMarkdown, "")
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	content, err := os.ReadFile(result.FilePath)
+	require.NoError(t, err)
+	s := string(content)
+	assert.True(t, strings.HasPrefix(s, "# TestTable Export"))
+	assert.Contains(t, s, "| ID | Name | State |")
+	assert.Contains(t, s, "| 1 | job-one | RUNNING |")
+}
+
+func TestTableExporterHTML(t *testing.T) {
+	dir := t.TempDir()
+	exp := NewTableExporter(dir)
+	result, err := exp.Export(makeTestTableData(), FormatHTML, "")
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	content, err := os.ReadFile(result.FilePath)
+	require.NoError(t, err)
+	s := string(content)
+	assert.Contains(t, s, "<th>ID</th>")
+	assert.Contains(t, s, "<td>job-one</td>")
+}
+
+func TestJobsTableData(t *testing.T) {
+	now := time.Now()
+	jobs := []*dao.Job{
+		{ID: "100", Name: "myjob", User: "alice", Account: "eng", State: "RUNNING",
+			Partition: "gpu", NodeCount: 2, Priority: 100, SubmitTime: now},
+	}
+	td := JobsTableData(jobs)
+	assert.Equal(t, "Jobs", td.Title)
+	require.Len(t, td.Rows, 1)
+	assert.Equal(t, "100", td.Rows[0][0])
+	assert.Equal(t, "myjob", td.Rows[0][1])
+	assert.Equal(t, "RUNNING", td.Rows[0][4])
+}
+
+func TestNodesTableData(t *testing.T) {
+	nodes := []*dao.Node{
+		{Name: "node01", State: "IDLE", Partitions: []string{"cpu", "gpu"},
+			CPUsTotal: 48, CPUsAllocated: 12, CPUsIdle: 36, MemoryTotal: 256000},
+	}
+	td := NodesTableData(nodes)
+	assert.Equal(t, "Nodes", td.Title)
+	require.Len(t, td.Rows, 1)
+	assert.Equal(t, "node01", td.Rows[0][0])
+	assert.Equal(t, "cpu,gpu", td.Rows[0][2])
+	assert.Equal(t, "48", td.Rows[0][3])
+}
+
+func TestPartitionsTableData(t *testing.T) {
+	parts := []*dao.Partition{
+		{Name: "gpu", State: "UP", TotalNodes: 10, TotalCPUs: 480,
+			DefaultTime: "1:00:00", MaxTime: "24:00:00"},
+	}
+	td := PartitionsTableData(parts)
+	assert.Equal(t, "Partitions", td.Title)
+	require.Len(t, td.Rows, 1)
+	assert.Equal(t, "gpu", td.Rows[0][0])
+}
+
+func TestReservationsTableData(t *testing.T) {
+	start := time.Now()
+	end := start.Add(2 * time.Hour)
+	reservations := []*dao.Reservation{
+		{Name: "maint", State: "ACTIVE", StartTime: start, EndTime: end,
+			Duration: 2 * time.Hour, NodeCount: 5},
+	}
+	td := ReservationsTableData(reservations)
+	assert.Equal(t, "Reservations", td.Title)
+	require.Len(t, td.Rows, 1)
+	assert.Equal(t, "maint", td.Rows[0][0])
+	assert.Equal(t, "5", td.Rows[0][6])
+}
+
+func TestQoSTableData(t *testing.T) {
+	qosList := []*dao.QoS{
+		{Name: "normal", Priority: 1000, MaxJobsPerUser: 50},
+	}
+	td := QoSTableData(qosList)
+	assert.Equal(t, "QoS", td.Title)
+	require.Len(t, td.Rows, 1)
+	assert.Equal(t, "normal", td.Rows[0][0])
+	assert.Equal(t, "1000", td.Rows[0][1])
+}
+
+func TestAccountsTableData(t *testing.T) {
+	accounts := []*dao.Account{
+		{Name: "research", Description: "Research group", Organization: "Uni",
+			DefaultQoS: "normal"},
+	}
+	td := AccountsTableData(accounts)
+	assert.Equal(t, "Accounts", td.Title)
+	require.Len(t, td.Rows, 1)
+	assert.Equal(t, "research", td.Rows[0][0])
+}
+
+func TestUsersTableData(t *testing.T) {
+	users := []*dao.User{
+		{Name: "alice", UID: 1001, DefaultAccount: "research",
+			Accounts: []string{"research", "ml"}, AdminLevel: "None"},
+	}
+	td := UsersTableData(users)
+	assert.Equal(t, "Users", td.Title)
+	require.Len(t, td.Rows, 1)
+	assert.Equal(t, "alice", td.Rows[0][0])
+	assert.Equal(t, "1001", td.Rows[0][1])
+	assert.Equal(t, "research,ml", td.Rows[0][3])
+}

--- a/internal/export/view_exporters.go
+++ b/internal/export/view_exporters.go
@@ -1,0 +1,221 @@
+package export
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jontk/s9s/internal/dao"
+)
+
+// JobsTableData converts a slice of jobs to TableData for export.
+func JobsTableData(jobs []*dao.Job) *TableData {
+	headers := []string{
+		"ID", "Name", "User", "Account", "State", "Partition",
+		"Nodes", "Time Used", "Time Limit", "Priority", "Submit Time",
+	}
+
+	rows := make([][]string, len(jobs))
+	for i, j := range jobs {
+		priority := fmt.Sprintf("%.0f", j.Priority)
+		submitTime := ""
+		if !j.SubmitTime.IsZero() {
+			submitTime = j.SubmitTime.Format("2006-01-02 15:04:05")
+		}
+		timeUsed := j.TimeUsed
+		if timeUsed == "" && j.StartTime != nil {
+			timeUsed = formatDuration(time.Since(*j.StartTime))
+		}
+		rows[i] = []string{
+			j.ID, j.Name, j.User, j.Account, j.State, j.Partition,
+			fmt.Sprintf("%d", j.NodeCount),
+			timeUsed,
+			j.TimeLimit,
+			priority,
+			submitTime,
+		}
+	}
+	return &TableData{Title: "Jobs", Headers: headers, Rows: rows, ExportedAt: time.Now()}
+}
+
+// NodesTableData converts a slice of nodes to TableData for export.
+func NodesTableData(nodes []*dao.Node) *TableData {
+	headers := []string{
+		"Name", "State", "Partitions", "CPUs Total", "CPUs Alloc",
+		"CPUs Idle", "CPU Load", "Memory Total (MB)", "Memory Alloc (MB)",
+		"Memory Free (MB)", "Features", "Reason",
+	}
+
+	rows := make([][]string, len(nodes))
+	for i, n := range nodes {
+		cpuLoad := ""
+		if n.CPULoad >= 0 {
+			cpuLoad = fmt.Sprintf("%.2f", n.CPULoad)
+		}
+		rows[i] = []string{
+			n.Name,
+			n.State,
+			strings.Join(n.Partitions, ","),
+			fmt.Sprintf("%d", n.CPUsTotal),
+			fmt.Sprintf("%d", n.CPUsAllocated),
+			fmt.Sprintf("%d", n.CPUsIdle),
+			cpuLoad,
+			fmt.Sprintf("%d", n.MemoryTotal),
+			fmt.Sprintf("%d", n.MemoryAllocated),
+			fmt.Sprintf("%d", n.MemoryFree),
+			strings.Join(n.Features, ","),
+			n.Reason,
+		}
+	}
+	return &TableData{Title: "Nodes", Headers: headers, Rows: rows, ExportedAt: time.Now()}
+}
+
+// PartitionsTableData converts a slice of partitions to TableData for export.
+func PartitionsTableData(partitions []*dao.Partition) *TableData {
+	headers := []string{
+		"Name", "State", "Total Nodes", "Total CPUs",
+		"Default Time", "Max Time", "QoS", "Nodes",
+	}
+
+	rows := make([][]string, len(partitions))
+	for i, p := range partitions {
+		rows[i] = []string{
+			p.Name,
+			p.State,
+			fmt.Sprintf("%d", p.TotalNodes),
+			fmt.Sprintf("%d", p.TotalCPUs),
+			p.DefaultTime,
+			p.MaxTime,
+			strings.Join(p.QOS, ","),
+			strings.Join(p.Nodes, ","),
+		}
+	}
+	return &TableData{Title: "Partitions", Headers: headers, Rows: rows, ExportedAt: time.Now()}
+}
+
+// ReservationsTableData converts a slice of reservations to TableData for export.
+func ReservationsTableData(reservations []*dao.Reservation) *TableData {
+	headers := []string{
+		"Name", "State", "Start Time", "End Time", "Duration",
+		"Nodes", "Node Count", "Core Count", "Users", "Accounts",
+	}
+
+	rows := make([][]string, len(reservations))
+	for i, r := range reservations {
+		startTime := r.StartTime.Format("2006-01-02 15:04:05")
+		endTime := r.EndTime.Format("2006-01-02 15:04:05")
+		duration := ""
+		if r.Duration > 0 {
+			duration = r.Duration.String()
+		}
+		rows[i] = []string{
+			r.Name,
+			r.State,
+			startTime,
+			endTime,
+			duration,
+			strings.Join(r.Nodes, ","),
+			fmt.Sprintf("%d", r.NodeCount),
+			fmt.Sprintf("%d", r.CoreCount),
+			strings.Join(r.Users, ","),
+			strings.Join(r.Accounts, ","),
+		}
+	}
+	return &TableData{Title: "Reservations", Headers: headers, Rows: rows, ExportedAt: time.Now()}
+}
+
+// QoSTableData converts a slice of QoS entries to TableData for export.
+func QoSTableData(qosList []*dao.QoS) *TableData {
+	headers := []string{
+		"Name", "Priority", "Preempt Mode", "Flags",
+		"Max Jobs/User", "Max Jobs/Account", "Max Submit Jobs/User",
+		"Max CPUs/User", "Max Nodes/User", "Max Wall Time (min)",
+		"Max Memory/User (MB)", "Min CPUs", "Min Nodes",
+	}
+
+	rows := make([][]string, len(qosList))
+	for i, q := range qosList {
+		rows[i] = []string{
+			q.Name,
+			fmt.Sprintf("%d", q.Priority),
+			q.PreemptMode,
+			strings.Join(q.Flags, ","),
+			fmt.Sprintf("%d", q.MaxJobsPerUser),
+			fmt.Sprintf("%d", q.MaxJobsPerAccount),
+			fmt.Sprintf("%d", q.MaxSubmitJobsPerUser),
+			fmt.Sprintf("%d", q.MaxCPUsPerUser),
+			fmt.Sprintf("%d", q.MaxNodesPerUser),
+			fmt.Sprintf("%d", q.MaxWallTime),
+			fmt.Sprintf("%d", q.MaxMemoryPerUser),
+			fmt.Sprintf("%d", q.MinCPUs),
+			fmt.Sprintf("%d", q.MinNodes),
+		}
+	}
+	return &TableData{Title: "QoS", Headers: headers, Rows: rows, ExportedAt: time.Now()}
+}
+
+// AccountsTableData converts a slice of accounts to TableData for export.
+func AccountsTableData(accounts []*dao.Account) *TableData {
+	headers := []string{
+		"Name", "Description", "Organization", "Parent",
+		"Default QoS", "QoS List", "Coordinators",
+		"Max Jobs", "Max Nodes", "Max CPUs", "Max Submit", "Max Wall (min)",
+		"Children",
+	}
+
+	rows := make([][]string, len(accounts))
+	for i, a := range accounts {
+		rows[i] = []string{
+			a.Name,
+			a.Description,
+			a.Organization,
+			a.Parent,
+			a.DefaultQoS,
+			strings.Join(a.QoSList, ","),
+			strings.Join(a.Coordinators, ","),
+			fmt.Sprintf("%d", a.MaxJobs),
+			fmt.Sprintf("%d", a.MaxNodes),
+			fmt.Sprintf("%d", a.MaxCPUs),
+			fmt.Sprintf("%d", a.MaxSubmit),
+			fmt.Sprintf("%d", a.MaxWall),
+			strings.Join(a.Children, ","),
+		}
+	}
+	return &TableData{Title: "Accounts", Headers: headers, Rows: rows, ExportedAt: time.Now()}
+}
+
+// UsersTableData converts a slice of users to TableData for export.
+func UsersTableData(users []*dao.User) *TableData {
+	headers := []string{
+		"Name", "UID", "Default Account", "Accounts",
+		"Admin Level", "Default QoS", "QoS List",
+		"Max Jobs", "Max Nodes", "Max CPUs", "Max Submit",
+	}
+
+	rows := make([][]string, len(users))
+	for i, u := range users {
+		rows[i] = []string{
+			u.Name,
+			fmt.Sprintf("%d", u.UID),
+			u.DefaultAccount,
+			strings.Join(u.Accounts, ","),
+			u.AdminLevel,
+			u.DefaultQoS,
+			strings.Join(u.QoSList, ","),
+			fmt.Sprintf("%d", u.MaxJobs),
+			fmt.Sprintf("%d", u.MaxNodes),
+			fmt.Sprintf("%d", u.MaxCPUs),
+			fmt.Sprintf("%d", u.MaxSubmit),
+		}
+	}
+	return &TableData{Title: "Users", Headers: headers, Rows: rows, ExportedAt: time.Now()}
+}
+
+// formatDuration formats a duration in HH:MM:SS style (same as the views package).
+func formatDuration(d time.Duration) string {
+	d = d.Round(time.Second)
+	h := int(d.Hours())
+	m := int(d.Minutes()) % 60
+	s := int(d.Seconds()) % 60
+	return fmt.Sprintf("%02d:%02d:%02d", h, m, s)
+}

--- a/internal/ui/widgets/table_export_dialog.go
+++ b/internal/ui/widgets/table_export_dialog.go
@@ -104,7 +104,7 @@ func (d *TableExportDialog) SetExportHandler(fn func(format export.ExportFormat,
 	d.onExport = fn
 }
 
-// SetCancelHandler registers the callback invoked when the dialog is cancelled.
+// SetCancelHandler registers the callback invoked when the dialog is canceled.
 func (d *TableExportDialog) SetCancelHandler(fn func()) {
 	d.onCancel = fn
 }

--- a/internal/ui/widgets/table_export_dialog.go
+++ b/internal/ui/widgets/table_export_dialog.go
@@ -1,0 +1,166 @@
+package widgets
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/jontk/s9s/internal/export"
+	"github.com/jontk/s9s/internal/ui/styles"
+	"github.com/rivo/tview"
+)
+
+// TableExportDialog is a modal dialog for exporting table data.
+// It is modal-safe: call Show/Hide and it manages its own page on tview.Pages.
+type TableExportDialog struct {
+	*tview.Flex
+	form           *tview.Form
+	pages          *tview.Pages
+	app            *tview.Application
+	selectedFormat export.ExportFormat
+	customPath     string
+	viewName       string // e.g. "Jobs", "Nodes"
+	recordCount    int
+	onExport       func(format export.ExportFormat, path string)
+	onCancel       func()
+}
+
+const tableExportPageName = "table_export_dialog"
+
+// NewTableExportDialog creates a new export dialog for the given view.
+func NewTableExportDialog(viewName string, recordCount int, pages *tview.Pages, app *tview.Application) *TableExportDialog {
+	homeDir, _ := os.UserHomeDir()
+	defaultPath := filepath.Join(homeDir, "slurm_exports")
+
+	d := &TableExportDialog{
+		Flex:           tview.NewFlex(),
+		pages:          pages,
+		app:            app,
+		viewName:       viewName,
+		recordCount:    recordCount,
+		selectedFormat: export.FormatCSV,
+		customPath:     defaultPath,
+	}
+	d.build()
+	return d
+}
+
+func (d *TableExportDialog) build() {
+	d.form = styles.StyleForm(tview.NewForm())
+	d.form.SetBorder(true)
+	d.form.SetBorderPadding(1, 1, 2, 2)
+	d.form.SetTitle(fmt.Sprintf(" Export %s (%d records) ", d.viewName, d.recordCount))
+	d.form.SetTitleAlign(tview.AlignCenter)
+	d.form.SetBorderColor(tcell.ColorTeal)
+
+	// Format dropdown — default CSV (index 1)
+	formats := []string{"Text", "CSV", "JSON", "Markdown", "HTML"}
+	d.form.AddDropDown("Format:", formats, 1, func(option string, _ int) {
+		d.selectedFormat = parseFormat(option)
+	})
+
+	// Path input
+	d.form.AddInputField("Save to:", d.customPath, 50, nil, func(text string) {
+		d.customPath = text
+	})
+
+	// Buttons
+	d.form.AddButton("Export", func() {
+		if d.onExport != nil {
+			d.onExport(d.selectedFormat, d.customPath)
+		}
+	})
+	d.form.AddButton("Cancel", func() {
+		d.Hide()
+		if d.onCancel != nil {
+			d.onCancel()
+		}
+	})
+
+	// Help line
+	help := tview.NewTextView().
+		SetText("[Tab] Navigate  [Enter] Select  [Esc] Cancel").
+		SetTextAlign(tview.AlignCenter).
+		SetTextColor(tcell.ColorGray)
+
+	// Outer flex — centers the form vertically and horizontally
+	d.SetDirection(tview.FlexRow).
+		AddItem(tview.NewBox(), 0, 1, false).
+		AddItem(
+			tview.NewFlex().SetDirection(tview.FlexColumn).
+				AddItem(tview.NewBox(), 0, 1, false).
+				AddItem(tview.NewFlex().SetDirection(tview.FlexRow).
+					AddItem(d.form, 11, 0, true).
+					AddItem(help, 1, 0, false),
+					60, 0, true).
+				AddItem(tview.NewBox(), 0, 1, false),
+			11, 0, true).
+		AddItem(tview.NewBox(), 0, 1, false)
+}
+
+// SetExportHandler registers the callback invoked when the user clicks Export.
+func (d *TableExportDialog) SetExportHandler(fn func(format export.ExportFormat, path string)) {
+	d.onExport = fn
+}
+
+// SetCancelHandler registers the callback invoked when the dialog is cancelled.
+func (d *TableExportDialog) SetCancelHandler(fn func()) {
+	d.onCancel = fn
+}
+
+// Show adds the dialog as a modal page.
+func (d *TableExportDialog) Show() {
+	if d.pages == nil {
+		return
+	}
+	d.pages.AddPage(tableExportPageName, d, true, true)
+	if d.app != nil {
+		d.app.SetFocus(d.form)
+	}
+}
+
+// Hide removes the dialog page.
+func (d *TableExportDialog) Hide() {
+	if d.pages == nil {
+		return
+	}
+	d.pages.RemovePage(tableExportPageName)
+}
+
+// InputHandler intercepts Escape to cancel.
+func (d *TableExportDialog) InputHandler() func(event *tcell.EventKey, setFocus func(p tview.Primitive)) {
+	return d.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p tview.Primitive)) {
+		if event.Key() == tcell.KeyEsc {
+			d.Hide()
+			if d.onCancel != nil {
+				d.onCancel()
+			}
+			return
+		}
+		d.Flex.InputHandler()(event, setFocus)
+	})
+}
+
+// UpdateRecordCount updates the displayed record count (e.g. after filtering).
+func (d *TableExportDialog) UpdateRecordCount(count int) {
+	d.recordCount = count
+	d.form.SetTitle(fmt.Sprintf(" Export %s (%d records) ", d.viewName, count))
+}
+
+// parseFormat maps the dropdown label to an ExportFormat.
+func parseFormat(option string) export.ExportFormat {
+	switch option {
+	case "Text":
+		return export.FormatText
+	case "CSV":
+		return export.FormatCSV
+	case "JSON":
+		return export.FormatJSON
+	case "Markdown":
+		return export.FormatMarkdown
+	case "HTML":
+		return export.FormatHTML
+	}
+	return export.FormatCSV
+}

--- a/internal/views/accounts.go
+++ b/internal/views/accounts.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/jontk/s9s/internal/dao"
+	"github.com/jontk/s9s/internal/export"
 	"github.com/jontk/s9s/internal/ui/components"
 	"github.com/jontk/s9s/internal/ui/filters"
 	"github.com/jontk/s9s/internal/ui/styles"
@@ -176,6 +177,7 @@ func (v *AccountsView) Hints() []string {
 		"[yellow]S[white] Sort",
 		"[yellow]R[white] Refresh",
 		"[yellow]H[white] Show Hierarchy",
+		"[yellow]e[white] Export",
 	}
 
 	if v.isAdvancedMode {
@@ -240,6 +242,8 @@ func (v *AccountsView) accountsRuneHandlers() map[rune]func() {
 		'/': func() { v.app.SetFocus(v.filterInput) },
 		'H': v.showAccountHierarchy,
 		'S': func() { v.promptSortBy() },
+		'e': func() { v.showExportDialog() },
+		'E': func() { v.showExportDialog() },
 	}
 }
 
@@ -868,4 +872,15 @@ func (v *AccountsView) promptSortBy() {
 	if v.pages != nil {
 		v.pages.AddPage("sort-by", centeredModal, true, true)
 	}
+}
+
+// showExportDialog opens the table export dialog for the current account list.
+func (v *AccountsView) showExportDialog() {
+	showTableExportDialog(v.pages, v.app, "Accounts", func() *export.TableData {
+		v.mu.RLock()
+		accounts := make([]*dao.Account, len(v.accounts))
+		copy(accounts, v.accounts)
+		v.mu.RUnlock()
+		return export.AccountsTableData(accounts)
+	})
 }

--- a/internal/views/export.go
+++ b/internal/views/export.go
@@ -1,0 +1,64 @@
+// Package views provides TUI views for the s9s application.
+// This file implements export functionality shared across all views.
+package views
+
+import (
+	"fmt"
+
+	"github.com/jontk/s9s/internal/export"
+	"github.com/jontk/s9s/internal/ui/widgets"
+	"github.com/rivo/tview"
+)
+
+// showTableExportDialog is a helper that shows the export dialog, performs the export,
+// and displays the result to the user via a modal message.
+// getData must return (headers []string, rows [][]string, title string).
+func showTableExportDialog(pages *tview.Pages, app *tview.Application, title string, getData func() *export.TableData) {
+	if pages == nil || app == nil {
+		return
+	}
+
+	td := getData()
+	dialog := widgets.NewTableExportDialog(title, len(td.Rows), pages, app)
+
+	dialog.SetExportHandler(func(format export.ExportFormat, path string) {
+		dialog.Hide()
+
+		// Perform export in background
+		go func() {
+			exporter := export.NewTableExporter(path)
+			result, err := exporter.Export(td, format, "")
+
+			app.QueueUpdateDraw(func() {
+				var msg string
+				if err != nil {
+					msg = fmt.Sprintf("[red]Export failed: %v[white]", err)
+				} else {
+					msg = fmt.Sprintf("[green]Exported %d records to:[white]\n%s", len(td.Rows), result.FilePath)
+				}
+				showExportResultModal(pages, app, msg)
+			})
+		}()
+	})
+
+	dialog.SetCancelHandler(func() {
+		dialog.Hide()
+	})
+
+	dialog.Show()
+}
+
+// showExportResultModal shows a brief result message after export.
+func showExportResultModal(pages *tview.Pages, app *tview.Application, msg string) {
+	const pageName = "export_result"
+
+	modal := tview.NewModal().
+		SetText(msg).
+		AddButtons([]string{"OK"}).
+		SetDoneFunc(func(_ int, _ string) {
+			pages.RemovePage(pageName)
+		})
+
+	pages.AddPage(pageName, modal, true, true)
+	app.SetFocus(modal)
+}

--- a/internal/views/jobs.go
+++ b/internal/views/jobs.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gdamore/tcell/v2"
 	"github.com/jontk/s9s/internal/dao"
 	"github.com/jontk/s9s/internal/debug"
+	"github.com/jontk/s9s/internal/export"
 	"github.com/jontk/s9s/internal/ui/components"
 	"github.com/jontk/s9s/internal/ui/filters"
 	"github.com/jontk/s9s/internal/ui/styles"
@@ -266,6 +267,7 @@ func (v *JobsView) Hints() []string {
 		"[yellow]v[white] Multi-Select",
 		"[yellow]S[white] Sort",
 		"[yellow]R[white] Refresh",
+		"[yellow]e[white] Export",
 	}
 
 	if v.isAdvancedMode {
@@ -376,6 +378,8 @@ func (v *JobsView) jobsRuneHandlers() map[rune]func(*JobsView, *tcell.EventKey) 
 		'U': func(v *JobsView, _ *tcell.EventKey) *tcell.EventKey { v.promptUserFilter(); return nil },
 		'v': func(v *JobsView, _ *tcell.EventKey) *tcell.EventKey { v.toggleMultiSelectMode(); return nil },
 		'V': func(v *JobsView, _ *tcell.EventKey) *tcell.EventKey { v.toggleMultiSelectMode(); return nil },
+		'e': func(v *JobsView, _ *tcell.EventKey) *tcell.EventKey { v.showExportDialog(); return nil },
+		'E': func(v *JobsView, _ *tcell.EventKey) *tcell.EventKey { v.showExportDialog(); return nil },
 	}
 }
 
@@ -1886,4 +1890,15 @@ func (v *JobsView) promptSortBy() {
 	if v.pages != nil {
 		v.pages.AddPage("sort-by", centeredModal, true, true)
 	}
+}
+
+// showExportDialog opens the table export dialog for the current job list.
+func (v *JobsView) showExportDialog() {
+	showTableExportDialog(v.pages, v.app, "Jobs", func() *export.TableData {
+		v.mu.RLock()
+		jobs := make([]*dao.Job, len(v.jobs))
+		copy(jobs, v.jobs)
+		v.mu.RUnlock()
+		return export.JobsTableData(jobs)
+	})
 }

--- a/internal/views/nodes.go
+++ b/internal/views/nodes.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gdamore/tcell/v2"
 	"github.com/jontk/s9s/internal/dao"
 	"github.com/jontk/s9s/internal/debug"
+	"github.com/jontk/s9s/internal/export"
 	"github.com/jontk/s9s/internal/ssh"
 	"github.com/jontk/s9s/internal/ui/components"
 	"github.com/jontk/s9s/internal/ui/filters"
@@ -210,6 +211,7 @@ func (v *NodesView) Hints() []string {
 		"[yellow]a[white] All States",
 		"[yellow]g[white] Group By",
 		"[yellow]Space[white] Toggle Group",
+		"[yellow]e[white] Export",
 		"Bar: █=Used ▒=Alloc ▱=Free",
 	}
 
@@ -308,6 +310,8 @@ func (v *NodesView) nodesRuneHandlers() map[rune]func(*NodesView, *tcell.EventKe
 		'g': func(v *NodesView, _ *tcell.EventKey) *tcell.EventKey { v.promptGroupBy(); return nil },
 		'G': func(v *NodesView, _ *tcell.EventKey) *tcell.EventKey { v.promptGroupBy(); return nil },
 		' ': func(v *NodesView, _ *tcell.EventKey) *tcell.EventKey { v.toggleGroupExpansion(); return nil },
+		'e': func(v *NodesView, _ *tcell.EventKey) *tcell.EventKey { v.showExportDialog(); return nil },
+		'E': func(v *NodesView, _ *tcell.EventKey) *tcell.EventKey { v.showExportDialog(); return nil },
 	}
 }
 
@@ -1873,4 +1877,15 @@ func (v *NodesView) promptSortBy() {
 	if v.pages != nil {
 		v.pages.AddPage("sort-by", centeredModal, true, true)
 	}
+}
+
+// showExportDialog opens the table export dialog for the current node list.
+func (v *NodesView) showExportDialog() {
+	showTableExportDialog(v.pages, v.app, "Nodes", func() *export.TableData {
+		v.mu.RLock()
+		nodes := make([]*dao.Node, len(v.nodes))
+		copy(nodes, v.nodes)
+		v.mu.RUnlock()
+		return export.NodesTableData(nodes)
+	})
 }

--- a/internal/views/partitions.go
+++ b/internal/views/partitions.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/jontk/s9s/internal/dao"
+	"github.com/jontk/s9s/internal/export"
 	"github.com/jontk/s9s/internal/ui/components"
 	"github.com/jontk/s9s/internal/ui/filters"
 	"github.com/jontk/s9s/internal/ui/styles"
@@ -187,6 +188,7 @@ func (v *PartitionsView) Hints() []string {
 		"[yellow]Click Headers[white] Sort",
 		"[yellow]S[white] Sort",
 		"[yellow]R[white] Refresh",
+		"[yellow]e[white] Export",
 	}
 
 	if v.isAdvancedMode {
@@ -279,6 +281,9 @@ func (v *PartitionsView) handleRuneCommand(r rune) bool {
 		return true
 	case '/':
 		v.app.SetFocus(v.filterInput)
+		return true
+	case 'e', 'E':
+		v.showExportDialog()
 		return true
 	}
 
@@ -1415,4 +1420,15 @@ func (v *PartitionsView) promptSortBy() {
 	if v.pages != nil {
 		v.pages.AddPage("sort-by", centeredModal, true, true)
 	}
+}
+
+// showExportDialog opens the table export dialog for the current partition list.
+func (v *PartitionsView) showExportDialog() {
+	showTableExportDialog(v.pages, v.app, "Partitions", func() *export.TableData {
+		v.mu.RLock()
+		partitions := make([]*dao.Partition, len(v.partitions))
+		copy(partitions, v.partitions)
+		v.mu.RUnlock()
+		return export.PartitionsTableData(partitions)
+	})
 }

--- a/internal/views/qos.go
+++ b/internal/views/qos.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gdamore/tcell/v2"
 	"github.com/jontk/s9s/internal/dao"
 	"github.com/jontk/s9s/internal/debug"
+	"github.com/jontk/s9s/internal/export"
 	"github.com/jontk/s9s/internal/ui/components"
 	"github.com/jontk/s9s/internal/ui/filters"
 	"github.com/jontk/s9s/internal/ui/styles"
@@ -179,6 +180,7 @@ func (v *QoSView) Hints() []string {
 		"[yellow]Click Headers[white] Sort",
 		"[yellow]S[white] Sort",
 		"[yellow]R[white] Refresh",
+		"[yellow]e[white] Export",
 	}
 
 	if v.isAdvancedMode {
@@ -242,6 +244,8 @@ func (v *QoSView) qosRuneHandlers() map[rune]func() {
 		'R': func() { go func() { _ = v.Refresh() }() },
 		'/': func() { v.app.SetFocus(v.filterInput) },
 		'S': func() { v.promptSortBy() },
+		'e': func() { v.showExportDialog() },
+		'E': func() { v.showExportDialog() },
 	}
 }
 
@@ -758,4 +762,15 @@ func (v *QoSView) promptSortBy() {
 	if v.pages != nil {
 		v.pages.AddPage("sort-by", centeredModal, true, true)
 	}
+}
+
+// showExportDialog opens the table export dialog for the current QoS list.
+func (v *QoSView) showExportDialog() {
+	showTableExportDialog(v.pages, v.app, "QoS", func() *export.TableData {
+		v.mu.RLock()
+		qosList := make([]*dao.QoS, len(v.qosList))
+		copy(qosList, v.qosList)
+		v.mu.RUnlock()
+		return export.QoSTableData(qosList)
+	})
 }

--- a/internal/views/reservations.go
+++ b/internal/views/reservations.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/jontk/s9s/internal/dao"
+	"github.com/jontk/s9s/internal/export"
 	"github.com/jontk/s9s/internal/ui/components"
 	"github.com/jontk/s9s/internal/ui/filters"
 	"github.com/jontk/s9s/internal/ui/styles"
@@ -176,6 +177,7 @@ func (v *ReservationsView) Hints() []string {
 		"[yellow]Click Headers[white] Sort",
 		"[yellow]S[white] Sort",
 		"[yellow]R[white] Refresh",
+		"[yellow]e[white] Export",
 	}
 
 	// Show active filter status
@@ -257,6 +259,8 @@ func (v *ReservationsView) reservationsRuneHandlers() map[rune]func() {
 		'f': v.toggleFutureFilter,
 		'F': v.toggleFutureFilter,
 		'S': func() { v.promptSortBy() },
+		'e': func() { v.showExportDialog() },
+		'E': func() { v.showExportDialog() },
 	}
 }
 
@@ -844,4 +848,15 @@ func (v *ReservationsView) promptSortBy() {
 	if v.pages != nil {
 		v.pages.AddPage("sort-by", centeredModal, true, true)
 	}
+}
+
+// showExportDialog opens the table export dialog for the current reservation list.
+func (v *ReservationsView) showExportDialog() {
+	showTableExportDialog(v.pages, v.app, "Reservations", func() *export.TableData {
+		v.mu.RLock()
+		reservations := make([]*dao.Reservation, len(v.reservations))
+		copy(reservations, v.reservations)
+		v.mu.RUnlock()
+		return export.ReservationsTableData(reservations)
+	})
 }

--- a/internal/views/users.go
+++ b/internal/views/users.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/jontk/s9s/internal/dao"
+	"github.com/jontk/s9s/internal/export"
 	"github.com/jontk/s9s/internal/ui/components"
 	"github.com/jontk/s9s/internal/ui/filters"
 	"github.com/jontk/s9s/internal/ui/styles"
@@ -187,6 +188,7 @@ func (v *UsersView) Hints() []string {
 		"[yellow]S[white] Sort",
 		"[yellow]R[white] Refresh",
 		adminHint,
+		"[yellow]e[white] Export",
 	}
 
 	if v.isAdvancedMode {
@@ -252,6 +254,8 @@ func (v *UsersView) usersRuneHandlers() map[rune]func() {
 		'a': v.toggleAdminFilter,
 		'A': v.toggleAdminFilter,
 		'S': func() { v.promptSortBy() },
+		'e': func() { v.showExportDialog() },
+		'E': func() { v.showExportDialog() },
 	}
 }
 
@@ -790,4 +794,15 @@ func (v *UsersView) promptSortBy() {
 	if v.pages != nil {
 		v.pages.AddPage("sort-by", centeredModal, true, true)
 	}
+}
+
+// showExportDialog opens the table export dialog for the current user list.
+func (v *UsersView) showExportDialog() {
+	showTableExportDialog(v.pages, v.app, "Users", func() *export.TableData {
+		v.mu.RLock()
+		users := make([]*dao.User, len(v.users))
+		copy(users, v.users)
+		v.mu.RUnlock()
+		return export.UsersTableData(users)
+	})
 }


### PR DESCRIPTION
## Summary

- Adds **'e' key export** to all 7 main views: Jobs, Nodes, Partitions, Reservations, QoS, Accounts, Users
- Supports **5 export formats**: CSV, JSON, Text, Markdown, HTML
- Files saved to `~/slurm_exports/` by default with timestamped names

## Changes

| File | Description |
|------|-------------|
| `internal/export/table_exporter.go` | Generic `TableExporter` — writes TableData to any of 5 formats with path-safe file creation |
| `internal/export/view_exporters.go` | Type-specific converters: `JobsTableData`, `NodesTableData`, `PartitionsTableData`, `ReservationsTableData`, `QoSTableData`, `AccountsTableData`, `UsersTableData` |
| `internal/export/table_exporter_test.go` | 16 unit tests covering all formats and all 7 data converters |
| `internal/ui/widgets/table_export_dialog.go` | Reusable modal dialog with format dropdown, path input, Export/Cancel buttons |
| `internal/views/export.go` | Shared `showTableExportDialog()` helper + post-export result modal |
| `internal/views/{jobs,nodes,partitions,reservations,qos,accounts,users}.go` | `'e'`/`'E'` key binding, hint added to status bar, `showExportDialog()` method |

## Test plan

- [ ] Press `e` in each view (Jobs, Nodes, Partitions, Reservations, QoS, Accounts, Users) — export dialog appears
- [ ] Select CSV format, click Export — `~/slurm_exports/<view>_<timestamp>.csv` is created with correct headers and data
- [ ] Select JSON format — JSON file contains `title`, `total`, and `records` array keyed by column name
- [ ] Select Markdown format — file contains a proper Markdown table
- [ ] Select HTML format — file is a valid HTML page with a styled table
- [ ] Select Text format — file contains a bordered ASCII table
- [ ] Press Escape or Cancel — dialog closes without creating a file
- [ ] All unit tests pass: `go test ./internal/export/...`