### PR TITLE
chore: prepare v0.6.3 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to release (e.g. v0.6.2)'
+        description: 'Tag to release (e.g. v0.6.3)'
         required: true
 
 env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [0.6.3] - 2026-03-14
+
+### Performance
+
+- **Eliminate N+1 API calls in Partitions view** (#107)
+  - Replace per-partition `calculateAllocatedCPUs()` (called on UI draw thread) and `calculateQueueInfo()` with a single bulk `Jobs().List()` call and `buildAllQueueInfo()` helper
+  - Reduces API calls from 2N+1 to 2 per refresh cycle (N = number of partitions)
+  - Fixes multi-second UI freezes on clusters with 20k+ jobs
+
+- **Lazy view initialization and background fetch** (#106)
+  - Views are only initialized and fetched when first focused, not all at startup
+  - Background data fetching with DAO-level caching to reduce redundant API calls
+  - Only the active view refreshes on timer; inactive views skip refresh cycles
+
+- **Async UI-thread API calls** (#107)
+  - Move 11 blocking API calls off the tview draw thread into goroutines with `QueueUpdateDraw`
+  - Affected: job cancel/hold/release/requeue/details, node details, partition details/analytics, job dependencies, job templates
+  - UI remains responsive during all API operations
+
+### Fixed
+
+- **Per-user temp file paths** (#103)
+  - Use per-user paths instead of shared `/tmp` files to prevent multi-user conflicts
+
+- **Install script serving** (#104)
+  - Serve install script directly at `get.s9s.dev` root
+
+- **Mock mode validation** (#105)
+  - Simplify mock mode validation logic
+
+### Changed
+
+- **Header bar** (#108)
+  - Remove clock display from header (added no value, wasted space)
+  - Add navigation hints (`Tab:Switch Views  Enter:Details  ?:Help`)
+
 ## [0.6.2] - 2026-03-10
 
 ### Fixed
@@ -411,7 +447,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Note**: Versions prior to 0.1.0 were in active development and did not follow semantic versioning.
 
-[Unreleased]: https://github.com/jontk/s9s/compare/v0.6.1...HEAD
+[Unreleased]: https://github.com/jontk/s9s/compare/v0.6.3...HEAD
+[0.6.3]: https://github.com/jontk/s9s/compare/v0.6.2...v0.6.3
+[0.6.2]: https://github.com/jontk/s9s/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/jontk/s9s/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/jontk/s9s/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/jontk/s9s/compare/v0.4.0...v0.5.0

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ s9s provides a terminal interface for managing SLURM clusters, inspired by the p
 #### Quick Install (Recommended)
 
 ```bash
-curl -sSL https://s9s.dev/install.sh | bash
+curl -sSL https://get.s9s.dev | bash
 ```
 
 #### Using Go Install

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Recent Changes
 
+### Version 0.6.3 (2026-03-14)
+
+Performance and responsiveness release:
+
+- **Eliminate N+1 API calls**: Partitions view now fetches all jobs in a single API call instead of 2N+1 calls per refresh — fixes multi-second freezes on clusters with 20k+ jobs
+- **Lazy view init & background fetch**: Views only initialize when first focused; DAO-level caching reduces redundant API calls; only the active view auto-refreshes
+- **Async UI-thread API calls**: 11 blocking API calls (cancel, hold, release, details modals, etc.) moved off the tview draw thread — UI stays responsive during all operations
+- **Header improvements**: Remove clock, add navigation key hints (`Tab`, `Enter`, `?`)
+- **Per-user temp paths**: Fix multi-user conflicts with shared `/tmp` files
+- **Install script fix**: Serve install script directly at `get.s9s.dev` root
+
 ### Version 0.6.2 (2026-03-10)
 
 Setup wizard improvements and bug fixes:
@@ -83,7 +94,8 @@ For a complete list of all changes, features, and fixes across all versions, ref
 
 ## Version History
 
-- [v0.6.2](../CHANGELOG.md#062---2026-03-10) - Latest release
+- [v0.6.3](../CHANGELOG.md#063---2026-03-14) - Latest release
+- [v0.6.2](../CHANGELOG.md#062---2026-03-10) - Setup wizard fixes
 - [v0.6.1](../CHANGELOG.md#061---2026-03-09) - Node metrics, job times, dashboard fixes
 - [v0.6.0](../CHANGELOG.md#060---2026-03-08) - Cluster switcher, export, config rename
 - [v0.5.0](../CHANGELOG.md#050---2026-02-18) - Auto-discovery, static builds

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -42,7 +42,7 @@ curl http://localhost:6820/slurm/v0.0.43/ping
 The easiest way to install s9s is using our installation script:
 
 ```bash
-curl -sSL https://s9s.dev/install.sh | bash
+curl -sSL https://get.s9s.dev | bash
 ```
 
 This script will:
@@ -57,31 +57,31 @@ Download pre-built binaries from our [releases page](https://github.com/jontk/s9
 
 ```bash
 # Linux (x86_64)
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.6.2_Linux_x86_64.tar.gz
-tar -xzf s9s_0.6.2_Linux_x86_64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.6.3_Linux_x86_64.tar.gz
+tar -xzf s9s_0.6.3_Linux_x86_64.tar.gz
 mkdir -p ~/.local/bin
 mv s9s ~/.local/bin/
 
 # Linux (ARM64)
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.6.2_Linux_arm64.tar.gz
-tar -xzf s9s_0.6.2_Linux_arm64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.6.3_Linux_arm64.tar.gz
+tar -xzf s9s_0.6.3_Linux_arm64.tar.gz
 mkdir -p ~/.local/bin
 mv s9s ~/.local/bin/
 
 # macOS (Apple Silicon)
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.6.2_Darwin_arm64.tar.gz
-tar -xzf s9s_0.6.2_Darwin_arm64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.6.3_Darwin_arm64.tar.gz
+tar -xzf s9s_0.6.3_Darwin_arm64.tar.gz
 mkdir -p ~/.local/bin
 mv s9s ~/.local/bin/
 
 # macOS (Intel)
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.6.2_Darwin_x86_64.tar.gz
-tar -xzf s9s_0.6.2_Darwin_x86_64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.6.3_Darwin_x86_64.tar.gz
+tar -xzf s9s_0.6.3_Darwin_x86_64.tar.gz
 mkdir -p ~/.local/bin
 mv s9s ~/.local/bin/
 ```
 
-> **Note:** Replace `0.6.2` with the latest version from the [releases page](https://github.com/jontk/s9s/releases).
+> **Note:** Replace `0.6.3` with the latest version from the [releases page](https://github.com/jontk/s9s/releases).
 
 ### 3. Using Go Install
 
@@ -296,7 +296,7 @@ To upgrade to the latest version:
 
 ```bash
 # If installed via script
-curl -sSL https://s9s.dev/install.sh | bash
+curl -sSL https://get.s9s.dev | bash
 
 # If installed via binary download
 wget https://github.com/jontk/s9s/releases/latest/download/s9s-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -529,7 +529,7 @@ rm ~/.local/bin/s9s
 rm -rf ~/.s9s
 
 # Reinstall
-curl -sSL https://s9s.dev/install.sh | bash
+curl -sSL https://get.s9s.dev | bash
 
 # Restore config
 mkdir -p ~/.s9s

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ s9s is a modern, terminal-based interface for SLURM workload managers. It provid
 
 ```bash
 # Install s9s
-curl -sSL https://s9s.dev/install.sh | bash
+curl -sSL https://get.s9s.dev | bash
 
 # Launch s9s
 s9s


### PR DESCRIPTION
## Summary

Prepare v0.6.3 release — performance and responsiveness improvements.

## Changes since v0.6.2

- **perf**: Eliminate N+1 API calls in Partitions view (#107)
- **perf**: Lazy view init, background fetch & DAO cache (#106)
- **perf**: Async UI-thread API calls (#107)
- **fix**: Per-user temp file paths (#103)
- **fix**: Install script serving at get.s9s.dev root (#104)
- **fix**: Simplify mock mode validation (#105)
- **ui**: Remove header clock, add navigation hints (#108)

## Release checklist

- [x] CHANGELOG.md updated
- [x] docs/about/changelog.md updated
- [ ] Merge PR
- [ ] Tag `v0.6.3` on main