### PR TITLE
fix: temporarily disable setup wizard that generates invalid configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,21 +99,7 @@ s9s --debug
 
 ### Configuration
 
-#### Quick Setup (Recommended)
-
-Run the interactive setup wizard for first-time configuration:
-
-```bash
-s9s setup
-```
-
-The wizard will guide you through:
-- 🏢 Cluster connection settings
-- 🔐 Authentication configuration  
-- 🔒 Secure credential storage
-- ⚡ Performance optimization
-
-#### Manual Configuration
+#### Configuration
 
 s9s looks for configuration in the following order:
 1. `~/.s9s/config.yaml`

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -6,28 +6,53 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Recent Changes
 
+### Version 0.6.1 (2026-03-09)
+
+Bug fix release focusing on metric accuracy:
+
+- **Node Resource Metrics**: Use real SLURM API fields (`AllocCPUs`, `AllocMemory`, `FreeMem`, `CPULoad`) instead of hardcoded 50% estimates
+- **Cluster Metrics**: Dashboard, Performance, and Health views now show real memory and CPU usage from node data
+- **Job Times**: Fix negative elapsed times for PENDING jobs (SLURM sets StartTime to future estimate)
+- Remove fake hardcoded "Job Throughput (24h)" chart from Dashboard
+
+### Version 0.6.0 (2026-03-08)
+
+Key features:
+
+- **Cluster Switcher**: Show active cluster name in header, press `Ctrl+K` to switch clusters at runtime
+- **`--cluster` Flag**: Select cluster context from the command line; fix `--config` flag being ignored
+- **Table Export**: Press `e` in any view to export data (CSV, JSON, Text, Markdown, HTML)
+- **VHS Integration Tests**: Regression testing against real Slurm clusters (24.05, 24.11, 25.11)
+- **Breaking**: Config keys renamed `contexts` → `clusters`, `currentContext` → `defaultCluster`
+
+### Version 0.5.0 (2026-02-18)
+
+Key features:
+
+- **Zero-Configuration Auto-Discovery**: Works out-of-the-box on SLURM systems without config files
+- **API Version Auto-Detection**: Removed hardcoded API version default
+- **Static Binary Builds**: `CGO_ENABLED=0` for cross-distribution compatibility
+- **Integration Tests CI**: PR testing with ephemeral k3d cluster and mock SLURM API
+
+### Version 0.4.0 (2026-02-08)
+
+Key features:
+
+- **Performance View**: Real-time cluster-wide metrics (jobs, nodes, CPU%, memory%)
+- **Sorting Modal**: Press `S` in any table view for interactive column sorting
+- **Command Mode with Arguments**: Vim-style `:cancel`, `:drain`, `:requeue` with Tab completion
+- **Reservation Filters**: `a` for active-only, `f` for future-only
+- **Job Output File Reading**: Local filesystem and SSH-based remote file access
+
 ### Version 0.3.0 (2026-01-30)
 
-Key improvements and new features:
+Key features:
 
-- **Job submission working directory default**: Working directory now defaults to the current directory where s9s is started
 - **Vim-style view navigation**: `h` and `l` keys for switching between views
-- **Global search cross-view navigation**: Search results navigate to the correct view and focus on the selected item
+- **Global search cross-view navigation**: Search results navigate to the correct view
 - **Partition filter syntax**: Use `p:partition_name` to filter by partition
-- **Users view admin filter**: Press `a` to toggle showing only administrators
-- **Status bar feedback**: Users view shows status messages when toggling filters
 - **Username resolution**: Jobs display actual usernames instead of numeric UIDs
 - Centralized version management and automated release processes
-- Comprehensive release notes following Keep a Changelog format
-
-Notable fixes:
-- Fixed drain operation to actually drain nodes
-- Fixed resume operation modal issues
-- Fixed node state truncation (shows full state like `IDLE+DRAIN`)
-- Fixed filter input hijacking by global shortcuts
-- Fixed search deadlocks in event handlers
-- Environment variables now properly override config file values
-- Case-insensitive admin level comparison in Users view
 
 ### Version 0.1.0 (2026-01-21)
 
@@ -48,7 +73,11 @@ For a complete list of all changes, features, and fixes across all versions, ref
 
 ## Version History
 
