### PR TITLE
chore: prepare v0.6.1 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to release (e.g. v0.6.0)'
+        description: 'Tag to release (e.g. v0.6.1)'
         required: true
 
 env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [0.6.1] - 2026-03-09
+
+### Fixed
+
+- **Node Resource Metrics** (#92)
+  - Replace hardcoded 50% CPU/memory estimates with real SLURM API fields (`AllocCPUs`, `AllocMemory`, `FreeMem`, `CPULoad`)
+  - Nodes now display actual allocation and real OS load average instead of fabricated values
+  - CPU Load label corrected to "OS 1-min load avg" (previously misleadingly said "1-minute load average" while showing allocation percentage)
+
+- **Cluster Metrics in Dashboard, Performance, and Health Views** (#92)
+  - Enrich `GetStats()` with node-level data for memory and CPU usage
+  - Memory usage now shows real allocation percentage (was displaying `-1.0%`)
+  - CPU usage falls back to node-level aggregation when Stats API returns 0
+
+- **Negative Job Times for PENDING Jobs** (#92)
+  - SLURM sets `StartTime` on pending jobs to a future estimated time, causing `time.Since()` to produce negative durations (e.g. `-13:-39:-58`)
+  - Elapsed time is now only computed for RUNNING jobs; PENDING jobs show an empty Time column
+
+### Removed
+
+- Fake hardcoded "Job Throughput (24h)" chart from Dashboard — was purely decorative with no real data
+
 ## [0.6.0] - 2026-03-08
 
 ### Added
@@ -364,7 +386,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Note**: Versions prior to 0.1.0 were in active development and did not follow semantic versioning.
 
-[Unreleased]: https://github.com/jontk/s9s/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/jontk/s9s/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/jontk/s9s/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/jontk/s9s/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/jontk/s9s/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/jontk/s9s/compare/v0.3.0...v0.4.0

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -31,31 +31,31 @@ Download pre-built binaries from our [releases page](https://github.com/jontk/s9
 
 ```bash
 # Linux (x86_64)
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.6.0_Linux_x86_64.tar.gz
-tar -xzf s9s_0.6.0_Linux_x86_64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.6.1_Linux_x86_64.tar.gz
+tar -xzf s9s_0.6.1_Linux_x86_64.tar.gz
 mkdir -p ~/.local/bin
 mv s9s ~/.local/bin/
 
 # Linux (ARM64)
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.6.0_Linux_arm64.tar.gz
-tar -xzf s9s_0.6.0_Linux_arm64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.6.1_Linux_arm64.tar.gz
+tar -xzf s9s_0.6.1_Linux_arm64.tar.gz
 mkdir -p ~/.local/bin
 mv s9s ~/.local/bin/
 
 # macOS (Apple Silicon)
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.6.0_Darwin_arm64.tar.gz
-tar -xzf s9s_0.6.0_Darwin_arm64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.6.1_Darwin_arm64.tar.gz
+tar -xzf s9s_0.6.1_Darwin_arm64.tar.gz
 mkdir -p ~/.local/bin
 mv s9s ~/.local/bin/
 
 # macOS (Intel)
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.6.0_Darwin_x86_64.tar.gz
-tar -xzf s9s_0.6.0_Darwin_x86_64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.6.1_Darwin_x86_64.tar.gz
+tar -xzf s9s_0.6.1_Darwin_x86_64.tar.gz
 mkdir -p ~/.local/bin
 mv s9s ~/.local/bin/
 ```
 
-> **Note:** Replace `0.6.0` with the latest version from the [releases page](https://github.com/jontk/s9s/releases).
+> **Note:** Replace `0.6.1` with the latest version from the [releases page](https://github.com/jontk/s9s/releases).
 
 ### 3. Using Go Install
 


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md with v0.6.1 release notes (node metrics fix, cluster metrics enrichment, job time fix, fake chart removal)
- Bump version references in installation docs from 0.6.0 to 0.6.1

## After merge

1. `git tag v0.6.1`
2. `git push origin v0.6.1` (triggers goreleaser via release workflow)