### PR TITLE
perf: move blocking API calls off tview UI thread

### DIFF
--- a/internal/dao/types.go
+++ b/internal/dao/types.go
@@ -149,12 +149,13 @@ type ReservationList struct {
 
 // QueueInfo represents queue information for a partition
 type QueueInfo struct {
-	Partition   string
-	PendingJobs int
-	RunningJobs int
-	TotalJobs   int
-	AverageWait time.Duration
-	LongestWait time.Duration
+	Partition     string
+	PendingJobs   int
+	RunningJobs   int
+	TotalJobs     int
+	AverageWait   time.Duration
+	LongestWait   time.Duration
+	AllocatedCPUs int
 }
 
 // ClusterMetrics represents overall cluster metrics

--- a/internal/views/job_dependencies.go
+++ b/internal/views/job_dependencies.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/jontk/s9s/internal/dao"
+	"github.com/jontk/s9s/internal/debug"
 	"github.com/jontk/s9s/internal/ui/styles"
 	"github.com/rivo/tview"
 )
@@ -22,77 +23,82 @@ type JobDependency struct {
 func (v *JobsView) showJobDependencies() {
 	data := v.table.GetSelectedData()
 	if len(data) == 0 {
-		// Note: Status bar update removed since individual view status bars are no longer used
 		return
 	}
 
 	jobID := data[0]
 	jobName := data[1]
 
-	// Fetch job details to check for dependencies
-	job, err := v.client.Jobs().Get(jobID)
-	if err != nil {
-		// Note: Status bar update removed since individual view status bars are no longer used
-		return
-	}
-
-	// Create dependency visualization
-	content := v.buildDependencyTree(job)
-
-	textView := tview.NewTextView().
-		SetDynamicColors(true).
-		SetText(content).
-		SetScrollable(true)
-
-	// Add controls
-	controlsText := "Press [yellow]ESC[white] to close | [yellow]a[white] Add Dependency | [yellow]r[white] Remove Dependency"
-	controls := tview.NewTextView().
-		SetDynamicColors(true).
-		SetText(controlsText).
-		SetTextAlign(tview.AlignCenter)
-
-	modal := tview.NewFlex().
-		SetDirection(tview.FlexRow).
-		AddItem(textView, 0, 1, true).
-		AddItem(controls, 1, 0, false)
-
-	modal.SetBorder(true).
-		SetTitle(fmt.Sprintf(" Job %s (%s) Dependencies ", jobID, jobName)).
-		SetTitleAlign(tview.AlignCenter)
-
-	// Create centered modal layout
-	centeredModal := tview.NewFlex().
-		AddItem(nil, 0, 1, false).
-		AddItem(tview.NewFlex().SetDirection(tview.FlexRow).
-			AddItem(nil, 0, 1, false).
-			AddItem(modal, 0, 8, true).
-			AddItem(nil, 0, 1, false), 0, 8, true).
-		AddItem(nil, 0, 1, false)
-
-	// Handle key events
-	textView.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
-		switch event.Key() {
-		case tcell.KeyEsc:
-			if v.pages != nil {
-				v.pages.RemovePage("job-dependencies")
-			}
-			return nil
-		case tcell.KeyRune:
-			switch event.Rune() {
-			case 'a', 'A':
-				v.showAddDependencyForm(jobID)
-				return nil
-			case 'r', 'R':
-				v.showRemoveDependencyForm(jobID)
-				return nil
-			}
+	go func() {
+		// Fetch job details off the UI thread
+		job, err := v.client.Jobs().Get(jobID)
+		if err != nil {
+			debug.Logger.Printf("showJobDependencies() - failed to get job %s: %v", jobID, err)
+			return
 		}
-		return event
-	})
 
-	if v.pages != nil {
-		v.pages.AddPage("job-dependencies", centeredModal, true, true)
-	}
+		if v.app != nil {
+			v.app.QueueUpdateDraw(func() {
+				// Create dependency visualization
+				content := v.buildDependencyTree(job)
+
+				textView := tview.NewTextView().
+					SetDynamicColors(true).
+					SetText(content).
+					SetScrollable(true)
+
+				// Add controls
+				controlsText := "Press [yellow]ESC[white] to close | [yellow]a[white] Add Dependency | [yellow]r[white] Remove Dependency"
+				controls := tview.NewTextView().
+					SetDynamicColors(true).
+					SetText(controlsText).
+					SetTextAlign(tview.AlignCenter)
+
+				modal := tview.NewFlex().
+					SetDirection(tview.FlexRow).
+					AddItem(textView, 0, 1, true).
+					AddItem(controls, 1, 0, false)
+
+				modal.SetBorder(true).
+					SetTitle(fmt.Sprintf(" Job %s (%s) Dependencies ", jobID, jobName)).
+					SetTitleAlign(tview.AlignCenter)
+
+				// Create centered modal layout
+				centeredModal := tview.NewFlex().
+					AddItem(nil, 0, 1, false).
+					AddItem(tview.NewFlex().SetDirection(tview.FlexRow).
+						AddItem(nil, 0, 1, false).
+						AddItem(modal, 0, 8, true).
+						AddItem(nil, 0, 1, false), 0, 8, true).
+					AddItem(nil, 0, 1, false)
+
+				// Handle key events
+				textView.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+					switch event.Key() {
+					case tcell.KeyEsc:
+						if v.pages != nil {
+							v.pages.RemovePage("job-dependencies")
+						}
+						return nil
+					case tcell.KeyRune:
+						switch event.Rune() {
+						case 'a', 'A':
+							v.showAddDependencyForm(jobID)
+							return nil
+						case 'r', 'R':
+							v.showRemoveDependencyForm(jobID)
+							return nil
+						}
+					}
+					return event
+				})
+
+				if v.pages != nil {
+					v.pages.AddPage("job-dependencies", centeredModal, true, true)
+				}
+			})
+		}
+	}()
 }
 
 // buildDependencyTree builds a visual representation of job dependencies

