### PR TITLE
chore: run gofmt on all Go source files

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,7 +17,7 @@ type Config struct {
 	RefreshRate    string            `mapstructure:"refreshRate"`
 	MaxRetries     int               `mapstructure:"maxRetries"`
 	DefaultCluster string            `mapstructure:"defaultCluster"`
-	Clusters       []ClusterContext   `mapstructure:"clusters"`
+	Clusters       []ClusterContext  `mapstructure:"clusters"`
 	UI             UIConfig          `mapstructure:"ui"`
 	Views          ViewsConfig       `mapstructure:"views"`
 	Features       FeaturesConfig    `mapstructure:"features"`
@@ -151,9 +151,9 @@ func DefaultConfig() *Config {
 		Views: ViewsConfig{
 			Jobs: JobsViewConfig{
 				Columns:        []string{"id", "name", "user", "state", "time", "nodes", "priority"}, // Aligned with setDefaults
-				ShowOnlyActive: true,                                                                   // Aligned with setDefaults
-				DefaultSort:    "time",                                                                 // Aligned with setDefaults
-				MaxJobs:        1000,                                                                   // Aligned with setDefaults
+				ShowOnlyActive: true,                                                                 // Aligned with setDefaults
+				DefaultSort:    "time",                                                               // Aligned with setDefaults
+				MaxJobs:        1000,                                                                 // Aligned with setDefaults
 			},
 			Nodes: NodesViewConfig{
 				GroupBy:         "partition", // Aligned with setDefaults
@@ -166,11 +166,11 @@ func DefaultConfig() *Config {
 			},
 		},
 		Features: FeaturesConfig{
-			Streaming: true,  // Aligned with setDefaults
-			Pulseye:   true,  // Aligned with setDefaults
+			Streaming: true, // Aligned with setDefaults
+			Pulseye:   true, // Aligned with setDefaults
 			Xray:      false,
 		},
-		Shortcuts:     []ShortcutConfig{},
+		Shortcuts: []ShortcutConfig{},
 		Aliases: map[string]string{ // Aligned with setDefaults
 			"ctx": "context",
 			"kj":  "kill job",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -259,7 +259,7 @@ func TestDefaultConfig(t *testing.T) {
 	// Test Views defaults
 	assert.NotNil(t, cfg.Views.Jobs)
 	assert.Equal(t, []string{"id", "name", "user", "state", "time", "nodes", "priority"}, cfg.Views.Jobs.Columns)
-	assert.True(t, cfg.Views.Jobs.ShowOnlyActive)  // Aligned with setDefaults
+	assert.True(t, cfg.Views.Jobs.ShowOnlyActive)       // Aligned with setDefaults
 	assert.Equal(t, "time", cfg.Views.Jobs.DefaultSort) // Aligned with setDefaults
 	assert.Equal(t, 1000, cfg.Views.Jobs.MaxJobs)       // Aligned with setDefaults
 
@@ -273,8 +273,8 @@ func TestDefaultConfig(t *testing.T) {
 	assert.True(t, cfg.Views.Partitions.ShowWaitTime)
 
 	// Test Features defaults
-	assert.True(t, cfg.Features.Streaming)  // Aligned with setDefaults
-	assert.True(t, cfg.Features.Pulseye)    // Aligned with setDefaults
+	assert.True(t, cfg.Features.Streaming) // Aligned with setDefaults
+	assert.True(t, cfg.Features.Pulseye)   // Aligned with setDefaults
 	assert.False(t, cfg.Features.Xray)
 
 	// Test Plugin Settings defaults
@@ -286,11 +286,11 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(t, 25.0, cfg.PluginSettings.MaxCPUPercent) // Aligned with setDefaults
 
 	// Test Discovery defaults (aligned with setDefaults)
-	assert.True(t, cfg.Discovery.Enabled)                     // Aligned with setDefaults
-	assert.True(t, cfg.Discovery.EnableEndpoint)              // Aligned with setDefaults
-	assert.True(t, cfg.Discovery.EnableToken)                 // Aligned with setDefaults
-	assert.Equal(t, "10s", cfg.Discovery.Timeout)             // Aligned with setDefaults
-	assert.Equal(t, 6820, cfg.Discovery.DefaultPort)          // Same in both
+	assert.True(t, cfg.Discovery.Enabled)                   // Aligned with setDefaults
+	assert.True(t, cfg.Discovery.EnableEndpoint)            // Aligned with setDefaults
+	assert.True(t, cfg.Discovery.EnableToken)               // Aligned with setDefaults
+	assert.Equal(t, "10s", cfg.Discovery.Timeout)           // Aligned with setDefaults
+	assert.Equal(t, 6820, cfg.Discovery.DefaultPort)        // Same in both
 	assert.Equal(t, "scontrol", cfg.Discovery.ScontrolPath) // Aligned with setDefaults (binary name, not full path)
 
 	// Test collections are initialized

--- a/internal/dao/slurm_adapter.go
+++ b/internal/dao/slurm_adapter.go
@@ -983,7 +983,6 @@ func convertNode(node *slurm.Node) *Node {
 	}
 }
 
-
 // safeSubtract subtracts two integers and returns 0 if result is negative
 func safeSubtract(a, b int) int {
 	result := a - b
@@ -1001,7 +1000,6 @@ func safeSubtract64(a, b int64) int64 {
 	}
 	return result
 }
-
 
 func convertPartition(partition *slurm.Partition) *Partition {
 	// Handle pointer fields

--- a/internal/export/table_exporter.go
+++ b/internal/export/table_exporter.go
@@ -16,9 +16,9 @@ import (
 
 // TableData holds tabular data for export (headers + rows + metadata).
 type TableData struct {
-	Title     string     // e.g. "Jobs", "Nodes", "Partitions"
-	Headers   []string   // column names
-	Rows      [][]string // raw (uncolored) row values
+	Title      string     // e.g. "Jobs", "Nodes", "Partitions"
+	Headers    []string   // column names
+	Rows       [][]string // raw (uncolored) row values
 	ExportedAt time.Time
 }
 

--- a/internal/monitoring/health_test.go
+++ b/internal/monitoring/health_test.go
@@ -23,21 +23,23 @@ type mockSlurmClient struct {
 	infoFunc     func() dao.InfoManager
 }
 
-func (m *mockSlurmClient) Jobs() dao.JobManager               { return m.jobs }
-func (m *mockSlurmClient) Nodes() dao.NodeManager             { return m.nodes }
+func (m *mockSlurmClient) Jobs() dao.JobManager   { return m.jobs }
+func (m *mockSlurmClient) Nodes() dao.NodeManager { return m.nodes }
 func (m *mockSlurmClient) Info() dao.InfoManager {
 	if m.infoFunc != nil {
 		return m.infoFunc()
 	}
 	return m.info
 }
-func (m *mockSlurmClient) Partitions() dao.PartitionManager   { return m.partitions }
+func (m *mockSlurmClient) Partitions() dao.PartitionManager     { return m.partitions }
 func (m *mockSlurmClient) Reservations() dao.ReservationManager { return m.reservations }
-func (m *mockSlurmClient) QoS() dao.QoSManager                { return m.qos }
-func (m *mockSlurmClient) Accounts() dao.AccountManager       { return m.accounts }
-func (m *mockSlurmClient) Users() dao.UserManager             { return m.users }
-func (m *mockSlurmClient) ClusterInfo() (*dao.ClusterInfo, error) { return nil, errors.New("not implemented") }
-func (m *mockSlurmClient) Close() error                       { return nil }
+func (m *mockSlurmClient) QoS() dao.QoSManager                  { return m.qos }
+func (m *mockSlurmClient) Accounts() dao.AccountManager         { return m.accounts }
+func (m *mockSlurmClient) Users() dao.UserManager               { return m.users }
+func (m *mockSlurmClient) ClusterInfo() (*dao.ClusterInfo, error) {
+	return nil, errors.New("not implemented")
+}
+func (m *mockSlurmClient) Close() error { return nil }
 
 // mockJobManager implements dao.JobManager for testing
 type mockJobManager struct {
@@ -846,12 +848,12 @@ func TestCheckUtilization(t *testing.T) {
 // TestSetCheckStatus tests status threshold logic
 func TestSetCheckStatus(t *testing.T) {
 	tests := []struct {
-		name            string
-		value           float64
-		threshold       HealthThreshold
-		expectedStatus  HealthStatus
-		expectCritical  bool
-		expectHealthy   bool
+		name           string
+		value          float64
+		threshold      HealthThreshold
+		expectedStatus HealthStatus
+		expectCritical bool
+		expectHealthy  bool
 	}{
 		{
 			name:  "below warning threshold",

--- a/internal/output/cache.go
+++ b/internal/output/cache.go
@@ -20,9 +20,9 @@ func (ce *CacheEntry) IsExpired() bool {
 
 // OutputCache provides LRU caching for job output
 type OutputCache struct {
-	mu       sync.RWMutex
-	entries  map[string]*CacheEntry
-	maxSize  int
+	mu         sync.RWMutex
+	entries    map[string]*CacheEntry
+	maxSize    int
 	defaultTTL time.Duration
 
 	// Statistics (using atomic for thread-safe access)

--- a/internal/output/reader.go
+++ b/internal/output/reader.go
@@ -11,20 +11,20 @@ import (
 
 // ReadOptions configures how output is read
 type ReadOptions struct {
-	MaxBytes      int64         // Maximum bytes to read (0 = unlimited)
-	MaxLines      int           // Maximum lines to read (0 = unlimited)
-	TailMode      bool          // Read from end instead of beginning
-	Offset        int64         // Byte offset to start reading
-	Timeout       time.Duration // Timeout for remote operations
-	CacheEnabled  bool          // Enable local caching
-	ForceRefresh  bool          // Bypass cache
+	MaxBytes     int64         // Maximum bytes to read (0 = unlimited)
+	MaxLines     int           // Maximum lines to read (0 = unlimited)
+	TailMode     bool          // Read from end instead of beginning
+	Offset       int64         // Byte offset to start reading
+	Timeout      time.Duration // Timeout for remote operations
+	CacheEnabled bool          // Enable local caching
+	ForceRefresh bool          // Bypass cache
 }
 
 // DefaultReadOptions returns sensible defaults for read operations
 func DefaultReadOptions() ReadOptions {
 	return ReadOptions{
 		MaxBytes:     10 * 1024 * 1024, // 10MB default
-		MaxLines:     10000,             // 10k lines default
+		MaxLines:     10000,            // 10k lines default
 		TailMode:     false,
 		Offset:       0,
 		Timeout:      30 * time.Second,

--- a/internal/ui/components/table.go
+++ b/internal/ui/components/table.go
@@ -602,7 +602,7 @@ func (t *Table) GetSortableColumns() []struct {
 		Index int
 		Name  string
 	}
-	
+
 	for i, col := range t.config.Columns {
 		if col.Sortable && !col.Hidden {
 			sortable = append(sortable, struct {
@@ -611,7 +611,7 @@ func (t *Table) GetSortableColumns() []struct {
 			}{Index: i, Name: col.Name})
 		}
 	}
-	
+
 	return sortable
 }
 

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -41,11 +41,11 @@ var (
 	ColorDim     = tcell.ColorGray    // ANSI 8: theme's dimmed/placeholder text
 
 	// Accent colors (from theme's palette)
-	ColorAccent    = tcell.ColorYellow  // ANSI 3: theme's yellow (for labels)
-	ColorHighlight = tcell.ColorGreen   // ANSI 2: theme's green (for success/selected)
-	ColorInfo      = tcell.ColorBlue    // ANSI 4: theme's blue
-	ColorWarning   = tcell.ColorYellow  // ANSI 3: theme's yellow
-	ColorError     = tcell.ColorRed     // ANSI 1: theme's red
+	ColorAccent    = tcell.ColorYellow // ANSI 3: theme's yellow (for labels)
+	ColorHighlight = tcell.ColorGreen  // ANSI 2: theme's green (for success/selected)
+	ColorInfo      = tcell.ColorBlue   // ANSI 4: theme's blue
+	ColorWarning   = tcell.ColorYellow // ANSI 3: theme's yellow
+	ColorError     = tcell.ColorRed    // ANSI 1: theme's red
 )
 
 // InputFieldColors defines colors for input field components

--- a/internal/ui/widgets/performance_dashboard_test.go
+++ b/internal/ui/widgets/performance_dashboard_test.go
@@ -13,11 +13,11 @@ import (
 // TestCalculateCPUUsage tests the CPU usage calculation function
 func TestCalculateCPUUsage(t *testing.T) {
 	tests := []struct {
-		name          string
-		stats         map[string]performance.OperationSummary
-		previousStats map[string]performance.OperationSummary
+		name           string
+		stats          map[string]performance.OperationSummary
+		previousStats  map[string]performance.OperationSummary
 		updateInterval time.Duration
-		want          float64
+		want           float64
 	}{
 		{
 			name:  "empty stats returns 0.0",
@@ -35,7 +35,7 @@ func TestCalculateCPUUsage(t *testing.T) {
 			},
 			previousStats:  nil,
 			updateInterval: 1 * time.Second,
-			want:          0.0,
+			want:           0.0,
 		},
 		{
 			name: "with previous stats calculates delta correctly",
@@ -54,7 +54,7 @@ func TestCalculateCPUUsage(t *testing.T) {
 				},
 			},
 			updateInterval: 1 * time.Second,
-			want:          20.0, // (300ms - 100ms) / 1s * 100 = 20%
+			want:           20.0, // (300ms - 100ms) / 1s * 100 = 20%
 		},
 		{
 			name: "caps at 100% max",
@@ -73,7 +73,7 @@ func TestCalculateCPUUsage(t *testing.T) {
 				},
 			},
 			updateInterval: 1 * time.Second,
-			want:          100.0, // Should cap at 100%
+			want:           100.0, // Should cap at 100%
 		},
 		{
 			name: "handles new operations not in previous stats",
@@ -97,7 +97,7 @@ func TestCalculateCPUUsage(t *testing.T) {
 				},
 			},
 			updateInterval: 1 * time.Second,
-			want:          30.0, // (200ms + 100ms) / 1s * 100 = 30%
+			want:           30.0, // (200ms + 100ms) / 1s * 100 = 30%
 		},
 		{
 			name: "handles zero update interval",
@@ -116,7 +116,7 @@ func TestCalculateCPUUsage(t *testing.T) {
 				},
 			},
 			updateInterval: 0,
-			want:          20.0, // Defaults to 1 second window
+			want:           20.0, // Defaults to 1 second window
 		},
 		{
 			name: "multiple operations",
@@ -145,7 +145,7 @@ func TestCalculateCPUUsage(t *testing.T) {
 				},
 			},
 			updateInterval: 1 * time.Second,
-			want:          25.0, // (150ms + 100ms) / 1s * 100 = 25%
+			want:           25.0, // (150ms + 100ms) / 1s * 100 = 25%
 		},
 	}
 
@@ -253,7 +253,7 @@ func TestCalculateNetworkUsage(t *testing.T) {
 			},
 			previousStats:  nil,
 			updateInterval: 1 * time.Second,
-			want:          0.0,
+			want:           0.0,
 		},
 		{
 			name: "identifies network operations - ssh",
@@ -272,7 +272,7 @@ func TestCalculateNetworkUsage(t *testing.T) {
 				},
 			},
 			updateInterval: 1 * time.Second,
-			want:          1.0, // 10 ops/s * 0.1 MB/op = 1.0 MB/s
+			want:           1.0, // 10 ops/s * 0.1 MB/op = 1.0 MB/s
 		},
 		{
 			name: "identifies network operations - api",
@@ -291,7 +291,7 @@ func TestCalculateNetworkUsage(t *testing.T) {
 				},
 			},
 			updateInterval: 1 * time.Second,
-			want:          2.0, // 20 ops/s * 0.1 MB/op = 2.0 MB/s
+			want:           2.0, // 20 ops/s * 0.1 MB/op = 2.0 MB/s
 		},
 		{
 			name: "identifies network operations - network in name",
@@ -310,7 +310,7 @@ func TestCalculateNetworkUsage(t *testing.T) {
 				},
 			},
 			updateInterval: 1 * time.Second,
-			want:          1.0, // 10 ops/s * 0.1 MB/op = 1.0 MB/s
+			want:           1.0, // 10 ops/s * 0.1 MB/op = 1.0 MB/s
 		},
 		{
 			name: "calculates delta ops correctly - multiple network operations",
@@ -339,7 +339,7 @@ func TestCalculateNetworkUsage(t *testing.T) {
 				},
 			},
 			updateInterval: 1 * time.Second,
-			want:          3.0, // (10 + 20) ops/s * 0.1 MB/op = 3.0 MB/s
+			want:           3.0, // (10 + 20) ops/s * 0.1 MB/op = 3.0 MB/s
 		},
 		{
 			name: "ignores non-network operations",
@@ -368,7 +368,7 @@ func TestCalculateNetworkUsage(t *testing.T) {
 				},
 			},
 			updateInterval: 1 * time.Second,
-			want:          1.0, // Only counts ssh_connect: 10 ops/s * 0.1 = 1.0 MB/s
+			want:           1.0, // Only counts ssh_connect: 10 ops/s * 0.1 = 1.0 MB/s
 		},
 		{
 			name: "handles new network operations not in previous stats",
@@ -392,7 +392,7 @@ func TestCalculateNetworkUsage(t *testing.T) {
 				},
 			},
 			updateInterval: 1 * time.Second,
-			want:          2.0, // (10 + 10) ops/s * 0.1 = 2.0 MB/s
+			want:           2.0, // (10 + 10) ops/s * 0.1 = 2.0 MB/s
 		},
 		{
 			name: "handles zero update interval",
@@ -411,7 +411,7 @@ func TestCalculateNetworkUsage(t *testing.T) {
 				},
 			},
 			updateInterval: 0,
-			want:          1.0, // Defaults to 1 second window: 10 ops/s * 0.1 = 1.0 MB/s
+			want:           1.0, // Defaults to 1 second window: 10 ops/s * 0.1 = 1.0 MB/s
 		},
 		{
 			name: "handles case insensitivity",
@@ -450,7 +450,7 @@ func TestCalculateNetworkUsage(t *testing.T) {
 				},
 			},
 			updateInterval: 1 * time.Second,
-			want:          4.0, // (10 + 20 + 10) ops/s * 0.1 = 4.0 MB/s
+			want:           4.0, // (10 + 20 + 10) ops/s * 0.1 = 4.0 MB/s
 		},
 		{
 			name: "handles 2 second interval",
@@ -469,7 +469,7 @@ func TestCalculateNetworkUsage(t *testing.T) {
 				},
 			},
 			updateInterval: 2 * time.Second,
-			want:          1.0, // 20 ops / 2s = 10 ops/s * 0.1 = 1.0 MB/s
+			want:           1.0, // 20 ops / 2s = 10 ops/s * 0.1 = 1.0 MB/s
 		},
 	}
 
@@ -511,7 +511,7 @@ func TestCalculateOpsRate(t *testing.T) {
 			},
 			previousStats:  nil,
 			updateInterval: 1 * time.Second,
-			want:          0.0,
+			want:           0.0,
 		},
 		{
 			name: "calculates delta operations correctly - single operation",
@@ -530,7 +530,7 @@ func TestCalculateOpsRate(t *testing.T) {
 				},
 			},
 			updateInterval: 1 * time.Second,
-			want:          10.0, // 10 ops / 1s = 10 ops/s
+			want:           10.0, // 10 ops / 1s = 10 ops/s
 		},
 		{
 			name: "calculates delta operations correctly - multiple operations",
@@ -559,7 +559,7 @@ func TestCalculateOpsRate(t *testing.T) {
 				},
 			},
 			updateInterval: 1 * time.Second,
-			want:          20.0, // (10 + 10) ops / 1s = 20 ops/s
+			want:           20.0, // (10 + 10) ops / 1s = 20 ops/s
 		},
 		{
 			name: "converts to ops/second based on updateInterval",
@@ -578,7 +578,7 @@ func TestCalculateOpsRate(t *testing.T) {
 				},
 			},
 			updateInterval: 2 * time.Second,