-- [v0.3.0](../CHANGELOG.md#030---2026-01-30) - Latest release
+- [v0.6.1](../CHANGELOG.md#061---2026-03-09) - Latest release
+- [v0.6.0](../CHANGELOG.md#060---2026-03-08) - Cluster switcher, export, config rename
+- [v0.5.0](../CHANGELOG.md#050---2026-02-18) - Auto-discovery, static builds
+- [v0.4.0](../CHANGELOG.md#040---2026-02-08) - Performance view, sorting, command mode
+- [v0.3.0](../CHANGELOG.md#030---2026-01-30) - Vim navigation, search, filters
 - [v0.1.0](../CHANGELOG.md#010---2026-01-21) - Initial release
 - [Unreleased](../CHANGELOG.md#unreleased) - Upcoming changes
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -781,20 +781,6 @@ s9s config import config-backup.yaml
 s9s config merge additional-config.yaml
 ```
 
-### Configuration Wizard
-
-```bash
-# Interactive setup
-s9s setup
-
-# Guided cluster addition
-s9s config add-cluster
-
-# Update specific settings
-s9s config set preferences.theme dark
-s9s config set clusters.default.url https://new-url.com
-```
-
 ## Configuration Examples
 
 ### Minimal Configuration

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -107,13 +107,7 @@ s9s version 0.3.0
 
 ### 2. Initial Configuration
 
-Run the setup wizard:
-
-```bash
-s9s setup
-```
-
-Or create a config file manually:
+Create a config file:
 
 ```bash
 mkdir -p ~/.s9s

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -494,9 +494,10 @@ cp -r ~/.s9s ~/.s9s.backup
 # Reset to defaults
 s9s reset
 
-# Or manual reset
+# Or manual reset and reconfigure
 rm -rf ~/.s9s
-s9s setup
+mkdir -p ~/.s9s
+# Then create ~/.s9s/config.yaml manually
 ```
 
 ### Clear Cache

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -53,9 +53,7 @@ Features:
 
 	Example: `  s9s                                    # Launch interactive TUI
   s9s --cluster production                 # Use a specific cluster context
-  s9s --config /path/to/config.yaml        # Use a custom config file
-  s9s setup                                # Run configuration wizard
-  s9s setup --auto-discover                # Auto-discover clusters`,
+  s9s --config /path/to/config.yaml        # Use a custom config file`,
 
 	RunE: runRoot,
 }

--- a/internal/cli/setup_cmd.go
+++ b/internal/cli/setup_cmd.go
@@ -8,9 +8,10 @@ import (
 
 // setupCmd represents the setup command
 var setupCmd = &cobra.Command{
-	Use:   "setup",
-	Short: "Interactive setup wizard (temporarily disabled)",
-	Long:  `The setup wizard is temporarily disabled while being reworked. Please configure s9s manually.`,
+	Use:    "setup",
+	Short:  "Interactive setup wizard (temporarily disabled)",
+	Long:   `The setup wizard is temporarily disabled while being reworked. Please configure s9s manually.`,
+	Hidden: true,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		fmt.Println("The setup wizard is temporarily disabled while being reworked.")
 		fmt.Println()

--- a/internal/cli/setup_cmd.go
+++ b/internal/cli/setup_cmd.go
@@ -1,126 +1,37 @@
 package cli
 
 import (
-	"context"
 	"fmt"
-	"strings"
 
-	"github.com/jontk/s9s/internal/config"
-	"github.com/jontk/s9s/internal/discovery"
-	"github.com/jontk/s9s/internal/setup"
 	"github.com/spf13/cobra"
 )
 
 // setupCmd represents the setup command
 var setupCmd = &cobra.Command{
 	Use:   "setup",
-	Short: "Interactive setup wizard for s9s configuration",
-	Long: `Launch the interactive setup wizard to configure s9s for first-time use.
-
-The setup wizard will guide you through:
-• 🏢 Cluster connection settings  
-• 🔐 Authentication configuration
-• 🔒 Secure credential storage
-• ⚡ Performance optimization
-
-Run this command when you first install s9s or want to reconfigure your setup.`,
-	Example: `  s9s setup                    # Run interactive setup
-  s9s setup --auto-discover     # Auto-discover clusters first
-  s9s setup --validate-only     # Just validate current config`,
-	RunE: runSetup,
+	Short: "Interactive setup wizard (temporarily disabled)",
+	Long:  `The setup wizard is temporarily disabled while being reworked. Please configure s9s manually.`,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		fmt.Println("The setup wizard is temporarily disabled while being reworked.")
+		fmt.Println()
+		fmt.Println("To configure s9s manually, create ~/.s9s/config.yaml:")
+		fmt.Println()
+		fmt.Println("  defaultCluster: my-cluster")
+		fmt.Println()
+		fmt.Println("  clusters:")
+		fmt.Println("    - name: my-cluster")
+		fmt.Println("      cluster:")
+		fmt.Println("        endpoint: http://your-slurmrestd:6820")
+		fmt.Println("        token: ${SLURM_TOKEN}")
+		fmt.Println("        apiVersion: v0.0.43")
+		fmt.Println()
+		fmt.Println("Or run s9s directly on a SLURM node — it will auto-discover slurmrestd.")
+		fmt.Println()
+		fmt.Println("See https://s9s.dev/docs for full configuration options.")
+		return nil
+	},
 }
-
-// setupFlags holds the flags for the setup command
-type setupFlags struct {
-	autoDiscover bool
-	validateOnly bool
-	force        bool
-	configPath   string
-}
-
-var setupFlagValues setupFlags
 
 func init() {
-	// Add setup command flags
-	setupCmd.Flags().BoolVar(&setupFlagValues.autoDiscover, "auto-discover", false, "Auto-discover SLURM clusters before setup")
-	setupCmd.Flags().BoolVar(&setupFlagValues.validateOnly, "validate-only", false, "Only validate existing configuration")
-	setupCmd.Flags().BoolVar(&setupFlagValues.force, "force", false, "Force setup even if configuration exists")
-	setupCmd.Flags().StringVar(&setupFlagValues.configPath, "config", "", "Path to configuration file")
-
-	// Add to root command
 	rootCmd.AddCommand(setupCmd)
-}
-
-// runSetup executes the setup command
-func runSetup(_ *cobra.Command, _ []string) error {
-	if setupFlagValues.validateOnly {
-		return runConfigValidation()
-	}
-
-	if setupFlagValues.autoDiscover {
-		if err := runAutoDiscovery(); err != nil {
-			fmt.Printf("⚠️  Auto-discovery failed: %v\n", err)
-			fmt.Println("Continuing with manual setup...")
-		}
-	}
-
-	// Run the setup wizard
-	wizard := setup.NewSetupWizard()
-	return wizard.Run()
-}
-
-// runConfigValidation validates the current configuration
-func runConfigValidation() error {
-	fmt.Println("🔍 Validating s9s configuration...")
-
-	// Load current configuration
-	cfg, err := config.LoadConfig("")
-	if err != nil {
-		fmt.Printf("❌ Failed to load configuration: %v\n", err)
-		fmt.Println("\n💡 Run 's9s setup' to create initial configuration")
-		return nil
-	}
-
-	// Validate configuration
-	result := config.ValidateAndFix(cfg, false)
-	config.PrintValidationResult(result, true)
-
-	if !result.Valid {
-		fmt.Println("\n🔧 To fix issues automatically, run: s9s setup --validate-only --auto-fix")
-		return fmt.Errorf("configuration validation failed")
-	}
-
-	return nil
-}
-
-// runAutoDiscovery attempts to auto-discover SLURM clusters
-func runAutoDiscovery() error {
-	fmt.Println("🔍 Auto-discovering SLURM clusters...")
-
-	discoveryService := discovery.NewClusterDiscovery()
-	clusters, err := discoveryService.DiscoverClusters(context.Background())
-	if err != nil {
-		return fmt.Errorf("cluster discovery failed: %w", err)
-	}
-
-	if len(clusters) == 0 {
-		fmt.Println("   📭 No clusters found")
-		return nil
-	}
-
-	fmt.Printf("   🎯 Found %d potential cluster(s):\n\n", len(clusters))
-
-	for i, cluster := range clusters {
-		fmt.Printf("   %d. %s\n", i+1, cluster.Name)
-		fmt.Printf("      🌐 Host: %s:%d\n", cluster.Host, cluster.Port)
-		if len(cluster.RestEndpoints) > 0 {
-			fmt.Printf("      🔗 Endpoint: %s\n", cluster.RestEndpoints[0])
-		}
-		fmt.Printf("      🎯 Confidence: %.1f%%\n", cluster.Confidence*100)
-		fmt.Printf("      📝 Methods: %s\n", strings.Join(cluster.DetectionMethods, ", "))
-		fmt.Println()
-	}
-
-	fmt.Println("These clusters will be available during setup configuration.")
-	return nil
 }

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -339,7 +339,7 @@ func (v *Validator) validateConfigDirectory(configDir string) {
 	} else {
 		v.addError("paths",
 			fmt.Sprintf("Config directory does not exist: %s", configDir),
-			"Run 's9s setup' or create directory manually", true)
+			"Create directory with: mkdir -p ~/.s9s", true)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `s9s setup` generates configs with lowercase YAML keys (`apiversion`, `defaultcluster`) and all zero-value fields — s9s expects camelCase and fails to load these configs
- Replace the wizard with a helpful message showing manual config format
- Remove `s9s setup` references from README, installation, configuration, and troubleshooting docs

## Test plan

- [ ] Run `s9s setup` — should print manual config instructions and exit cleanly
- [ ] Verify `s9s` still works with manually created configs