### PR TITLE
chore: prepare v0.6.2 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to release (e.g. v0.6.1)'
+        description: 'Tag to release (e.g. v0.6.2)'
         required: true
 
 env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [0.6.2] - 2026-03-10
+
+### Fixed
+
+- **Setup Wizard Config Generation** (#99)
+  - Replace `yaml.Marshal` with template-based rendering to produce valid camelCase YAML keys (`defaultCluster`, `apiVersion`, not `defaultcluster`, `apiversion`)
+  - Config structs only have `mapstructure` tags, so `yaml.Marshal` lowercased all keys and s9s failed to load the generated config
+
+- **Setup Wizard Token Discovery** (#99)
+  - Generated config now writes `enableEndpoint: false` instead of `enabled: false`, so `scontrol token` and `SLURM_JWT` fallback still works when no token is entered during setup
+
+- **Lint Fixes** (#97)
+  - Use `http.NoBody` instead of `nil` for HTTP request bodies (gocritic)
+
+### Changed
+
+- **Setup Wizard Streamlined** (#95, #99)
+  - Remove wizard steps that collected data but never wrote to config (name, organization, auth method details, storage preferences, caching, logging, plugins)
+  - Wizard now asks only: endpoint, cluster name, and optional JWT token
+  - Add connection test to slurmrestd during setup (#95)
+  - Update docs to lead with zero-configuration auto-discovery (DNS SRV, `scontrol ping`, `scontrol token`) — s9s works on any SLURM node without running setup
+
+- **Code Formatting** (#98)
+  - Run `gofmt` across entire codebase
+
 ## [0.6.1] - 2026-03-09
 
 ### Fixed

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Recent Changes
 
+### Version 0.6.2 (2026-03-10)
+
+Setup wizard improvements and bug fixes:
+
+- **Setup Wizard Config Fix**: Generated config now uses valid camelCase YAML keys — previously `yaml.Marshal` produced lowercase keys that s9s couldn't load
+- **Streamlined Wizard**: Removed questions that didn't affect config; wizard now asks only endpoint, cluster name, and optional JWT token
+- **Token Discovery Fix**: Generated config no longer disables token auto-discovery, so `scontrol token` and `SLURM_JWT` fallback works without a configured token
+- **Connection Test**: Setup wizard now tests the slurmrestd connection before completing
+- **Docs Update**: Lead with zero-configuration auto-discovery (DNS SRV, `scontrol ping`) — s9s works on any SLURM node without running setup
+
 ### Version 0.6.1 (2026-03-09)
 
 Bug fix release focusing on metric accuracy:
@@ -73,7 +83,8 @@ For a complete list of all changes, features, and fixes across all versions, ref
 
 ## Version History
 
-- [v0.6.1](../CHANGELOG.md#061---2026-03-09) - Latest release
+- [v0.6.2](../CHANGELOG.md#062---2026-03-10) - Latest release
+- [v0.6.1](../CHANGELOG.md#061---2026-03-09) - Node metrics, job times, dashboard fixes
 - [v0.6.0](../CHANGELOG.md#060---2026-03-08) - Cluster switcher, export, config rename
 - [v0.5.0](../CHANGELOG.md#050---2026-02-18) - Auto-discovery, static builds
 - [v0.4.0](../CHANGELOG.md#040---2026-02-08) - Performance view, sorting, command mode

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -57,31 +57,31 @@ Download pre-built binaries from our [releases page](https://github.com/jontk/s9
 
 ```bash
 # Linux (x86_64)
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.6.1_Linux_x86_64.tar.gz
-tar -xzf s9s_0.6.1_Linux_x86_64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.6.2_Linux_x86_64.tar.gz
+tar -xzf s9s_0.6.2_Linux_x86_64.tar.gz
 mkdir -p ~/.local/bin
 mv s9s ~/.local/bin/
 
 # Linux (ARM64)
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.6.1_Linux_arm64.tar.gz
-tar -xzf s9s_0.6.1_Linux_arm64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.6.2_Linux_arm64.tar.gz
+tar -xzf s9s_0.6.2_Linux_arm64.tar.gz
 mkdir -p ~/.local/bin
 mv s9s ~/.local/bin/
 
 # macOS (Apple Silicon)
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.6.1_Darwin_arm64.tar.gz
-tar -xzf s9s_0.6.1_Darwin_arm64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.6.2_Darwin_arm64.tar.gz
+tar -xzf s9s_0.6.2_Darwin_arm64.tar.gz
 mkdir -p ~/.local/bin
 mv s9s ~/.local/bin/
 
 # macOS (Intel)
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.6.1_Darwin_x86_64.tar.gz
-tar -xzf s9s_0.6.1_Darwin_x86_64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.6.2_Darwin_x86_64.tar.gz
+tar -xzf s9s_0.6.2_Darwin_x86_64.tar.gz
 mkdir -p ~/.local/bin
 mv s9s ~/.local/bin/
 ```
 
-> **Note:** Replace `0.6.1` with the latest version from the [releases page](https://github.com/jontk/s9s/releases).
+> **Note:** Replace `0.6.2` with the latest version from the [releases page](https://github.com/jontk/s9s/releases).
 
 ### 3. Using Go Install
 


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md with v0.6.2 release notes (setup wizard fixes, lint, gofmt)
- Update docs/about/changelog.md with v0.6.2 summary
- Bump version references in installation docs and release workflow

## Changes since v0.6.1

- fix(setup): fix wizard config generation and strip to essential questions (#99)
- chore: run gofmt on all Go source files (#98)
- fix(lint): use http.NoBody instead of nil for request body (#97)
- wizard: Test connecting to slurmrestd (#95)
- docs: update docs changelog with all releases through v0.6.1 (#94)