-			want:          10.0, // 20 ops / 2s = 10 ops/s
+			want:           10.0, // 20 ops / 2s = 10 ops/s
 		},
 		{
 			name: "handles new operations not in previous stats",
@@ -602,7 +602,7 @@ func TestCalculateOpsRate(t *testing.T) {
 				},
 			},
 			updateInterval: 1 * time.Second,
-			want:          25.0, // (10 + 15) ops / 1s = 25 ops/s
+			want:           25.0, // (10 + 15) ops / 1s = 25 ops/s
 		},
 		{
 			name: "handles zero update interval",
@@ -621,7 +621,7 @@ func TestCalculateOpsRate(t *testing.T) {
 				},
 			},
 			updateInterval: 0,
-			want:          10.0, // Defaults to 1 second window: 10 ops / 1s = 10 ops/s
+			want:           10.0, // Defaults to 1 second window: 10 ops / 1s = 10 ops/s
 		},
 		{
 			name: "handles operations removed from stats",
@@ -645,7 +645,7 @@ func TestCalculateOpsRate(t *testing.T) {
 				},
 			},
 			updateInterval: 1 * time.Second,
-			want:          10.0, // Only counts operation1: 10 ops / 1s = 10 ops/s
+			want:           10.0, // Only counts operation1: 10 ops / 1s = 10 ops/s
 		},
 		{
 			name: "handles high operation rate",
@@ -664,7 +664,7 @@ func TestCalculateOpsRate(t *testing.T) {
 				},
 			},
 			updateInterval: 1 * time.Second,
