### PR TITLE
fix(lint): use http.NoBody instead of nil for request body

### DIFF
--- a/internal/setup/wizard.go
+++ b/internal/setup/wizard.go
@@ -672,7 +672,7 @@ func (w *Wizard) testEndpoint(endpoint string) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, http.NoBody)
 	if err != nil {
 		debug.Logger.Printf("Endpoint test failed for %s: %v", endpoint, err)
 		return false


### PR DESCRIPTION
Fix gocritic lint error from #95 — use `http.NoBody` instead of `nil` in `http.NewRequestWithContext`.