--- a/internal/views/job_templates.go
+++ b/internal/views/job_templates.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/jontk/s9s/internal/dao"
+	"github.com/jontk/s9s/internal/debug"
 	"github.com/jontk/s9s/internal/fileperms"
 	"github.com/jontk/s9s/internal/ui/styles"
 	"github.com/rivo/tview"
@@ -400,15 +401,21 @@ func (v *JobsView) showJobSubmissionFormWithTemplate(template *dao.JobSubmission
 
 // saveJobAsTemplate saves the selected job as a template
 func (v *JobsView) saveJobAsTemplate(jobID string) {
-	// Fetch job details
-	job, err := v.client.Jobs().Get(jobID)
-	if err != nil {
-		// Note: Status bar update removed since individual view status bars are no longer used
-		return
-	}
+	go func() {
+		// Fetch job details off the UI thread
+		job, err := v.client.Jobs().Get(jobID)
+		if err != nil {
+			debug.Logger.Printf("saveJobAsTemplate() - failed to get job %s: %v", jobID, err)
+			return
+		}
 
-	// Show template save form
-	v.showSaveTemplateForm(job)
+		if v.app != nil {
+			v.app.QueueUpdateDraw(func() {
+				// Show template save form
+				v.showSaveTemplateForm(job)
+			})
+		}
+	}()
 }
 
 // saveFormAsTemplate saves the current form data as a template

--- a/internal/views/jobs.go
+++ b/internal/views/jobs.go
@@ -749,29 +749,35 @@ func (v *JobsView) performCancelJob(jobID string) {
 		v.mainStatusBar.Info(fmt.Sprintf("Canceling job %s...", jobID))
 	}
 
-	// Attempt to cancel
-	debug.Logger.Printf("Calling Cancel API for job %s", jobID)
-	err := v.client.Jobs().Cancel(jobID)
-	if err != nil {
-		debug.Logger.Printf("Cancel API failed for job %s: %v", jobID, err)
-		if v.mainStatusBar != nil {
-			v.mainStatusBar.Error(fmt.Sprintf("Failed to cancel job %s: %v", jobID, err))
+	go func() {
+		// Attempt to cancel off the UI thread
+		debug.Logger.Printf("Calling Cancel API for job %s", jobID)
+		err := v.client.Jobs().Cancel(jobID)
+
+		if v.app != nil {
+			v.app.QueueUpdateDraw(func() {
+				if err != nil {
+					debug.Logger.Printf("Cancel API failed for job %s: %v", jobID, err)
+					if v.mainStatusBar != nil {
+						v.mainStatusBar.Error(fmt.Sprintf("Failed to cancel job %s: %v", jobID, err))
+					}
+					return
+				}
+
+				debug.Logger.Printf("Cancel API returned success for job %s - refreshing view", jobID)
+				if v.mainStatusBar != nil {
+					v.mainStatusBar.Success(fmt.Sprintf("Job %s canceled", jobID))
+				}
+			})
 		}
-		return
-	}
 
-	debug.Logger.Printf("Cancel API returned success for job %s - refreshing view", jobID)
-
-	// If the API call succeeded, assume the cancel worked and show success
-	// The API returns success, so we trust it and refresh
-	if v.mainStatusBar != nil {
-		v.mainStatusBar.Success(fmt.Sprintf("Job %s canceled", jobID))
-	}
-
-	// Refresh the view to get updated state
-	time.Sleep(500 * time.Millisecond)
-	debug.Logger.Printf("Refreshing jobs view after cancel")
-	_ = v.Refresh()
+		if err == nil {
+			// Refresh the view to get updated state
+			time.Sleep(500 * time.Millisecond)
+			debug.Logger.Printf("Refreshing jobs view after cancel")
+			_ = v.Refresh()
+		}
+	}()
 }
 
 // holdSelectedJob holds the selected job
@@ -801,22 +807,31 @@ func (v *JobsView) holdSelectedJob() {
 		return
 	}
 
-	// Perform hold
-	err := v.client.Jobs().Hold(jobID)
-	if err != nil {
-		if v.mainStatusBar != nil {
-			v.mainStatusBar.Error(fmt.Sprintf("Failed to hold job %s: %v", jobID, err))
+	go func() {
+		// Perform hold off the UI thread
+		err := v.client.Jobs().Hold(jobID)
+
+		if v.app != nil {
+			v.app.QueueUpdateDraw(func() {
+				if err != nil {
+					if v.mainStatusBar != nil {
+						v.mainStatusBar.Error(fmt.Sprintf("Failed to hold job %s: %v", jobID, err))
+					}
+					return
+				}
+
+				if v.mainStatusBar != nil {
+					v.mainStatusBar.Success(fmt.Sprintf("Job %s held", jobID))
+				}
+			})
 		}
-		return
-	}
 
-	if v.mainStatusBar != nil {
-		v.mainStatusBar.Success(fmt.Sprintf("Job %s held", jobID))
-	}
-
-	// Refresh the view
-	time.Sleep(500 * time.Millisecond)
-	_ = v.Refresh()
+		if err == nil {
+			// Refresh the view
+			time.Sleep(500 * time.Millisecond)
+			_ = v.Refresh()
+		}
+	}()
 }
 
 // releaseSelectedJob releases the selected job
@@ -847,39 +862,46 @@ func (v *JobsView) releaseSelectedJob() {
 		return
 	}
 
-	// Get job details before release
-	jobBefore, _ := v.client.Jobs().Get(jobID)
-	if jobBefore != nil {
-		debug.Logger.Printf("Pre-release job %s - State: %s", jobID, jobBefore.State)
-	}
-
-	// Perform release
-	debug.Logger.Printf("Calling Release API for job %s", jobID)
-	err := v.client.Jobs().Release(jobID)
-	if err != nil {
-		debug.Logger.Printf("Release API failed for job %s: %v", jobID, err)
-		if v.mainStatusBar != nil {
-			v.mainStatusBar.Error(fmt.Sprintf("Failed to release job %s: %v", jobID, err))
+	go func() {
+		// Get job details before release
+		jobBefore, _ := v.client.Jobs().Get(jobID)
+		if jobBefore != nil {
+			debug.Logger.Printf("Pre-release job %s - State: %s", jobID, jobBefore.State)
 		}
-		return
-	}
 
-	debug.Logger.Printf("Release API returned success for job %s", jobID)
+		// Perform release
+		debug.Logger.Printf("Calling Release API for job %s", jobID)
+		err := v.client.Jobs().Release(jobID)
 
-	// Verify release worked by checking job state
-	time.Sleep(500 * time.Millisecond)
-	jobAfter, _ := v.client.Jobs().Get(jobID)
-	if jobAfter != nil {
-		debug.Logger.Printf("Post-release job %s - State: %s", jobID, jobAfter.State)
-	}
+		if v.app != nil {
+			v.app.QueueUpdateDraw(func() {
+				if err != nil {
+					debug.Logger.Printf("Release API failed for job %s: %v", jobID, err)
+					if v.mainStatusBar != nil {
+						v.mainStatusBar.Error(fmt.Sprintf("Failed to release job %s: %v", jobID, err))
+					}
+					return
+				}
 
-	if v.mainStatusBar != nil {
-		v.mainStatusBar.Success(fmt.Sprintf("Job %s released", jobID))
-	}
+				debug.Logger.Printf("Release API returned success for job %s", jobID)
+				if v.mainStatusBar != nil {
+					v.mainStatusBar.Success(fmt.Sprintf("Job %s released", jobID))
+				}
+			})
+		}
 
-	// Refresh the view
-	time.Sleep(500 * time.Millisecond)
-	_ = v.Refresh()
+		if err == nil {
+			// Verify release worked by checking job state
+			time.Sleep(500 * time.Millisecond)
+			jobAfter, _ := v.client.Jobs().Get(jobID)
+			if jobAfter != nil {
+				debug.Logger.Printf("Post-release job %s - State: %s", jobID, jobAfter.State)
+			}
+
+			// Refresh the view
+			_ = v.Refresh()
+		}
+	}()
 }
 
 // showJobDetails shows detailed information for the selected job
@@ -891,53 +913,59 @@ func (v *JobsView) showJobDetails() {
 
 	jobID := data[0]
 
-	// Fetch full job details
-	job, err := v.client.Jobs().Get(jobID)
-	if err != nil {
-		// Note: Status bar update removed since individual view status bars are no longer used
-		return
-	}
-
-	// Create details view
-	details := v.formatJobDetails(job)
-
-	textView := tview.NewTextView().
-		SetDynamicColors(true).
-		SetText(details).
-		SetScrollable(true)
-
-	modal := tview.NewFlex().
-		SetDirection(tview.FlexRow).
-		AddItem(textView, 0, 1, true).
-		AddItem(tview.NewTextView().SetText("Press ESC to close"), 1, 0, false)
-
-	modal.SetBorder(true).
-		SetTitle(fmt.Sprintf(" Job %s Details ", jobID)).
-		SetTitleAlign(tview.AlignCenter)
-
-	// Create centered modal layout
-	centeredModal := tview.NewFlex().
-		AddItem(nil, 0, 1, false).
-		AddItem(tview.NewFlex().SetDirection(tview.FlexRow).
-			AddItem(nil, 0, 1, false).
-			AddItem(modal, 0, 8, true).
-			AddItem(nil, 0, 1, false), 0, 8, true).
-		AddItem(nil, 0, 1, false)
-
-	// Handle ESC key
-	modal.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
-		if event.Key() == tcell.KeyEsc {
-			if v.pages != nil {
-				v.pages.RemovePage("job-details")
-			}
-			return nil
+	go func() {
+		// Fetch full job details off the UI thread
+		job, err := v.client.Jobs().Get(jobID)
+		if err != nil {
+			debug.Logger.Printf("showJobDetails() - failed to get job %s: %v", jobID, err)
+			return
 		}
-		return event
-	})
 
-	if v.pages != nil {
-		v.pages.AddPage("job-details", centeredModal, true, true)
-	}
+		if v.app != nil {
+			v.app.QueueUpdateDraw(func() {
+				// Create details view
+				details := v.formatJobDetails(job)
+
+				textView := tview.NewTextView().
+					SetDynamicColors(true).
+					SetText(details).
+					SetScrollable(true)
+
+				modal := tview.NewFlex().
+					SetDirection(tview.FlexRow).
+					AddItem(textView, 0, 1, true).
+					AddItem(tview.NewTextView().SetText("Press ESC to close"), 1, 0, false)
+
+				modal.SetBorder(true).
+					SetTitle(fmt.Sprintf(" Job %s Details ", jobID)).
+					SetTitleAlign(tview.AlignCenter)
+
+				// Create centered modal layout
+				centeredModal := tview.NewFlex().
+					AddItem(nil, 0, 1, false).
+					AddItem(tview.NewFlex().SetDirection(tview.FlexRow).
+						AddItem(nil, 0, 1, false).
+						AddItem(modal, 0, 8, true).
+						AddItem(nil, 0, 1, false), 0, 8, true).
+					AddItem(nil, 0, 1, false)
+
+				// Handle ESC key
+				modal.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+					if event.Key() == tcell.KeyEsc {
+						if v.pages != nil {
+							v.pages.RemovePage("job-details")
+						}
+						return nil
+					}
+					return event
+				})
+
+				if v.pages != nil {
+					v.pages.AddPage("job-details", centeredModal, true, true)
+				}
+			})
+		}
+	}()
 }
 
 // formatJobDetails formats job details for display
