### PR TITLE
fix(metrics): use real SLURM API data for node resources and cluster metrics

### DIFF
--- a/internal/dao/slurm_adapter.go
+++ b/internal/dao/slurm_adapter.go
@@ -938,7 +938,7 @@ func convertNode(node *slurm.Node) *Node {
 		allocMemory = *node.AllocMemory
 	}
 	idleCPUs := safeSubtract(cpusTotal, allocCPUs)
-	freeMemory := int64(0)
+	var freeMemory int64
 	if node.FreeMem != nil {
 		freeMemory = int64(*node.FreeMem)
 	} else {

--- a/internal/dao/slurm_adapter.go
+++ b/internal/dao/slurm_adapter.go
@@ -156,8 +156,9 @@ func (s *SlurmAdapter) Users() UserManager {
 // Info returns the info manager for cluster information
 func (s *SlurmAdapter) Info() InfoManager {
 	return &infoManager{
-		client: s.client.Info(),
-		ctx:    s.ctx,
+		client:     s.client.Info(),
+		nodeClient: s.client.Nodes(),
+		ctx:        s.ctx,
 	}
 }
 
@@ -712,8 +713,9 @@ func (r *reservationManager) Get(name string) (*Reservation, error) {
 
 // infoManager implements InfoManager
 type infoManager struct {
-	client slurm.InfoManager
-	ctx    context.Context
+	client     slurm.InfoManager
+	nodeClient slurm.NodeManager
+	ctx        context.Context
 }
 
 func (i *infoManager) GetClusterInfo() (*ClusterInfo, error) {
@@ -741,18 +743,48 @@ func (i *infoManager) GetStats() (*ClusterMetrics, error) {
 		cpuUsage = float64(stats.AllocatedCPUs) / float64(stats.TotalCPUs) * 100
 	}
 
-	return &ClusterMetrics{
+	metrics := &ClusterMetrics{
 		TotalJobs:   stats.TotalJobs,
 		RunningJobs: stats.RunningJobs,
 		PendingJobs: stats.PendingJobs,
 		TotalNodes:  stats.TotalNodes,
 		ActiveNodes: stats.AllocatedNodes,
 		IdleNodes:   stats.IdleNodes,
-		DownNodes:   0, // Not available in basic ClusterStats
+		DownNodes:   0,
 		CPUUsage:    cpuUsage,
-		MemoryUsage: -1.0, // Not available in basic ClusterStats (would require aggregating node data) - use -1 to indicate unknown
+		MemoryUsage: -1.0, // Will be enriched from node data below
 		LastUpdated: time.Now(),
-	}, nil
+	}
+
+	// Enrich with node-level data for metrics the Stats API doesn't provide
+	if i.nodeClient != nil {
+		if nodeList, err := i.nodeClient.List(i.ctx, nil); err == nil {
+			var totalMem, allocMem int64
+			var totalCPUs, allocCPUs int
+			for _, node := range nodeList.Nodes {
+				if node.RealMemory != nil {
+					totalMem += *node.RealMemory
+				}
+				if node.AllocMemory != nil {
+					allocMem += *node.AllocMemory
+				}
+				if node.CPUs != nil {
+					totalCPUs += int(*node.CPUs)
+				}
+				if node.AllocCPUs != nil {
+					allocCPUs += int(*node.AllocCPUs)
+				}
+			}
+			if totalMem > 0 {
+				metrics.MemoryUsage = float64(allocMem) / float64(totalMem) * 100
+			}
+			if metrics.CPUUsage == 0 && totalCPUs > 0 && allocCPUs > 0 {
+				metrics.CPUUsage = float64(allocCPUs) / float64(totalCPUs) * 100
+			}
+		}
+	}
+
+	return metrics, nil
 }
 
 // Conversion functions
@@ -896,12 +928,27 @@ func convertNode(node *slurm.Node) *Node {
 		memoryTotalMB = *node.RealMemory
 	}
 
-	// Calculate estimates
-	allocCPUs := estimateAllocatedCPUs(node)
-	allocMemory := estimateAllocatedMemory(node, memoryTotalMB)
+	// Use real allocation data from SLURM API
+	allocCPUs := 0
+	if node.AllocCPUs != nil {
+		allocCPUs = int(*node.AllocCPUs)
+	}
+	allocMemory := int64(0)
+	if node.AllocMemory != nil {
+		allocMemory = *node.AllocMemory
+	}
 	idleCPUs := safeSubtract(cpusTotal, allocCPUs)
-	freeMemory := safeSubtract64(memoryTotalMB, allocMemory)
-	cpuLoad := calculateCPULoad(allocCPUs, cpusTotal)
+	freeMemory := int64(0)
+	if node.FreeMem != nil {
+		freeMemory = int64(*node.FreeMem)
+	} else {
+		freeMemory = safeSubtract64(memoryTotalMB, allocMemory)
+	}
+	// SLURM cpu_load is the 1-minute OS load average * 100
+	cpuLoad := float64(-1)
+	if node.CPULoad != nil {
+		cpuLoad = float64(*node.CPULoad) / 100.0
+	}
 
 	// Reason is *string
 	reason := ""
@@ -936,43 +983,6 @@ func convertNode(node *slurm.Node) *Node {
 	}
 }
 
-// estimateAllocatedCPUs estimates CPU allocation based on node state
-func estimateAllocatedCPUs(node *slurm.Node) int {
-	if node.CPUs == nil || *node.CPUs <= 0 {
-		return 0
-	}
-
-	cpus := int(*node.CPUs)
-
-	// Check state (now a slice of NodeState)
-	if len(node.State) > 0 {
-		stateStr := string(node.State[0])
-		switch stateStr {
-		case "MIXED", "ALLOCATED", "mixed", "allocated":
-			return cpus / 2 // Estimate 50% utilization
-		}
-	}
-
-	return 0
-}
-
-// estimateAllocatedMemory estimates memory allocation based on node state
-func estimateAllocatedMemory(node *slurm.Node, totalMemory int64) int64 {
-	if totalMemory <= 0 {
-		return 0
-	}
-
-	// Check state (now a slice of NodeState)
-	if len(node.State) > 0 {
-		stateStr := string(node.State[0])
-		switch stateStr {
-		case "MIXED", "ALLOCATED", "mixed", "allocated":
-			return totalMemory / 2 // Estimate 50% utilization
-		}
-	}
-
-	return 0
-}
 
 // safeSubtract subtracts two integers and returns 0 if result is negative
 func safeSubtract(a, b int) int {
@@ -992,13 +1002,6 @@ func safeSubtract64(a, b int64) int64 {
 	return result
 }
 
-// calculateCPULoad calculates CPU load as a percentage
-func calculateCPULoad(allocCPUs, totalCPUs int) float64 {
-	if allocCPUs <= 0 || totalCPUs <= 0 {
-		return 0.0
-	}
-	return float64(allocCPUs) / float64(totalCPUs) * 100.0
-}
 
 func convertPartition(partition *slurm.Partition) *Partition {
 	// Handle pointer fields

--- a/internal/dao/types.go
+++ b/internal/dao/types.go
@@ -88,7 +88,7 @@ type Node struct {
 	CPUsTotal       int
 	CPUsAllocated   int
 	CPUsIdle        int
-	CPULoad         float64 // CPU load average
+	CPULoad         float64 // OS 1-minute load average (SLURM cpu_load / 100)
 	MemoryTotal     int64   // in MB
 	MemoryAllocated int64   // in MB
 	MemoryFree      int64   // in MB

--- a/internal/views/dashboard.go
+++ b/internal/views/dashboard.go
@@ -299,13 +299,19 @@ func (v *DashboardView) updateClusterOverview() {
 
 		// Key metrics
 		content.WriteString(fmt.Sprintf("[yellow]CPU Usage:[white] %.1f%%\n", v.clusterMetrics.CPUUsage))
-		content.WriteString(fmt.Sprintf("[yellow]Memory Usage:[white] %.1f%%\n", v.clusterMetrics.MemoryUsage))
+		if v.clusterMetrics.MemoryUsage >= 0 {
+			content.WriteString(fmt.Sprintf("[yellow]Memory Usage:[white] %.1f%%\n", v.clusterMetrics.MemoryUsage))
+		} else {
+			content.WriteString("[yellow]Memory Usage:[white] N/A\n")
+		}
 
 		// Utilization bars
 		cpuBar := v.createUtilizationBar(v.clusterMetrics.CPUUsage)
-		memBar := v.createUtilizationBar(v.clusterMetrics.MemoryUsage)
 		content.WriteString(fmt.Sprintf("[yellow]CPU:[white] %s\n", cpuBar))
-		content.WriteString(fmt.Sprintf("[yellow]Memory:[white] %s\n", memBar))
+		if v.clusterMetrics.MemoryUsage >= 0 {
+			memBar := v.createUtilizationBar(v.clusterMetrics.MemoryUsage)
+			content.WriteString(fmt.Sprintf("[yellow]Memory:[white] %s\n", memBar))
+		}
 	}
 
 	content.WriteString(fmt.Sprintf("\n[gray]Last Updated: %s[white]", v.lastUpdate.Format("15:04:05")))
@@ -513,11 +519,7 @@ func (v *DashboardView) updateTrendsPanel() {
 
 	content.WriteString("[yellow]Performance Overview[white]\n\n")
 
-	// Job throughput trends (mock data for now)
-	content.WriteString("[teal]Job Throughput (24h):[white]\n")
-	content.WriteString("Jobs/Hour: █▇▆▅▄▃▂▁▂▃▄▅▆▇█ (Trend: ↗)\n")
-
-	content.WriteString("\n[teal]Resource Efficiency:[white]\n")
+	content.WriteString("[teal]Resource Efficiency:[white]\n")
 	if v.clusterMetrics != nil {
 		efficiency := (v.clusterMetrics.CPUUsage + v.clusterMetrics.MemoryUsage) / 2
 		efficiencyBar := v.createMiniBar(efficiency, getUtilizationColor(efficiency))

--- a/internal/views/jobs.go
+++ b/internal/views/jobs.go
@@ -490,7 +490,7 @@ func (v *JobsView) updateTable() {
 		coloredState := fmt.Sprintf("[%s]%s[white]", stateColor, job.State)
 
 		timeUsed := job.TimeUsed
-		if timeUsed == "" && job.StartTime != nil {
+		if timeUsed == "" && job.StartTime != nil && job.State == dao.JobStateRunning {
 			timeUsed = FormatDurationDetailed(time.Since(*job.StartTime))
 		}
 

--- a/internal/views/nodes.go
+++ b/internal/views/nodes.go
@@ -1100,7 +1100,7 @@ func (v *NodesView) writeCPUDetails(w *strings.Builder, node *dao.Node) {
 	fmt.Fprintf(w, "[yellow]  CPU Allocation:[white] %.1f%% (SLURM allocated)\n", cpuAllocPercent)
 
 	if node.CPULoad >= 0 {
-		fmt.Fprintf(w, "[yellow]  CPU Load:[white] %.2f (1-minute load average)\n", node.CPULoad)
+		fmt.Fprintf(w, "[yellow]  CPU Load:[white] %.2f (OS 1-min load avg)\n", node.CPULoad)
 		if node.CPUsAllocated > 0 {
 			efficiency := (node.CPULoad / float64(node.CPUsAllocated)) * 100.0
 			if efficiency > 100 {

--- a/internal/views/performance_view.go
+++ b/internal/views/performance_view.go
@@ -215,13 +215,19 @@ func (pv *PerformanceView) updateDisplay() {
 
 	// Resource metrics
 	cpuColor := pv.getUsageColor(pv.metrics.CPUUsage)
-	memColor := pv.getUsageColor(pv.metrics.MemoryUsage)
 
 	resourceText := "\n[yellow]Cluster Utilization[white]\n\n"
 	resourceText += fmt.Sprintf("[%s]CPU:[white] %.1f%%\n", cpuColor, pv.metrics.CPUUsage)
-	resourceText += fmt.Sprintf("[%s]Memory:[white] %.1f%%\n", memColor, pv.metrics.MemoryUsage)
+	if pv.metrics.MemoryUsage >= 0 {
+		memColor := pv.getUsageColor(pv.metrics.MemoryUsage)
+		resourceText += fmt.Sprintf("[%s]Memory:[white] %.1f%%\n", memColor, pv.metrics.MemoryUsage)
+	} else {
+		resourceText += "[white]Memory:[white] N/A\n"
+	}
 	resourceText += fmt.Sprintf("\n%s\n", pv.getUsageBar(pv.metrics.CPUUsage, "CPU"))
-	resourceText += fmt.Sprintf("%s\n", pv.getUsageBar(pv.metrics.MemoryUsage, "Mem"))
+	if pv.metrics.MemoryUsage >= 0 {
+		resourceText += fmt.Sprintf("%s\n", pv.getUsageBar(pv.metrics.MemoryUsage, "Mem"))
+	}
 	pv.resourceBox.SetText(resourceText)
 }
 


### PR DESCRIPTION
## Summary

- **Node metrics**: Replace hardcoded 50% CPU/memory estimates with real SLURM API fields (`AllocCPUs`, `AllocMemory`, `FreeMem`, `CPULoad`) — nodes now show actual allocation and OS load average
- **Cluster metrics**: Enrich `GetStats()` with node-level data so Dashboard, Performance, and Health views all show real memory usage (was `-1.0%`) and correct CPU usage
- **Job times**: Fix negative times (`-13:-39:-58`) for PENDING jobs — SLURM sets `StartTime` to a future estimate, so only compute elapsed time for RUNNING jobs
- **Dashboard**: Remove fake hardcoded "Job Throughput (24h)" chart; handle unknown memory as "N/A"
- **Labels**: Fix misleading "1-minute load average" label — now accurately says "OS 1-min load avg" since it uses real `cpu_load` data

## Test plan

- [ ] Verify node CPU/memory allocation matches `sinfo` output on real clusters
- [ ] Check Dashboard, Performance, and Health views show real CPU% and Memory%
- [ ] Confirm PENDING jobs show empty Time column (no negative values)
- [ ] Confirm RUNNING jobs still show correct elapsed time
- [ ] Verify node detail view shows real OS load average