-			want:          1000.0, // 1000 ops / 1s = 1000 ops/s
+			want:           1000.0, // 1000 ops / 1s = 1000 ops/s
 		},
 		{
 			name: "handles fractional seconds interval",
@@ -683,7 +683,7 @@ func TestCalculateOpsRate(t *testing.T) {
 				},
 			},
 			updateInterval: 500 * time.Millisecond,
-			want:          10.0, // 5 ops / 0.5s = 10 ops/s
+			want:           10.0, // 5 ops / 0.5s = 10 ops/s
 		},
 		{
 			name: "handles zero delta operations",
@@ -702,7 +702,7 @@ func TestCalculateOpsRate(t *testing.T) {
 				},
 			},
 			updateInterval: 1 * time.Second,
-			want:          0.0, // No new operations
+			want:           0.0, // No new operations
 		},
 	}
 

--- a/internal/views/base.go
+++ b/internal/views/base.go
@@ -64,15 +64,15 @@ type View interface {
 
 // BaseView provides common functionality for all views
 type BaseView struct {
-	ctx         context.Context
-	name        string
-	title       string
-	app         *tview.Application
-	pages       *tview.Pages
-	viewMgr     *ViewManager
+	ctx          context.Context
+	name         string
+	title        string
+	app          *tview.Application
+	pages        *tview.Pages
+	viewMgr      *ViewManager
 	switchViewFn func(string) // Callback to switch to a view
-	refreshing  bool
-	lastError   error
+	refreshing   bool
+	lastError    error
 }
 
 // NewBaseView creates a new base view instance

--- a/internal/views/health_test.go
+++ b/internal/views/health_test.go
@@ -89,10 +89,10 @@ func TestHealthStatusPriority(t *testing.T) {
 		{
 			name: "Mixed - critical takes precedence",
 			checks: map[string]monitoring.HealthCheck{
-				"nodes":    {Status: monitoring.HealthStatusHealthy},
-				"jobs":     {Status: monitoring.HealthStatusWarning},
-				"storage":  {Status: monitoring.HealthStatusCritical},
-				"network":  {Status: monitoring.HealthStatusWarning},
+				"nodes":   {Status: monitoring.HealthStatusHealthy},
+				"jobs":    {Status: monitoring.HealthStatusWarning},
+				"storage": {Status: monitoring.HealthStatusCritical},
+				"network": {Status: monitoring.HealthStatusWarning},
 			},
 			expectedStatus: monitoring.HealthStatusCritical,
 		},
@@ -146,12 +146,12 @@ func TestHealthStatusPriority(t *testing.T) {
 // TestHealthCheckCounting tests health check statistics calculation
 func TestHealthCheckCounting(t *testing.T) {
 	tests := []struct {
-		name              string
-		checks            map[string]monitoring.HealthCheck
-		expectedHealthy   int
-		expectedWarning   int
-		expectedCritical  int
-		expectedTotal     int
+		name             string
+		checks           map[string]monitoring.HealthCheck
+		expectedHealthy  int
+		expectedWarning  int
+		expectedCritical int
+		expectedTotal    int
 	}{
 		{
 			name: "All healthy",
@@ -240,9 +240,9 @@ func TestHealthCheckCounting(t *testing.T) {
 // TestHealthMessageGeneration tests health check message formatting
 func TestHealthMessageGeneration(t *testing.T) {
 	tests := []struct {
-		name            string
-		check           monitoring.HealthCheck
-		shouldContain   []string
+		name             string
+		check            monitoring.HealthCheck
+		shouldContain    []string
 		shouldNotContain []string
 	}{
 		{
@@ -253,7 +253,7 @@ func TestHealthMessageGeneration(t *testing.T) {
 				Message:     "All nodes operational",
 				Description: "Checks if all nodes are up and running",
 			},
-			shouldContain: []string{"operational"},
+			shouldContain:    []string{"operational"},
 			shouldNotContain: []string{"critical", "warning", "error"},
 		},
 		{
@@ -264,7 +264,7 @@ func TestHealthMessageGeneration(t *testing.T) {
 				Message:     "10 jobs pending for > 1 hour",
 				Description: "Checks for stuck jobs",
 			},
-			shouldContain: []string{"pending", "hour"},
+			shouldContain:    []string{"pending", "hour"},
 			shouldNotContain: []string{},
 		},
 		{
@@ -275,7 +275,7 @@ func TestHealthMessageGeneration(t *testing.T) {
 				Message:     "Disk usage above 95%",
 				Description: "Monitors disk space",
 			},
-			shouldContain: []string{"95"},
+			shouldContain:    []string{"95"},
 			shouldNotContain: []string{},
 		},
 	}

--- a/internal/views/partitions_test.go
+++ b/internal/views/partitions_test.go
@@ -12,12 +12,12 @@ import (
 // TestCreateEfficiencyBar tests partition efficiency visualization
 func TestCreateEfficiencyBar(t *testing.T) {
 	tests := []struct {
-		name             string
-		percentage       float64
-		expectedColor    string
-		expectedFilled   int
-		expectedEmpty    int
-		expectedText     string
+		name           string
+		percentage     float64
+		expectedColor  string
+		expectedFilled int
+		expectedEmpty  int
+		expectedText   string
 	}{
 		{
 			name:           "Zero efficiency",
@@ -125,76 +125,76 @@ func TestCreateEfficiencyBar(t *testing.T) {
 // TestCreateQueueDepthBar tests queue depth visualization
 func TestCreateQueueDepthBar(t *testing.T) {
 	tests := []struct {
-		name           string
-		pending        int
-		running        int
-		expectedTotal  string
-		expectRunning  bool
-		expectPending  bool
+		name          string
+		pending       int
+		running       int
+		expectedTotal string
+		expectRunning bool
+		expectPending bool
 	}{
 		{
-			name:           "No jobs",
-			pending:        0,
-			running:        0,
-			expectedTotal:  "0",
-			expectRunning:  false,
-			expectPending:  false,
+			name:          "No jobs",
+			pending:       0,
+			running:       0,
+			expectedTotal: "0",
+			expectRunning: false,
+			expectPending: false,
 		},
 		{
-			name:           "Only running jobs",
-			pending:        0,
-			running:        10,
-			expectedTotal:  "10",
-			expectRunning:  true,
-			expectPending:  false,
+			name:          "Only running jobs",
+			pending:       0,
+			running:       10,
+			expectedTotal: "10",
+			expectRunning: true,
+			expectPending: false,
 		},
 		{
-			name:           "Only pending jobs",
-			pending:        10,
-			running:        0,
-			expectedTotal:  "10",
-			expectRunning:  false,
-			expectPending:  true,
+			name:          "Only pending jobs",
+			pending:       10,
+			running:       0,
+			expectedTotal: "10",
+			expectRunning: false,
+			expectPending: true,
 		},
 		{
-			name:           "Equal running and pending",
-			pending:        5,
-			running:        5,
-			expectedTotal:  "10",
-			expectRunning:  true,
-			expectPending:  true,
+			name:          "Equal running and pending",
+			pending:       5,
+			running:       5,
+			expectedTotal: "10",
+			expectRunning: true,
+			expectPending: true,
 		},
 		{
-			name:           "More running than pending",
-			pending:        2,
-			running:        8,
-			expectedTotal:  "10",
-			expectRunning:  true,
-			expectPending:  true,
+			name:          "More running than pending",
+			pending:       2,
+			running:       8,
+			expectedTotal: "10",
+			expectRunning: true,
+			expectPending: true,
 		},
 		{
-			name:           "More pending than running",
-			pending:        8,
-			running:        2,
-			expectedTotal:  "10",
-			expectRunning:  true,
-			expectPending:  true,
+			name:          "More pending than running",
+			pending:       8,
+			running:       2,
+			expectedTotal: "10",
+			expectRunning: true,
+			expectPending: true,
 		},
 		{
-			name:           "Large numbers",
-			pending:        100,
-			running:        50,
-			expectedTotal:  "150",
-			expectRunning:  true,
-			expectPending:  true,
+			name:          "Large numbers",
+			pending:       100,
+			running:       50,
+			expectedTotal: "150",
+			expectRunning: true,
+			expectPending: true,
 		},
 		{
-			name:           "Single job running",
-			pending:        0,
-			running:        1,
-			expectedTotal:  "1",
-			expectRunning:  true,
-			expectPending:  false,
+			name:          "Single job running",
+			pending:       0,
+			running:       1,
+			expectedTotal: "1",
+			expectRunning: true,
+			expectPending: false,
 		},
 	}
 
@@ -230,10 +230,10 @@ func TestCreateQueueDepthBar(t *testing.T) {
 // This is the critical test based on the architectural review finding
 func TestPartitionEfficiencyCalculation(t *testing.T) {
 	tests := []struct {
-		name           string
-		partition      *dao.Partition
-		allocatedCPUs  int
-		expectedEff    float64
+		name          string
+		partition     *dao.Partition
+		allocatedCPUs int
+		expectedEff   float64
 	}{
 		{
 			name: "Full utilization",
@@ -334,10 +334,10 @@ func TestPartitionEfficiencyCalculation(t *testing.T) {
 // TestQueueDepthBarProportions tests that bar proportions are calculated correctly
 func TestQueueDepthBarProportions(t *testing.T) {
 	tests := []struct {
-		name             string
-		pending          int
-		running          int
-		expectedRatio    float64 // expected running/(running+pending)
+		name          string
+		pending       int
+		running       int
+		expectedRatio float64 // expected running/(running+pending)
 	}{
 		{
 			name:          "50-50 split",
@@ -433,7 +433,7 @@ func TestAssessPartitionStatus(t *testing.T) {
 			name: "Backlog - too many pending jobs",
 			queueInfo: &dao.QueueInfo{
 				PendingJobs: 100,
-				RunningJobs: 10, // pending > running * 2
+				RunningJobs: 10,                          // pending > running * 2
 				LongestWait: 1 * 60 * 60 * 1_000_000_000, // 1 hour
 			},
 			expectedColor:  "orange",
@@ -553,10 +553,10 @@ func TestIsWarningWaitTime(t *testing.T) {
 // TestHasJobBacklog tests job backlog detection
 func TestHasJobBacklog(t *testing.T) {
 	tests := []struct {
-		name        string
-		pending     int
-		running     int
-		hasBacklog  bool
+		name       string
+		pending    int
+		running    int
+		hasBacklog bool
 	}{
 		{"No backlog - equal", 10, 10, false},
 		{"No backlog - more running", 10, 20, false},

--- a/internal/views/performance_view.go
+++ b/internal/views/performance_view.go
@@ -24,10 +24,10 @@ type PerformanceView struct {
 	statsGrid *tview.Flex
 
 	// Metric displays
-	jobsBox    *tview.TextView
-	nodesBox   *tview.TextView
+	jobsBox     *tview.TextView
+	nodesBox    *tview.TextView
 	resourceBox *tview.TextView
-	controlBar *tview.TextView
+	controlBar  *tview.TextView
 
 	// State
 	autoRefresh     bool

--- a/internal/views/reservations.go
+++ b/internal/views/reservations.go
@@ -19,18 +19,18 @@ import (
 // ReservationsView displays the reservations list
 type ReservationsView struct {
 	*BaseView
-	client         dao.SlurmClient
-	table          *components.Table
-	reservations   []*dao.Reservation
-	mu             sync.RWMutex
-	refreshTimer   *time.Timer
-	refreshRate    time.Duration
-	filter         string
-	container      *tview.Flex
-	filterInput    *tview.InputField
-	statusBar      *tview.TextView
-	app            *tview.Application
-	pages          *tview.Pages
+	client              dao.SlurmClient
+	table               *components.Table
+	reservations        []*dao.Reservation
+	mu                  sync.RWMutex
+	refreshTimer        *time.Timer
+	refreshRate         time.Duration
+	filter              string
+	container           *tview.Flex
+	filterInput         *tview.InputField
+	statusBar           *tview.TextView
+	app                 *tview.Application
+	pages               *tview.Pages
 	filterBar           *components.FilterBar
 	advancedFilter      *filters.Filter
 	isAdvancedMode      bool

--- a/plugins/observability/historical/collector.go
+++ b/plugins/observability/historical/collector.go
@@ -47,7 +47,7 @@ type DataCollector struct {
 	series   map[string]*MetricSeries
 	queries  map[string]string
 	mu       sync.RWMutex
-	running  atomic.Bool   // Use atomic for thread-safe access
+	running  atomic.Bool // Use atomic for thread-safe access
 	stopChan chan struct{}
 	wg       sync.WaitGroup // Track goroutines for clean shutdown
 }

--- a/plugins/observability/prometheus/cache_keys.go
+++ b/plugins/observability/prometheus/cache_keys.go
@@ -12,16 +12,16 @@ import (
 // CacheKeyGenerator provides optimized cache key generation for Prometheus queries
 type CacheKeyGenerator struct {
 	// Compiled regex patterns for query normalization
-	whitespaceRegex   *regexp.Regexp
-	numberRegex       *regexp.Regexp
-	stringRegex       *regexp.Regexp
-	durationRegex     *regexp.Regexp
-	parenRegex        *regexp.Regexp
-	braceRegex        *regexp.Regexp
-	metricBraceRegex  *regexp.Regexp
-	commaRegex        *regexp.Regexp
-	equalsRegex       *regexp.Regexp
-	selectorRegex     *regexp.Regexp
+	whitespaceRegex  *regexp.Regexp
+	numberRegex      *regexp.Regexp
+	stringRegex      *regexp.Regexp
+	durationRegex    *regexp.Regexp
+	parenRegex       *regexp.Regexp
+	braceRegex       *regexp.Regexp
+	metricBraceRegex *regexp.Regexp
+	commaRegex       *regexp.Regexp
+	equalsRegex      *regexp.Regexp
+	selectorRegex    *regexp.Regexp
 }
 
 // NewCacheKeyGenerator creates a new cache key generator with compiled patterns


### PR DESCRIPTION
## Summary

- Run `gofmt` across all 17 Go files that had formatting inconsistencies
- Whitespace-only changes (tab/space alignment), no logic changes