@@ -1085,21 +1113,30 @@ func (v *JobsView) performRequeueJob(jobID string) {
 		v.mainStatusBar.Info(fmt.Sprintf("Requeuing job %s...", jobID))
 	}
 
-	newJob, err := v.client.Jobs().Requeue(jobID)
-	if err != nil {
-		if v.mainStatusBar != nil {
-			v.mainStatusBar.Error(fmt.Sprintf("Failed to requeue job %s: %v", jobID, err))
+	go func() {
+		newJob, err := v.client.Jobs().Requeue(jobID)
+
+		if v.app != nil {
+			v.app.QueueUpdateDraw(func() {
+				if err != nil {
+					if v.mainStatusBar != nil {
+						v.mainStatusBar.Error(fmt.Sprintf("Failed to requeue job %s: %v", jobID, err))
+					}
+					return
+				}
+
+				if v.mainStatusBar != nil {
+					v.mainStatusBar.Success(fmt.Sprintf("Job %s requeued as job %s", jobID, newJob.ID))
+				}
+			})
 		}
-		return
-	}
 
-	if v.mainStatusBar != nil {
-		v.mainStatusBar.Success(fmt.Sprintf("Job %s requeued as job %s", jobID, newJob.ID))
-	}
-
-	// Refresh the view to show the new job
-	time.Sleep(500 * time.Millisecond)
-	_ = v.Refresh()
+		if err == nil {
+			// Refresh the view to show the new job
+			time.Sleep(500 * time.Millisecond)
+			_ = v.Refresh()
+		}
+	}()
 }
 
 // showJobSubmissionForm shows job submission form using the wizard

