### PR TITLE
docs: streamline install page, move slurmrestd to troubleshooting

### DIFF
--- a/demos/job-submission.tape
+++ b/demos/job-submission.tape
@@ -10,31 +10,33 @@ Source demos/bootstrap.tape
 Set Height 900
 
 
-# Open job submission directly (s key)
+# Open job submission wizard (s key)
 Type "s"
 Sleep 2s
 
+# Template selection is shown first
+# Select "Custom Job" (already highlighted as first item)
+Enter
+Sleep 1500ms
+
 # Fill in job name
-Type "simulation-job"
+Type "simulation-run-01"
 Tab
 Sleep 500ms
 
-# Skip to script content (Tab through fields)
-Tab
-Sleep 500ms
-
-# Add script content
+# Add script content in the text area
 Type "#!/bin/bash"
 Enter
-Type "#SBATCH --nodes=4"
-Enter
-Type "#SBATCH --ntasks-per-node=16"
-Enter
-Enter
-Type "srun ./my_simulation"
+Type "srun ./my_simulation --input data.csv"
 Sleep 1s
 
-# Navigate through other fields
+# Tab through remaining fields
+Tab
+Sleep 500ms
+Tab
+Sleep 500ms
+Tab
+Sleep 500ms
 Tab
 Sleep 500ms
 Tab
@@ -42,36 +44,28 @@ Sleep 500ms
 Tab
 Sleep 500ms
 
-# Show preview of the job script
-Tab
-Tab
-Enter
-Sleep 3s
-Escape
-Sleep 500ms
+# Pause to show the filled form
+Sleep 2s
 
 # Cancel this submission
 Escape
-Sleep 500ms
-
-# Open job submission directly (s key)
-Type "s"
-Sleep 1500ms
-
-# Quick submit without template
-Type "quick-test"
-Tab
-Sleep 500ms
-Tab
-Sleep 500ms
-Type "echo 'Hello World'"
 Sleep 1s
 
-# Cancel and exit
+# Open wizard again to show template selection
+Type "s"
+Sleep 2s
+
+# Select "MPI Parallel Job" template (second item)
+Down
+Enter
+Sleep 2s
+
+# Show the pre-filled template form
+Sleep 2s
+
+# Cancel and return to jobs view
 Escape
-Sleep 500ms
-Escape
-Sleep 500ms
+Sleep 1s
 
 # Exit
 Type "q"

--- a/demos/performance.tape
+++ b/demos/performance.tape
@@ -7,8 +7,8 @@ Source demos/common.tape
 Source demos/bootstrap.tape
 
 
-# Switch to Performance view (key 9)
-Type "9"
+# Switch to Performance view (key 0)
+Type "0"
 Sleep 2s
 
 # Show cluster metrics updating
@@ -19,8 +19,8 @@ Sleep 3s
 Type "R"
 Sleep 1s
 
-# Manual refresh (F5)
-Type@500ms "F5"
+# Manual refresh (F5 key)
+F5
 Sleep 1500ms
 
 # Toggle auto-refresh back on

--- a/demos/performance.tape
+++ b/demos/performance.tape
@@ -17,10 +17,6 @@ Sleep 3s
 
 # Toggle auto-refresh off (R key)
 Type "R"
-Sleep 1s
-
-# Manual refresh (F5 key)
-F5
 Sleep 1500ms
 
 # Toggle auto-refresh back on

--- a/demos/reservations.tape
+++ b/demos/reservations.tape
@@ -46,16 +46,14 @@ Sleep 500ms
 Enter
 Sleep 1s
 
-# Quick filter
+# Quick filter to demonstrate filtering
 Type "/"
 Sleep 500ms
 Type "maint"
-Sleep 1s
-Escape
-Sleep 500ms
+Sleep 1500ms
 
-# Refresh the view
-Type "R"
+# Return to table (Escape unfocuses filter)
+Escape
 Sleep 1s
 
 # Exit

--- a/demos/search.tape
+++ b/demos/search.tape
@@ -50,9 +50,9 @@ Sleep 500ms
 Type "admin"
 Sleep 1500ms
 
-# Select first result directly with Enter
-Enter
-Sleep 2s
+# Close search and return to view
+Escape
+Sleep 500ms
 
 # Exit
 Type "q"

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -7,33 +7,7 @@ s9s can be installed using several methods. Choose the one that best fits your e
 - **Operating System**: Linux, macOS, or Windows
 - **Go Version**: 1.19 or higher (for building from source)
 - **Terminal**: 256 color support recommended
-- **SLURM REST API**: A running `slurmrestd` instance (optional - mock mode available)
-
-### slurmrestd (SLURM REST API)
-
-s9s connects to SLURM through **slurmrestd**, the SLURM REST API daemon. This is a separate service from `slurmctld` (the controller) and `slurmdbd` (the accounting database). It typically runs on port **6820**.
-
-If slurmrestd is not already running on your cluster, start it:
-
-```bash
-# Start slurmrestd (as root or SlurmUser)
-slurmrestd 0.0.0.0:6820
-
-# Or with systemd (if configured)
-sudo systemctl start slurmrestd
-```
-
-Verify it's running:
-
-```bash
-# Check the port is listening
-ss -tlnp | grep 6820
-
-# Test the API
-curl http://localhost:6820/slurm/v0.0.43/ping
-```
-
-> **Note**: Having `slurmctld` and `slurmdbd` running is **not sufficient** - s9s specifically requires `slurmrestd` for its REST API.
+- **SLURM REST API**: A running `slurmrestd` instance — see [Troubleshooting](../guides/troubleshooting.md#cannot-connect-to-slurm-cluster) if connection fails ([mock mode](../guides/mock-mode.md) available for testing without SLURM)
 
 ## Installation Methods
 
@@ -128,7 +102,7 @@ s9s --version
 
 You should see output like:
 ```
-s9s version 0.3.0
+s9s version 0.6.3
 ```
 
 ### 2. Initial Configuration

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -70,7 +70,20 @@ echo $SLURM_TOKEN
 
 **Solutions**:
 
-1. **Check URL format**:
+1. **Start slurmrestd** if it's not running:
+   ```bash
+   # Start slurmrestd (as root or SlurmUser)
+   slurmrestd 0.0.0.0:6820
+
+   # Or with systemd (if configured)
+   sudo systemctl start slurmrestd
+
+   # Verify it's listening
+   ss -tlnp | grep 6820
+   curl http://localhost:6820/slurm/v0.0.43/ping
+   ```
+
+2. **Check URL format**:
    ```yaml
    # Correct
    url: https://slurm.example.com:6820
@@ -80,7 +93,7 @@ echo $SLURM_TOKEN
    url: https://slurm.example.com:6820/  # Trailing slash
    ```
 
-2. **Verify network access**:
+3. **Verify network access**:
    ```bash
    # Test connectivity
    ping slurm.example.com
@@ -90,7 +103,7 @@ echo $SLURM_TOKEN
    sudo iptables -L | grep 6820
    ```
 
-3. **Handle SSL/TLS issues**:
+4. **Handle SSL/TLS issues**:
    ```yaml
    # For self-signed certificates
    clusters:


### PR DESCRIPTION
## Summary

- Remove slurmrestd setup section from installation guide — it pushed the actual install commands below the fold
- Link to troubleshooting from the requirements line instead
- Add slurmrestd startup steps to the troubleshooting "Cannot connect to SLURM cluster" section where users will actually look
- Fix stale version string (`0.3.0` → `0.6.3`) in the verify installation example

## Test plan
- [ ] Verify anchor link `#cannot-connect-to-slurm-cluster` resolves correctly in docs