### PR TITLE
refactor: simplify mock mode validation

### DIFF
--- a/internal/cli/mock_cmd.go
+++ b/internal/cli/mock_cmd.go
@@ -16,25 +16,18 @@ var mockCmd = &cobra.Command{
 	Long: `Utilities for working with s9s mock mode.
 
 Mock mode provides simulated SLURM cluster data for development and testing.
-It requires S9S_ENABLE_MOCK environment variable to be set for security.`,
+It requires S9S_ENABLE_MOCK environment variable to be set.`,
 }
 
 // mockStatusCmd shows current mock status
 var mockStatusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show mock mode status and configuration",
-	Long: `Display current mock mode status including:
-• Whether mock mode is enabled via environment variables
-• Production environment detection
-• Available environment variable options`,
-	RunE: runMockStatus,
+	RunE:  runMockStatus,
 }
 
 func init() {
-	// Add subcommands
 	mockCmd.AddCommand(mockStatusCmd)
-
-	// Add mock command to root
 	rootCmd.AddCommand(mockCmd)
 }
 
@@ -43,40 +36,13 @@ func runMockStatus(_ *cobra.Command, _ []string) error {
 	fmt.Println("==================")
 	fmt.Println()
 
-	// Check mock availability
 	if mock.IsMockEnabled() {
 		fmt.Println("✅ Mock mode: ENABLED")
-		fmt.Printf("   %s\n", mock.GetMockStatusMessage())
 	} else {
 		fmt.Println("❌ Mock mode: DISABLED")
-		fmt.Printf("   %s\n", mock.GetMockStatusMessage())
+		fmt.Println()
+		mock.SuggestMockSetup()
 	}
-	fmt.Println()
-
-	// Check production environment
-	if mock.IsProductionEnvironment() {
-		fmt.Println("🚨 Production environment: DETECTED")
-		fmt.Println("   Mock usage will require explicit confirmation")
-	} else {
-		fmt.Println("🔧 Development environment: DETECTED")
-		fmt.Println("   Mock mode can be used without additional warnings")
-	}
-	fmt.Println()
-
-	// Show configuration options
-	fmt.Println("⚙️  Configuration Options:")
-	fmt.Println("   To enable mock mode, set one of:")
-	fmt.Println("   • S9S_ENABLE_MOCK=development  (recommended for dev)")
-	fmt.Println("   • S9S_ENABLE_MOCK=testing      (for testing)")
-	fmt.Println("   • S9S_ENABLE_MOCK=debug        (for debugging)")
-	fmt.Println("   • S9S_ENABLE_MOCK=local        (for local use)")
-	fmt.Println("   • S9S_ENABLE_MOCK=true         (generic enable)")
-	fmt.Println()
-
-	fmt.Println("📝 Usage:")
-	fmt.Println("   export S9S_ENABLE_MOCK=development")
-	fmt.Println("   s9s --mock")
-	fmt.Println()
 
 	return nil
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -166,7 +166,7 @@ func applyCommandLineOverrides(cfg *config.Config) {
 			fmt.Printf("⚠️  Cluster %q not found in config\n", clusterName)
 		}
 	}
-	if useMock {
+	if useMock || mock.IsMockEnabled() {
 		cfg.UseMockClient = true
 	}
 	if noMock {
@@ -180,14 +180,9 @@ func applyCommandLineOverrides(cfg *config.Config) {
 // handleMockConfiguration validates mock mode configuration
 func handleMockConfiguration(cfg *config.Config) error {
 	if err := mock.ValidateMockUsage(cfg.UseMockClient); err != nil {
-		if useMock {
-			fmt.Printf("❌ %v\n\n", err)
-			mock.SuggestMockSetup()
-			return fmt.Errorf("mock mode validation failed")
-		}
-		fmt.Printf("⚠️  Mock mode disabled by environment: %v\n", err)
-		fmt.Printf("   Switching to real SLURM client mode\n\n")
-		cfg.UseMockClient = false
+		fmt.Printf("❌ %v\n\n", err)
+		mock.SuggestMockSetup()
+		return fmt.Errorf("mock mode validation failed")
 	}
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -179,7 +179,7 @@ func DefaultConfig() *Config {
 			"sub": "submit job",
 		},
 		Plugins:       []PluginConfig{},
-		UseMockClient: true, // Aligned with setDefaults
+		UseMockClient: false,
 		PluginSettings: PluginSettings{
 			EnableAll:     false,
 			PluginDir:     "$HOME/.s9s/plugins", // Aligned with setDefaults
@@ -267,7 +267,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("refreshRate", "2s")
 	v.SetDefault("maxRetries", 3)
 	v.SetDefault("defaultCluster", "default")
-	v.SetDefault("useMockClient", true)
+	v.SetDefault("useMockClient", false)
 
 	// UI defaults
 	v.SetDefault("ui.skin", "default")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -245,7 +245,7 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(t, "2s", cfg.RefreshRate)
 	assert.Equal(t, 3, cfg.MaxRetries)
 	assert.Equal(t, "default", cfg.DefaultCluster)
-	assert.True(t, cfg.UseMockClient)
+	assert.False(t, cfg.UseMockClient)
 
 	// Test UI defaults
 	assert.Equal(t, "default", cfg.UI.Skin)
@@ -309,7 +309,7 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Empty(t, cfg.Plugins)
 
 	// Test mock client default (aligned with setDefaults)
-	assert.True(t, cfg.UseMockClient)
+	assert.False(t, cfg.UseMockClient)
 }
 
 func TestValidateMockUsage(t *testing.T) {

--- a/internal/mock/validator.go
+++ b/internal/mock/validator.go
@@ -2,137 +2,42 @@
 package mock
 
 import (
-	"bufio"
 	"fmt"
 	"os"
-	"strings"
-	"syscall"
-
-	"golang.org/x/term"
 )
 
-// IsMockEnabled checks if mock mode is allowed based on environment variables
+// IsMockEnabled checks if mock mode is allowed based on the S9S_ENABLE_MOCK
+// environment variable. Any non-empty value enables mock mode.
 func IsMockEnabled() bool {
-	mockEnv := os.Getenv("S9S_ENABLE_MOCK")
-
-	// Allow specific development/testing values
-	allowedValues := []string{
-		"true",
-		"development",
-		"dev",
-		"testing",
-		"test",
-		"debug",
-		"local",
-	}
-
-	for _, allowed := range allowedValues {
-		if strings.ToLower(mockEnv) == allowed {
-			return true
-		}
-	}
-
-	return false
+	return os.Getenv("S9S_ENABLE_MOCK") != ""
 }
 
-// IsProductionEnvironment detects if we're running in production
-func IsProductionEnvironment() bool {
-	env := strings.ToLower(os.Getenv("ENVIRONMENT"))
-	if env == "production" || env == "prod" {
-		return true
-	}
-
-	// Check common production indicators
-	prodIndicators := []string{
-		"NODE_ENV=production",
-		"GO_ENV=production",
-		"RAILS_ENV=production",
-	}
-
-	for _, indicator := range prodIndicators {
-		parts := strings.SplitN(indicator, "=", 2)
-		if len(parts) == 2 && strings.ToLower(os.Getenv(parts[0])) == parts[1] {
-			return true
-		}
-	}
-
-	return false
-}
-
-// ValidateMockUsage validates mock usage with appropriate warnings
+// ValidateMockUsage validates mock usage and returns an error if mock mode
+// is requested but not enabled via the environment variable.
 func ValidateMockUsage(useMockClient bool) error {
 	if !useMockClient {
-		return nil // No mock usage, nothing to validate
+		return nil
 	}
 
-	// Check if mock is enabled
 	if !IsMockEnabled() {
 		return fmt.Errorf(`mock mode disabled
 
-To enable mock mode, set one of these environment variables:
-  S9S_ENABLE_MOCK=development  # For development
-  S9S_ENABLE_MOCK=testing      # For testing
-  S9S_ENABLE_MOCK=debug        # For debugging
-  S9S_ENABLE_MOCK=true         # Generic enable
-
-Example:
-  export S9S_ENABLE_MOCK=development
+To enable mock mode, set the S9S_ENABLE_MOCK environment variable:
+  export S9S_ENABLE_MOCK=1
   s9s --mock`)
-	}
-
-	// Show warning in production environments
-	if IsProductionEnvironment() {
-		fmt.Printf("🚨 WARNING: Mock SLURM client enabled in production environment!\n")
-		fmt.Printf("   This should only be used for debugging purposes.\n")
-		fmt.Printf("   Mock mode provides simulated data, not real cluster information.\n\n")
-
-		// Require explicit confirmation in production
-		if !confirmMockInProduction() {
-			return fmt.Errorf("mock mode canceled by user")
-		}
-
-		fmt.Printf("✅ Proceeding with mock mode in production (user confirmed)\n\n")
 	}
 
 	return nil
 }
 
-// confirmMockInProduction asks user for confirmation when using mock in production
-func confirmMockInProduction() bool {
-	fmt.Print("Are you sure you want to continue with mock mode in production? (yes/no): ")
-
-	// Try to read from terminal first
-	if term.IsTerminal(int(syscall.Stdin)) {
-		scanner := bufio.NewScanner(os.Stdin)
-		if scanner.Scan() {
-			response := strings.ToLower(strings.TrimSpace(scanner.Text()))
-			return response == "yes" || response == "y"
-		}
-	}
-
-	// Fallback for non-interactive environments - default to no
-	fmt.Println("(non-interactive terminal detected, defaulting to 'no')")
-	return false
-}
-
-// GetMockStatusMessage returns a user-friendly message about mock status
-func GetMockStatusMessage() string {
-	if IsMockEnabled() {
-		env := os.Getenv("S9S_ENABLE_MOCK")
-		return fmt.Sprintf("Mock mode available (S9S_ENABLE_MOCK=%s)", env)
-	}
-
-	return "Mock mode disabled (set S9S_ENABLE_MOCK to enable)"
-}
-
-// SuggestMockSetup provides setup suggestions when mock is requested but not enabled
+// SuggestMockSetup provides setup suggestions when mock is requested but not enabled.
 func SuggestMockSetup() {
-	fmt.Printf("💡 To enable mock mode for development:\n\n")
+	fmt.Printf("💡 To enable mock mode:\n\n")
 	fmt.Printf("  # For current session:\n")
-	fmt.Printf("  export S9S_ENABLE_MOCK=development\n\n")
+	fmt.Printf("  export S9S_ENABLE_MOCK=1\n\n")
 	fmt.Printf("  # For permanent setup, add to your shell profile:\n")
-	fmt.Printf("  echo 'export S9S_ENABLE_MOCK=development' >> ~/.bashrc\n")
-	fmt.Printf("  echo 'export S9S_ENABLE_MOCK=development' >> ~/.zshrc\n\n")
+	fmt.Printf("  echo 'export S9S_ENABLE_MOCK=1' >> ~/.bashrc\n")
+	fmt.Printf("  echo 'export S9S_ENABLE_MOCK=1' >> ~/.zshrc\n\n")
 	fmt.Printf("  # Then run:\n")
 	fmt.Printf("  s9s --mock\n\n")
 }


### PR DESCRIPTION
## Summary
- Simplify `S9S_ENABLE_MOCK` to accept any non-empty value instead of a whitelist (`development`, `testing`, `debug`, etc.)
- Remove production environment detection (`NODE_ENV`, `RAILS_ENV`, etc.) and interactive confirmation prompt
- Default `UseMockClient` to `false` — fixes spurious mock warning when starting normally without `--mock`
- Enable mock mode automatically when `S9S_ENABLE_MOCK` is set (no need to also pass `--mock`)
- Remove unused `GetMockStatusMessage` and `IsProductionEnvironment` functions

**Before:** `s9s --config ... --cluster slurm-2411` would print a mock mode warning even though mock wasn't requested.

**After:** Mock mode is cleanly opt-in via `S9S_ENABLE_MOCK=1` or `--mock`.

## Test plan
- [ ] `s9s` — no mock warning shown
- [ ] `s9s --mock` without `S9S_ENABLE_MOCK` — shows error with setup instructions
- [ ] `S9S_ENABLE_MOCK=1 s9s --mock` — enters mock mode
- [ ] `S9S_ENABLE_MOCK=1 s9s` — enters mock mode (no `--mock` needed)
- [ ] `S9S_ENABLE_MOCK=1 s9s --no-mock` — overrides, uses real client