--- a/internal/views/nodes.go
+++ b/internal/views/nodes.go
@@ -1016,53 +1016,59 @@ func (v *NodesView) showNodeDetails() {
 
 	nodeName := data[0]
 
-	// Fetch full node details
-	node, err := v.client.Nodes().Get(nodeName)
-	if err != nil {
-		// Note: Status bar update removed since individual view status bars are no longer used
-		return
-	}
-
-	// Create details view
-	details := v.formatNodeDetails(node)
-
-	textView := tview.NewTextView().
-		SetDynamicColors(true).
-		SetText(details).
-		SetScrollable(true)
-
-	modal := tview.NewFlex().
-		SetDirection(tview.FlexRow).
-		AddItem(textView, 0, 1, true).
-		AddItem(tview.NewTextView().SetText("Press ESC to close"), 1, 0, false)
-
-	modal.SetBorder(true).
-		SetTitle(fmt.Sprintf(" Node %s Details ", nodeName)).
-		SetTitleAlign(tview.AlignCenter)
-
-	// Create centered modal layout
-	centeredModal := tview.NewFlex().
-		AddItem(nil, 0, 1, false).
-		AddItem(tview.NewFlex().SetDirection(tview.FlexRow).
-			AddItem(nil, 0, 1, false).
-			AddItem(modal, 0, 8, true).
-			AddItem(nil, 0, 1, false), 0, 8, true).
-		AddItem(nil, 0, 1, false)
-
-	// Handle ESC key
-	modal.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
-		if event.Key() == tcell.KeyEsc {
-			if v.pages != nil {
-				v.pages.RemovePage("node-details")
-			}
-			return nil
+	go func() {
+		// Fetch full node details off the UI thread
+		node, err := v.client.Nodes().Get(nodeName)
+		if err != nil {
+			debug.Logger.Printf("showNodeDetails() - failed to get node %s: %v", nodeName, err)
+			return
 		}
-		return event
-	})
 
-	if v.pages != nil {
-		v.pages.AddPage("node-details", centeredModal, true, true)
-	}
+		if v.app != nil {
+			v.app.QueueUpdateDraw(func() {
+				// Create details view
+				details := v.formatNodeDetails(node)
+
+				textView := tview.NewTextView().
+					SetDynamicColors(true).
+					SetText(details).
+					SetScrollable(true)
+
+				modal := tview.NewFlex().
+					SetDirection(tview.FlexRow).
+					AddItem(textView, 0, 1, true).
+					AddItem(tview.NewTextView().SetText("Press ESC to close"), 1, 0, false)
+
+				modal.SetBorder(true).
+					SetTitle(fmt.Sprintf(" Node %s Details ", nodeName)).
+					SetTitleAlign(tview.AlignCenter)
+
+				// Create centered modal layout
+				centeredModal := tview.NewFlex().
+					AddItem(nil, 0, 1, false).
+					AddItem(tview.NewFlex().SetDirection(tview.FlexRow).
+						AddItem(nil, 0, 1, false).
+						AddItem(modal, 0, 8, true).
+						AddItem(nil, 0, 1, false), 0, 8, true).
+					AddItem(nil, 0, 1, false)
+
+				// Handle ESC key
+				modal.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+					if event.Key() == tcell.KeyEsc {
+						if v.pages != nil {
+							v.pages.RemovePage("node-details")
+						}
+						return nil
+					}
+					return event
+				})
+
+				if v.pages != nil {
+					v.pages.AddPage("node-details", centeredModal, true, true)
+				}
+			})
+		}
+	}()
 }
 
 // formatNodeDetails formats node details for display

