### PR TITLE
fix: align install script and docs with actual CLI behavior

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -136,14 +136,16 @@ See [Configuration Guide](configuration.md) for complete configuration options.
 ### 3. Test Connection
 
 ```bash
-# Test with your SLURM cluster
+# On a SLURM node (auto-discovers slurmrestd)
 s9s
 
-# Or test with mock mode (no SLURM required)
-s9s --mock
+# Or connect manually
+export SLURM_REST_URL=https://your-slurm-api.example.com:6820
+export SLURM_JWT=your-token
+s9s
 ```
 
-If connection succeeds, you should see the s9s dashboard.
+If connection succeeds, you should see the s9s dashboard. See [Mock Mode](../guides/mock-mode.md) for testing without a SLURM cluster.
 
 ## Platform-Specific Notes
 
@@ -244,8 +246,9 @@ If you cannot connect to SLURM:
    - Check token is valid
    - Verify API URL is correct
 
-3. **Try mock mode** to rule out s9s issues:
+3. **Try mock mode** to rule out s9s issues (see [Mock Mode Guide](../guides/mock-mode.md)):
    ```bash
+   export S9S_ENABLE_MOCK=1
    s9s --mock
    ```
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -183,9 +183,6 @@ setup_config() {
 # s9s Configuration File
 # See https://s9s.dev/docs/configuration for full documentation
 
-# Refresh rate for auto-updates
-refreshRate: "2s"
-
 # Cluster connections (optional - s9s auto-discovers on SLURM nodes)
 # clusters:
 #   - name: default
@@ -193,11 +190,6 @@ refreshRate: "2s"
 #       endpoint: https://slurm.example.com:6820
 #       token: ${SLURM_JWT}
 #       timeout: 30s
-
-# UI settings
-ui:
-  skin: default
-  enableMouse: true
 EOF
         log "Created default configuration at $CONFIG_DIR/config.yaml"
     else

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -183,23 +183,21 @@ setup_config() {
 # s9s Configuration File
 # See https://s9s.dev/docs/configuration for full documentation
 
-# Default cluster (optional - you can specify multiple clusters)
+# Refresh rate for auto-updates
+refreshRate: "2s"
+
+# Cluster connections (optional - s9s auto-discovers on SLURM nodes)
 # clusters:
-#   production:
-#     url: https://slurm.example.com
-#     auth:
-#       method: token
-#       token: ${SLURM_TOKEN}
+#   - name: default
+#     cluster:
+#       endpoint: https://slurm.example.com:6820
+#       token: ${SLURM_JWT}
+#       timeout: 30s
 
-# User preferences
-preferences:
-  theme: dark
-  refresh_interval: 30s
-  default_view: jobs
-
-# Logging
-logging:
-  level: info
+# UI settings
+ui:
+  skin: default
+  enableMouse: true
 EOF
         log "Created default configuration at $CONFIG_DIR/config.yaml"
     else
@@ -222,25 +220,21 @@ verify_installation() {
         
         echo
         echo "🚀 Quick Start:"
-        echo "  # Run setup wizard (recommended for first-time users)"
-        echo "  s9s setup"
         echo
-        echo "  # Or run with mock data (no SLURM cluster required)"
-        echo "  s9s --mock"
-        echo
-        echo "  # Or connect to your SLURM cluster manually"
-        echo "  export SLURM_URL=https://your-slurm-cluster.com"
-        echo "  export SLURM_TOKEN=your-token"
+        echo "  # On a SLURM node (auto-discovers slurmrestd):"
         echo "  s9s"
         echo
-        echo "📖 Documentation:"
-        echo "  https://s9s.dev/docs"
+        echo "  # Or connect manually:"
+        echo "  export SLURM_REST_URL=https://your-slurm-cluster.com:6820"
+        echo "  export SLURM_JWT=your-token"
+        echo "  s9s"
         echo
-        echo "🔧 Configuration:"
-        echo "  $CONFIG_DIR/config.yaml"
+        echo "  # If auto-discovery doesn't work, run the setup wizard:"
+        echo "  s9s setup"
         echo
-        echo "❓ Get help:"
-        echo "  s9s --help"
+        echo "📖 Documentation: https://s9s.dev/docs"
+        echo "🔧 Configuration: $CONFIG_DIR/config.yaml"
+        echo "❓ Help:          s9s --help"
         
         return 0
     else

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -207,7 +207,7 @@ verify_installation() {
     
     if command_exists "$BINARY_NAME"; then
         local installed_version
-        installed_version=$("$BINARY_NAME" --version 2>/dev/null | head -1 | awk '{print $3}' || echo "unknown")
+        installed_version=$("$BINARY_NAME" --version 2>/dev/null | head -1 | awk '{print $NF}' || echo "unknown")
         log "s9s $installed_version installed successfully!"
         
         echo


### PR DESCRIPTION
## Summary

- Fix install script default config: uses actual s9s config keys instead of incorrect ones
- Fix environment variable names: `SLURM_REST_URL`/`SLURM_JWT` (not `SLURM_URL`/`SLURM_TOKEN`)
- Lead Quick Start with auto-discovery instead of setup wizard
- Add `S9S_ENABLE_MOCK` requirement where `--mock` is referenced

## Details

The install script (`scripts/install.sh`) generated a config file with keys that don't exist in s9s (`preferences.theme`, `refresh_interval`, `default_view`, `logging.level`). The actual config uses `ui.skin`, `refreshRate`, `views.jobs`, etc. The Quick Start section also referenced wrong env var names and suggested `--mock` without the required `S9S_ENABLE_MOCK` gate.

## Test plan

- [ ] `curl -sSL https://get.s9s.dev | bash -s -- --help` shows correct examples
- [ ] Generated `~/.s9s/config.yaml` uses valid s9s config keys
- [ ] `docs/getting-started/installation.md` references correct env vars
- [ ] Mock mode references include `S9S_ENABLE_MOCK` or link to mock mode guide