### PR TITLE
fix: use per-user paths instead of shared /tmp files

### DIFF
--- a/internal/auth/keyring_store.go
+++ b/internal/auth/keyring_store.go
@@ -7,10 +7,26 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"runtime"
 
 	"github.com/jontk/s9s/internal/debug"
+	"github.com/jontk/s9s/internal/fileperms"
 )
+
+// s9sDataDir returns the per-user s9s data directory (~/.s9s),
+// creating it if it doesn't exist.
+func s9sDataDir() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		// Last resort: use a user-specific tmp path
+		return filepath.Join(os.TempDir(), fmt.Sprintf("s9s-%d", os.Getuid()))
+	}
+	dir := filepath.Join(homeDir, ".s9s")
+	_ = os.MkdirAll(dir, fileperms.ConfigDir)
+	return dir
+}
 
 // KeyringSecureStore implements secure storage using the system keyring
 type KeyringSecureStore struct {
@@ -41,7 +57,7 @@ func NewKeyringSecureStore(serviceName string) SecureStore {
 	default:
 		// Fall back to file-based storage for unsupported platforms
 		debug.Logger.Printf("Keyring not supported on %s, falling back to file storage", runtime.GOOS)
-		return NewFileSecureStore(fmt.Sprintf("/tmp/s9s-%s.keyring", serviceName))
+		return NewFileSecureStore(filepath.Join(s9sDataDir(), fmt.Sprintf("%s.keyring", serviceName)))
 	}
 
 	return store
@@ -118,7 +134,7 @@ func NewLinuxKeyringBackend() KeyringBackend {
 	// - Secret Service API
 	// For now, fall back to encrypted file storage
 	return &LinuxKeyringBackend{
-		fallback: NewFileSecureStore("/tmp/s9s-linux-keyring.encrypted"),
+		fallback: NewFileSecureStore(filepath.Join(s9sDataDir(), "keyring.encrypted")),
 	}
 }
 
@@ -196,7 +212,7 @@ func NewMacOSKeyringBackend() KeyringBackend {
 	// SecItemAdd, SecItemCopyMatching, SecItemDelete, etc.
 	// For now, fall back to encrypted file storage
 	return &MacOSKeyringBackend{
-		fallback: NewFileSecureStore("/tmp/s9s-macos-keychain.encrypted"),
+		fallback: NewFileSecureStore(filepath.Join(s9sDataDir(), "keychain.encrypted")),
 	}
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -99,7 +99,12 @@ func runRoot(cmd *cobra.Command, _ []string) error {
 		return displayVersion()
 	}
 
-	logging.Init(logging.DefaultConfig())
+	logConfig := logging.DefaultConfig()
+	if debugMode {
+		logConfig.File = true
+		logConfig.Level = logging.DebugLevel
+	}
+	logging.Init(logConfig)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -68,14 +68,23 @@ type Config struct {
 	Compress bool
 }
 
+// defaultLogPath returns a per-user log file path (~/.s9s/s9s.log),
+// falling back to a UID-specific temp path if $HOME is unavailable.
+func defaultLogPath() string {
+	if homeDir, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(homeDir, ".s9s", "s9s.log")
+	}
+	return filepath.Join(os.TempDir(), fmt.Sprintf("s9s-%d.log", os.Getuid()))
+}
+
 // DefaultConfig returns default logger configuration
 func DefaultConfig() *Config {
 	return &Config{
 		Level:       InfoLevel,
-		Console:     true,
+		Console:     false,
 		ConsoleJSON: false,
-		File:        true,
-		Filename:    filepath.Join(os.TempDir(), "s9s.log"),
+		File:        false,
+		Filename:    defaultLogPath(),
 		MaxSize:     10,
 		MaxBackups:  3,
 		MaxAge:      7,
@@ -146,7 +155,7 @@ func newLogger(config *Config) *Logger {
 	var writer io.Writer
 	switch len(writers) {
 	case 0:
-		writer = os.Stderr
+		writer = io.Discard
 	case 1:
 		writer = writers[0]
 	default:


### PR DESCRIPTION
## Summary

Fixes #101 — multiple users on the same system conflict on `/tmp/s9s.log`.

- **Root cause**: `logging.DefaultConfig()` set `File: true` with path `os.TempDir()/s9s.log` (`/tmp/s9s.log`). First user creates it with `0600` perms, second user gets permission denied.
- **Log path**: Move default to `~/.s9s/s9s.log` (per-user), with UID-specific fallback if `$HOME` is unavailable
- **Disable logging by default**: Set `Console: false` and `File: false` in defaults; `--debug` enables file logging
- **Fix writer fallback**: `io.Discard` instead of `os.Stderr` when no writers configured (the `case 0` fallback was sending logs to stderr even with both options disabled)
- **Keyring paths** (defensive): Move fallback keyring files from `/tmp/` to `~/.s9s/` (currently dead code but fixed to prevent future issues)

## Test plan

- [ ] Run `s9s` without `--debug` — no log file created, no stderr output
- [ ] Run `s9s --debug` — logs written to `~/.s9s/s9s.log`
- [ ] Run as two different users — no permission conflicts