--- a/internal/views/partitions.go
+++ b/internal/views/partitions.go
@@ -9,12 +9,18 @@ import (
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/jontk/s9s/internal/dao"
+	"github.com/jontk/s9s/internal/debug"
 	"github.com/jontk/s9s/internal/export"
 	"github.com/jontk/s9s/internal/ui/components"
 	"github.com/jontk/s9s/internal/ui/filters"
 	"github.com/jontk/s9s/internal/ui/styles"
 	"github.com/rivo/tview"
 )
+
+// maxJobsFetchLimit is the upper bound for the single bulk jobs fetch used to
+// compute per-partition queue info.  If a cluster has more jobs than this, the
+// queue metrics will under-report.
+const maxJobsFetchLimit = 100_000
 
 // PartitionsView displays the partitions list with queue depth visualization
 type PartitionsView struct {
@@ -150,13 +156,16 @@ func (v *PartitionsView) Refresh() error {
 			return
 		}
 
-		queueInfo := make(map[string]*dao.QueueInfo)
-		for _, partition := range partitionList.Partitions {
-			info, err := v.calculateQueueInfo(partition.Name)
-			if err == nil {
-				queueInfo[partition.Name] = info
-			}
+		// Single fetch of all jobs (no partition filter) — replaces N per-partition calls
+		jobList, err := v.client.Jobs().List(&dao.ListJobsOptions{
+			Limit: maxJobsFetchLimit,
+		})
+		if err != nil {
+			v.SetLastError(err)
+			return
 		}
+
+		queueInfo := v.buildAllQueueInfo(jobList.Jobs, partitionList.Partitions)
 
 		if v.app != nil {
 			v.app.QueueUpdateDraw(func() {
@@ -172,6 +181,77 @@ func (v *PartitionsView) Refresh() error {
 	}()
 
 	return nil
+}
+
+// buildAllQueueInfo computes queue info for all partitions from a single jobs list.
+// This replaces per-partition calculateQueueInfo and calculateAllocatedCPUs calls,
+// reducing N+1 API calls to 1.
+func (v *PartitionsView) buildAllQueueInfo(jobs []*dao.Job, partitions []*dao.Partition) map[string]*dao.QueueInfo {
+	// Build CPUs-per-node ratio map for allocated CPU estimation
+	cpusPerNode := make(map[string]float64, len(partitions))
+	for _, p := range partitions {
+		if p.TotalNodes > 0 {
+			cpusPerNode[p.Name] = float64(p.TotalCPUs) / float64(p.TotalNodes)
+		} else {
+			cpusPerNode[p.Name] = 1.0
+		}
+	}
+
+	// Initialize QueueInfo for every partition
+	infoMap := make(map[string]*dao.QueueInfo, len(partitions))
+	for _, p := range partitions {
+		infoMap[p.Name] = &dao.QueueInfo{Partition: p.Name}
+	}
+
+	// Per-partition wait time accumulators
+	type waitAcc struct {
+		total   time.Duration
+		longest time.Duration
+		count   int
+	}
+	waits := make(map[string]*waitAcc, len(partitions))
+
+	now := time.Now()
+
+	for _, job := range jobs {
+		info, ok := infoMap[job.Partition]
+		if !ok {
+			// Job belongs to a partition not in our list — skip
+			continue
+		}
+
+		info.TotalJobs++
+
+		switch job.State {
+		case dao.JobStateRunning, dao.JobStateCompleting:
+			info.RunningJobs++
+			// Accumulate allocated CPUs from running jobs
+			info.AllocatedCPUs += int(float64(job.NodeCount) * cpusPerNode[job.Partition])
+		case dao.JobStatePending:
+			info.PendingJobs++
+			waitTime := now.Sub(job.SubmitTime)
+			w := waits[job.Partition]
+			if w == nil {
+				w = &waitAcc{}
+				waits[job.Partition] = w
+			}
+			w.total += waitTime
+			w.count++
+			if waitTime > w.longest {
+				w.longest = waitTime
+			}
+		}
+	}
+
+	// Compute average/longest wait times
+	for partName, w := range waits {
+		if w.count > 0 {
+			infoMap[partName].AverageWait = w.total / time.Duration(w.count)
+			infoMap[partName].LongestWait = w.longest
+		}
+	}
+
+	return infoMap
 }
 
 // TODO: implement per-view toggleable auto-refresh (like jobs view)
@@ -365,8 +445,7 @@ func (v *PartitionsView) updateTable() {
 
 			// Calculate efficiency (allocated CPUs / total capacity)
 			if partition.TotalCPUs > 0 {
-				allocatedCPUs := v.calculateAllocatedCPUs(partition.Name)
-				efficiencyPct := float64(allocatedCPUs) * 100.0 / float64(partition.TotalCPUs)
+				efficiencyPct := float64(queueInfo.AllocatedCPUs) * 100.0 / float64(partition.TotalCPUs)
 				if efficiencyPct > 100 {
 					efficiencyPct = 100 // Cap at 100%
 				}
@@ -497,97 +576,6 @@ func (v *PartitionsView) createEfficiencyBar(percentage float64) string {
 	return bar.String()
 }
 
-// calculateAllocatedCPUs estimates allocated CPUs for running jobs in a partition
-func (v *PartitionsView) calculateAllocatedCPUs(partitionName string) int {
-	// Fetch running jobs for this partition
-	opts := &dao.ListJobsOptions{
-		Partitions: []string{partitionName},
-		States:     []string{dao.JobStateRunning},
-		Limit:      1000,
-	}
-
-	jobList, err := v.client.Jobs().List(opts)
-	if err != nil {
-		// If we can't get jobs, return 0
-		return 0
-	}
-
-	// Estimate allocated CPUs based on node count
-	// Assume each node contributes proportionally to partition's CPUs/nodes ratio
-	// This is an approximation since we don't have per-job CPU allocation data
-	totalNodes := 0
-	for _, job := range jobList.Jobs {
-		totalNodes += job.NodeCount
-	}
-
-	// Find the partition to get CPUs per node ratio
-	v.mu.RLock()
-	cpusPerNode := 1.0 // default fallback
-	for _, p := range v.partitions {
-		if p.Name == partitionName && p.TotalNodes > 0 {
-			cpusPerNode = float64(p.TotalCPUs) / float64(p.TotalNodes)
-			break
-		}
-	}
-	v.mu.RUnlock()
-
-	return int(float64(totalNodes) * cpusPerNode)
-}
-
-// calculateQueueInfo calculates queue information for a partition
-func (v *PartitionsView) calculateQueueInfo(partitionName string) (*dao.QueueInfo, error) {
-	// Fetch jobs for this partition
-	opts := &dao.ListJobsOptions{
-		Partitions: []string{partitionName},
-		Limit:      1000,
-	}
-
-	jobList, err := v.client.Jobs().List(opts)
-	if err != nil {
-		return nil, err
-	}
-
-	info := &dao.QueueInfo{
-		Partition: partitionName,
-	}
-
-	var waitTimes []time.Duration
-	now := time.Now()
-
-	for _, job := range jobList.Jobs {
-		switch job.State {
-		case dao.JobStateRunning:
-			info.RunningJobs++
-		case dao.JobStatePending:
-			info.PendingJobs++
-			// Calculate wait time
-			waitTime := now.Sub(job.SubmitTime)
-			waitTimes = append(waitTimes, waitTime)
-		case dao.JobStateCompleting:
-			info.RunningJobs++ // Count completing jobs as running
-		}
-		info.TotalJobs++
-	}
-
-	// Calculate average and longest wait times
-	if len(waitTimes) > 0 {
-		var totalWait time.Duration
-		var longest time.Duration
-
-		for _, wait := range waitTimes {
-			totalWait += wait
-			if wait > longest {
-				longest = wait
-			}
-		}
-
-		info.AverageWait = totalWait / time.Duration(len(waitTimes))
-		info.LongestWait = longest
-	}
-
-	return info, nil
-}
-
 /*
 TODO(lint): Review unused code - func (*PartitionsView).updateStatusBar is unused
 
@@ -667,53 +655,59 @@ func (v *PartitionsView) showPartitionDetails() {
 
 	partitionName := data[0]
 
-	// Fetch full partition details
-	partition, err := v.client.Partitions().Get(partitionName)
-	if err != nil {
-		// Note: Status bar update removed since individual view status bars are no longer used
-		return
-	}
-
-	// Create details view
-	details := v.formatPartitionDetails(partition)
-
-	textView := tview.NewTextView().
-		SetDynamicColors(true).
-		SetText(details).
-		SetScrollable(true)
-
-	modal := tview.NewFlex().
-		SetDirection(tview.FlexRow).
-		AddItem(textView, 0, 1, true).
-		AddItem(tview.NewTextView().SetText("Press ESC to close"), 1, 0, false)
-
-	modal.SetBorder(true).
-		SetTitle(fmt.Sprintf(" Partition %s Details ", partitionName)).
-		SetTitleAlign(tview.AlignCenter)
-
-	// Create centered modal layout
-	centeredModal := tview.NewFlex().
-		AddItem(nil, 0, 1, false).
-		AddItem(tview.NewFlex().SetDirection(tview.FlexRow).
-			AddItem(nil, 0, 1, false).
-			AddItem(modal, 0, 8, true).
-			AddItem(nil, 0, 1, false), 0, 8, true).
-		AddItem(nil, 0, 1, false)
-
-	// Handle ESC key
-	modal.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
-		if event.Key() == tcell.KeyEsc {
-			if v.pages != nil {
-				v.pages.RemovePage("partition-details")
-			}
-			return nil
+	go func() {
+		// Fetch full partition details off the UI thread
+		partition, err := v.client.Partitions().Get(partitionName)
+		if err != nil {
+			debug.Logger.Printf("showPartitionDetails() - failed to get partition %s: %v", partitionName, err)
+			return
 		}
-		return event
-	})
 
-	if v.pages != nil {
-		v.pages.AddPage("partition-details", centeredModal, true, true)
-	}
+		if v.app != nil {
+			v.app.QueueUpdateDraw(func() {
+				// Create details view
+				details := v.formatPartitionDetails(partition)
+
+				textView := tview.NewTextView().
+					SetDynamicColors(true).
+					SetText(details).
+					SetScrollable(true)
+
+				modal := tview.NewFlex().
+					SetDirection(tview.FlexRow).
+					AddItem(textView, 0, 1, true).
+					AddItem(tview.NewTextView().SetText("Press ESC to close"), 1, 0, false)
+
+				modal.SetBorder(true).
+					SetTitle(fmt.Sprintf(" Partition %s Details ", partitionName)).
+					SetTitleAlign(tview.AlignCenter)
+
+				// Create centered modal layout
+				centeredModal := tview.NewFlex().
+					AddItem(nil, 0, 1, false).
+					AddItem(tview.NewFlex().SetDirection(tview.FlexRow).
+						AddItem(nil, 0, 1, false).
+						AddItem(modal, 0, 8, true).
+						AddItem(nil, 0, 1, false), 0, 8, true).
+					AddItem(nil, 0, 1, false)
+
+				// Handle ESC key
+				modal.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+					if event.Key() == tcell.KeyEsc {
+						if v.pages != nil {
+							v.pages.RemovePage("partition-details")
+						}
+						return nil
+					}
+					return event
+				})
+
+				if v.pages != nil {
+					v.pages.AddPage("partition-details", centeredModal, true, true)
+				}
+			})
+		}
+	}()
 }
 
 // formatPartitionDetails formats partition details for display
@@ -809,65 +803,74 @@ func (v *PartitionsView) showPartitionAnalytics() {
 
 	partitionName := data[0]
 
-	// Fetch full partition details
-	partition, err := v.client.Partitions().Get(partitionName)
-	if err != nil {
-		// Note: Status bar update removed since individual view status bars are no longer used
-		return
-	}
-
-	// Create analytics view
-	analytics := v.formatPartitionAnalytics(partition)
-
-	textView := tview.NewTextView().
-		SetDynamicColors(true).
-		SetText(analytics).
-		SetScrollable(true)
-
-	modal := tview.NewFlex().
-		SetDirection(tview.FlexRow).
-		AddItem(textView, 0, 1, true).
-		AddItem(tview.NewTextView().SetText("Press ESC to close | R to refresh"), 1, 0, false)
-
-	modal.SetBorder(true).
-		SetTitle(fmt.Sprintf(" Analytics: %s ", partitionName)).
-		SetTitleAlign(tview.AlignCenter)
-
-	// Create centered modal layout
-	centeredModal := tview.NewFlex().
-		AddItem(nil, 0, 1, false).
-		AddItem(tview.NewFlex().SetDirection(tview.FlexRow).
-			AddItem(nil, 0, 1, false).
-			AddItem(modal, 0, 8, true).
-			AddItem(nil, 0, 1, false), 0, 8, true).
-		AddItem(nil, 0, 1, false)
-
-	// Handle keys
-	modal.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
-		switch event.Key() {
-		case tcell.KeyEsc:
-			if v.pages != nil {
-				v.pages.RemovePage("partition-analytics")
-			}
-			return nil
-		case tcell.KeyRune:
-			if event.Rune() == 'R' || event.Rune() == 'r' {
-				// Refresh and update the display
-				go func() {
-					_ = v.Refresh()
-					// Update the analytics display
-					newAnalytics := v.formatPartitionAnalytics(partition)
-					textView.SetText(newAnalytics)
-				}()
-				return nil
-			}
+	go func() {
+		// Fetch full partition details off the UI thread
+		partition, err := v.client.Partitions().Get(partitionName)
+		if err != nil {
+			debug.Logger.Printf("showPartitionAnalytics() - failed to get partition %s: %v", partitionName, err)
+			return
 		}
-		return event
-	})
 
-	if v.pages != nil {
-		v.pages.AddPage("partition-analytics", centeredModal, true, true)
-	}
+		if v.app != nil {
+			v.app.QueueUpdateDraw(func() {
+				// Create analytics view
+				analytics := v.formatPartitionAnalytics(partition)
+
+				textView := tview.NewTextView().
+					SetDynamicColors(true).
+					SetText(analytics).
+					SetScrollable(true)
+
+				modal := tview.NewFlex().
+					SetDirection(tview.FlexRow).
+					AddItem(textView, 0, 1, true).
+					AddItem(tview.NewTextView().SetText("Press ESC to close | R to refresh"), 1, 0, false)
+
+				modal.SetBorder(true).
+					SetTitle(fmt.Sprintf(" Analytics: %s ", partitionName)).
+					SetTitleAlign(tview.AlignCenter)
+
+				// Create centered modal layout
+				centeredModal := tview.NewFlex().
+					AddItem(nil, 0, 1, false).
+					AddItem(tview.NewFlex().SetDirection(tview.FlexRow).
+						AddItem(nil, 0, 1, false).
+						AddItem(modal, 0, 8, true).
+						AddItem(nil, 0, 1, false), 0, 8, true).
+					AddItem(nil, 0, 1, false)
+
+				// Handle keys
+				modal.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+					switch event.Key() {
+					case tcell.KeyEsc:
+						if v.pages != nil {
+							v.pages.RemovePage("partition-analytics")
+						}
+						return nil
+					case tcell.KeyRune:
+						if event.Rune() == 'R' || event.Rune() == 'r' {
+							// Refresh and update the display
+							go func() {
+								_ = v.Refresh()
+								if v.app != nil {
+									v.app.QueueUpdateDraw(func() {
+										newAnalytics := v.formatPartitionAnalytics(partition)
+										textView.SetText(newAnalytics)
+									})
+								}
+							}()
+							return nil
+						}
+					}
+					return event
+				})
+
+				if v.pages != nil {
+					v.pages.AddPage("partition-analytics", centeredModal, true, true)
+				}
+			})
+		}
+	}()
 }
 
 // formatPartitionAnalytics formats comprehensive analytics for display


### PR DESCRIPTION
## Summary

- **Eliminate N+1 per-partition API calls**: Replace `calculateAllocatedCPUs()` (called on UI thread inside `updateTable()`) and `calculateQueueInfo()` (N calls in Refresh goroutine) with a single bulk `Jobs().List()` call + `buildAllQueueInfo()` helper — reduces API calls from 2N+1 to 2
- **Async-wrap 11 blocking UI-thread API calls**: All detail-showing and mutation methods (cancel, hold, release, requeue, drain, details modals) now run API calls in goroutines with `QueueUpdateDraw` for UI updates
- **Add `AllocatedCPUs` field to `dao.QueueInfo`**: Pre-computed during the single jobs fetch instead of per-partition on the draw thread

## Motivation

With 20+ partitions and 20k+ jobs, the TUI freezes for multiple seconds because:
1. `calculateAllocatedCPUs()` makes a `Jobs().List()` call **per partition on the tview draw thread** inside `updateTable()`
2. `calculateQueueInfo()` makes a separate `Jobs().List()` call **per partition** in the Refresh goroutine
3. Key handlers for cancel/hold/release/details block the draw thread until the API responds

## Call sites wrapped

| Method | File | Pattern |
|--------|------|---------|
| `performCancelJob` | jobs.go | async, err-gated refresh |
| `holdSelectedJob` | jobs.go | async, err-gated refresh |
| `releaseSelectedJob` | jobs.go | async, err-gated verify+refresh |
| `showJobDetails` | jobs.go | async, debug-logged errors |
| `performRequeueJob` | jobs.go | async, err-gated refresh |
| `showJobDependencies` | job_dependencies.go | async, debug-logged errors |
| `saveJobAsTemplate` | job_templates.go | async, debug-logged errors |
| `showNodeDetails` | nodes.go | async, debug-logged errors |
| `showPartitionDetails` | partitions.go | async, debug-logged errors |
| `showPartitionAnalytics` | partitions.go | async, debug-logged errors |
| `calculateAllocatedCPUs` + `calculateQueueInfo` | partitions.go | **deleted**, replaced by single-fetch `buildAllQueueInfo` |

`drainSelectedNode` and `resumeSelectedNode` were already async (pre-existing).

## Test plan

- [x] `go build ./...` — clean
- [x] `go test -race ./internal/...` — all pass
- [x] `gofmt -l ./internal/` — no output
- [ ] Manual: open partitions view on 20k+ cluster — should not freeze
- [ ] Manual: press Enter on a job/node/partition — modal appears without freeze
- [ ] Manual: cancel/hold/release a job — UI stays responsive
- [ ] Manual: switch between views rapidly — no freezes