### PR TITLE
chore: regenerate demo gifs for v0.6.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@
 
 s9s provides a terminal interface for managing SLURM clusters, inspired by the popular [k9s](https://k9scli.io/) Kubernetes CLI. It allows HPC administrators and users to monitor and manage jobs, nodes, and cluster resources efficiently from the terminal.
 
+## Demo
+
 <p align="center">
   <img src="demos/output/overview.gif" alt="s9s demo" width="800">
 </p>

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@
 
 s9s provides a terminal interface for managing SLURM clusters, inspired by the popular [k9s](https://k9scli.io/) Kubernetes CLI. It allows HPC administrators and users to monitor and manage jobs, nodes, and cluster resources efficiently from the terminal.
 
+<p align="center">
+  <img src="demos/output/overview.gif" alt="s9s demo" width="800">
+</p>
+
 ## 📚 Documentation
 
 - **User Documentation**: [https://s9s.dev/docs](https://s9s.dev/docs)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 s9s provides a terminal interface for managing SLURM clusters, inspired by the popular [k9s](https://k9scli.io/) Kubernetes CLI. It allows HPC administrators and users to monitor and manage jobs, nodes, and cluster resources efficiently from the terminal.
 
-## Demo
+## 🎬 Demo
 
 <p align="center">
   <img src="demos/output/overview.gif" alt="s9s demo" width="800">

--- a/demos/output/accounts.gif
+++ b/demos/output/accounts.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d155c1ef52ac1b79743e1a39869ff13a6e114eb49345a85b3107c189a23459c7
-size 1029479
+oid sha256:ebf8aedfeac08b6477e23d7732bc442ead033577b8a2cd2b5cb2cf73e4ed1f4e
+size 984014

--- a/demos/output/dashboard.gif
+++ b/demos/output/dashboard.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:00947ce4fc68cf684e534c776dbb62f1110daf32f6fada28d23bcc7780fc74c7
-size 560963
+oid sha256:360b6c2ad84673c91f3b9109fbb28caa9e2503a73b3f84a0bda39cc6b01fae6d
+size 601954

--- a/demos/output/health.gif
+++ b/demos/output/health.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3de5a8abb890a68f7ec262c3c338925a448d392f90186363007d92668b3c2168
-size 556322
+oid sha256:c7c8660b52fefe5f2eadec38a6029d99e9f254a2f661787c1e399aaf9e321f65
+size 688310

--- a/demos/output/job-submission.gif
+++ b/demos/output/job-submission.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ffb49730610e3c73c8af92a31625b028398e9eedd592028cc9fd1a1eb7f14757
-size 2343701
+oid sha256:4db6369faea06f28cb90ee20b5ff6cadbbf86e8da0696c288b016b3269730dd8
+size 1343979

--- a/demos/output/jobs.gif
+++ b/demos/output/jobs.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d4bb4bd5a895acf0c9abb48f18e2eb679aa9b143771d989ed145bcd8686f95fd
-size 2678012
+oid sha256:de323ff220e67654aefa1efdffbce016295c7272d3f108e6a16058cefd90ef53
+size 3694105

--- a/demos/output/linkedin.gif
+++ b/demos/output/linkedin.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a869927b157c6816ff5810105cd5fb42333912661b0e2eeacca1efd7a85ad7d4
+size 973231

--- a/demos/output/nodes.gif
+++ b/demos/output/nodes.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ade11222b59ea7fe24d2fbce3a960ac9058cb37d5d587942e23835688c19c09e
-size 1331034
+oid sha256:e2cca1248a8277df45f801d4968dee68687131d98b8cafd5f17adf9f5e00cf98
+size 1501793

--- a/demos/output/overview.gif
+++ b/demos/output/overview.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:57c41c24f5becb1c78dd0c05c4a9c67700ef2fe71dc1ca1c80f785e6141ca9dc
-size 1376837
+oid sha256:3f766dcce57c45b36a30391324648db2eade3d589626308824455a35672318c7
+size 1607798

--- a/demos/output/partitions.gif
+++ b/demos/output/partitions.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c073089edc9fe7ddd2dbe1d44cde4e0ea10ee70716babab18dd8b9a57855a12b
-size 930497
+oid sha256:6a909c1bb80f4d31dd2c1eddbec4edb7ca1d08d84562ba2d06779cc34941ee3e
+size 848035

--- a/demos/output/performance.gif
+++ b/demos/output/performance.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d0c49143d43b1292e4e4588076e2a4c2781d7132a1e8a0050e08ead93de846d0
-size 383167
+oid sha256:58ae987742a7fa713296d2039e70ea867c0b83d11f799c85f585edbbb692bb8d
+size 410267

--- a/demos/output/qos.gif
+++ b/demos/output/qos.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a425bde1b196ef24728203bc399389fcba002b85af2ef58601ecabbafdf066e6
-size 457845
+oid sha256:c4401769a05e249bf65219c356d8d881e8f1404042b8d099792e7537e576a27c
+size 503904

--- a/demos/output/reservations.gif
+++ b/demos/output/reservations.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b44c619d2855db99f4e5e79b404b3fc12dbe08e4d784f1ae71942ab2a81d776f
-size 400878
+oid sha256:8f815d4bbb61f2720139dceac7b13b88b9ed82206ed04a8f0cf862acd9f6301a
+size 534877

--- a/demos/output/search.gif
+++ b/demos/output/search.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a4e53f1457f79eecd8e0c15c5f1f62b4d5a603fd7936f1bcaacc3ee66b248dc8
-size 1695535
+oid sha256:9fd11cb5a805e97e05a049888962919c272022adb77191dd14e1c8e4b13d92fa
+size 1538506

--- a/demos/output/users.gif
+++ b/demos/output/users.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4b5f49a95f1396a14f916023d254326ef94d41838c5ac3dd31bf24cca3d357ad
-size 647049
+oid sha256:71ba1202bf157f1eafddc1e595bc2e4db071085873a826afce24e7426018c895
+size 696659


### PR DESCRIPTION
## Summary

Regenerate all 13 demo GIFs to reflect the current v0.6.3 UI.

## What changed visually

- Header now shows navigation hints (`Tab:Switch Views  Enter:Details  ?:Help`) instead of clock
- Lazy view initialization (views load on first focus)
- Updated job submission wizard flow (template selection → form)
- Fixed tape scripts from #110

## Test plan

- [x] All 13 tapes run successfully with VHS
- [ ] Spot-check GIFs render correctly in browser