### PR TITLE
docs: update README with correct config format and keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ s9s provides a terminal interface for managing SLURM clusters, inspired by the p
 
 ### Prerequisites
 
-- Go 1.19 or higher
+- Go 1.24 or higher
 - Access to a SLURM cluster (or use mock mode)
 - Terminal with 256 color support
 
@@ -90,6 +90,9 @@ s9s --mock
 # Connect to a specific cluster
 s9s --cluster production
 
+# Use a specific config file
+s9s --config /path/to/config.yaml
+
 # Enable debug logging
 s9s --debug
 ```
@@ -122,22 +125,22 @@ Example configuration:
 
 ```yaml
 # ~/.s9s/config.yaml
-clusters:
-  production:
-    url: https://slurm-api.example.com
-    token: ${SLURM_TOKEN}
-    default: true
-  
-  development:
-    url: https://slurm-dev.example.com
-    auth:
-      username: ${SLURM_USER}
-      password: ${SLURM_PASS}
+defaultCluster: production
 
-preferences:
-  theme: dark
-  refreshInterval: 5s
-  defaultView: jobs
+clusters:
+  - name: production
+    cluster:
+      endpoint: "https://slurm-api.example.com:6820"
+      token: "${SLURM_TOKEN}"
+      apiVersion: v0.0.44
+
+  - name: development
+    cluster:
+      endpoint: "https://slurm-dev.example.com:6820"
+      token: "${SLURM_DEV_TOKEN}"
+      apiVersion: v0.0.43
+
+refreshRate: 5s
 ```
 
 ## 🎮 Key Bindings
@@ -149,9 +152,11 @@ preferences:
 | `?` | Show help |
 | `q` | Quit |
 | `:` | Command mode |
-| `/` | Search |
+| `/` | Search/filter |
+| `e` | Export view data |
 | `Tab` | Switch view |
-| `Ctrl+r` | Force refresh |
+| `Ctrl+K` | Switch cluster |
+| `F5` / `R` | Force refresh |
 
 #### Command Mode with Autocomplete
 
@@ -211,7 +216,7 @@ internal/
   ├── performance/# Performance profiling and optimization
   └── plugins/    # Plugin system implementation
 pkg/
-  └── mock/       # Mock SLURM implementation for testing
+  └── slurm/      # SLURM client and mock implementation
 ```
 
 For more information about the project structure, see the [docs/](docs/) directory.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -30,30 +30,32 @@ This script will:
 Download pre-built binaries from our [releases page](https://github.com/jontk/s9s/releases):
 
 ```bash
-# Linux (AMD64)
-wget https://github.com/jontk/s9s/releases/latest/download/s9s-linux-amd64
-chmod +x s9s-linux-amd64
+# Linux (x86_64)
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.6.0_Linux_x86_64.tar.gz
+tar -xzf s9s_0.6.0_Linux_x86_64.tar.gz
 mkdir -p ~/.local/bin
-mv s9s-linux-amd64 ~/.local/bin/s9s
+mv s9s ~/.local/bin/
 
 # Linux (ARM64)
-wget https://github.com/jontk/s9s/releases/latest/download/s9s-linux-arm64
-chmod +x s9s-linux-arm64
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.6.0_Linux_arm64.tar.gz
+tar -xzf s9s_0.6.0_Linux_arm64.tar.gz
 mkdir -p ~/.local/bin
-mv s9s-linux-arm64 ~/.local/bin/s9s
+mv s9s ~/.local/bin/
 
 # macOS (Apple Silicon)
-wget https://github.com/jontk/s9s/releases/latest/download/s9s-darwin-arm64
-chmod +x s9s-darwin-arm64
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.6.0_Darwin_arm64.tar.gz
+tar -xzf s9s_0.6.0_Darwin_arm64.tar.gz
 mkdir -p ~/.local/bin
-mv s9s-darwin-arm64 ~/.local/bin/s9s
+mv s9s ~/.local/bin/
 
 # macOS (Intel)
-wget https://github.com/jontk/s9s/releases/latest/download/s9s-darwin-amd64
-chmod +x s9s-darwin-amd64
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.6.0_Darwin_x86_64.tar.gz
+tar -xzf s9s_0.6.0_Darwin_x86_64.tar.gz
 mkdir -p ~/.local/bin
-mv s9s-darwin-amd64 ~/.local/bin/s9s
+mv s9s ~/.local/bin/
 ```
+
+> **Note:** Replace `0.6.0` with the latest version from the [releases page](https://github.com/jontk/s9s/releases).
 
 ### 3. Using Go Install
 

--- a/docs/install
+++ b/docs/install
@@ -47,24 +47,24 @@ detect_platform() {
     local os
     local arch
     
-    # Detect OS
+    # Detect OS (title case to match goreleaser naming)
     case "$(uname -s)" in
-        Linux*)  os="linux" ;;
-        Darwin*) os="darwin" ;;
-        CYGWIN*|MINGW*|MSYS*) os="windows" ;;
+        Linux*)  os="Linux" ;;
+        Darwin*) os="Darwin" ;;
+        CYGWIN*|MINGW*|MSYS*) os="Windows" ;;
         *) error "Unsupported operating system: $(uname -s)" ;;
     esac
-    
-    # Detect architecture
+
+    # Detect architecture (match goreleaser naming)
     case "$(uname -m)" in
-        x86_64|amd64) arch="amd64" ;;
+        x86_64|amd64) arch="x86_64" ;;
         arm64|aarch64) arch="arm64" ;;
-        armv7l) arch="arm" ;;
-        i386|i686) arch="386" ;;
+        armv7l) arch="armv7" ;;
+        i386|i686) arch="i386" ;;
         *) error "Unsupported architecture: $(uname -m)" ;;
     esac
-    
-    echo "${os}-${arch}"
+
+    echo "${os}_${arch}"
 }
 
 # Get latest release version
@@ -88,7 +88,7 @@ install_binary() {
     debug "Using temporary directory: $temp_dir"
     
     # Construct download URL
-    local archive_name="s9s-${version#v}-${platform}"
+    local archive_name="s9s_${version#v}_${platform}"
     local download_url
     
     if [[ "$platform" == *"windows"* ]]; then


### PR DESCRIPTION
## Summary

- Fix config example to use current YAML format (`defaultCluster`, `clusters` array with `name`/`cluster` structure)
- Add `Ctrl+K` (cluster switcher) and `e` (export) to keybindings table
- Fix refresh key: was `Ctrl+r`, actually `F5`/`R`
- Fix Go version requirement: 1.24, not 1.19
- Fix architecture tree: `pkg/slurm/`, not `pkg/mock/`
- Add `--config` flag to basic usage examples

## Test plan
- [x] Config example matches actual `config.example.yaml` format
- [x] Keybindings match implemented shortcuts