### PR TITLE
chore: prepare v0.7.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to release (e.g. v0.6.3)'
+        description: 'Tag to release (e.g. v0.7.0)'
         required: true
 
 env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Removed
+
+## [0.7.0] - 2026-03-16
+
+### Added
+
 - **Configurable job submission templates** — define custom templates with pre-filled values, global form defaults, hidden fields, and restricted dropdown options via `views.jobs.submission` config section
 - **3-tier template merge** — templates from built-in (8), config YAML, and user-saved JSON (`~/.s9s/templates/`) merge with name-based override; controlled by `templateSources` config
 - **84 SLURM sbatch fields** — job submission wizard supports 84 of 117 SLURM OpenAPI JobCreate fields (was 12); fields organized in visibility tiers (7 always visible, 7 default, 70 hidden — shown via templates)

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Recent Changes
 
-### Unreleased
+### Version 0.7.0 (2026-03-16)
 
 Configurable job submission templates and full SLURM field support:
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -31,31 +31,31 @@ Download pre-built binaries from our [releases page](https://github.com/jontk/s9
 
 ```bash
 # Linux (x86_64)
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.6.3_Linux_x86_64.tar.gz
-tar -xzf s9s_0.6.3_Linux_x86_64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.7.0_Linux_x86_64.tar.gz
+tar -xzf s9s_0.7.0_Linux_x86_64.tar.gz
 mkdir -p ~/.local/bin
 mv s9s ~/.local/bin/
 
 # Linux (ARM64)
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.6.3_Linux_arm64.tar.gz
-tar -xzf s9s_0.6.3_Linux_arm64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.7.0_Linux_arm64.tar.gz
+tar -xzf s9s_0.7.0_Linux_arm64.tar.gz
 mkdir -p ~/.local/bin
 mv s9s ~/.local/bin/
 
 # macOS (Apple Silicon)
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.6.3_Darwin_arm64.tar.gz
-tar -xzf s9s_0.6.3_Darwin_arm64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.7.0_Darwin_arm64.tar.gz
+tar -xzf s9s_0.7.0_Darwin_arm64.tar.gz
 mkdir -p ~/.local/bin
 mv s9s ~/.local/bin/
 
 # macOS (Intel)
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.6.3_Darwin_x86_64.tar.gz
-tar -xzf s9s_0.6.3_Darwin_x86_64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.7.0_Darwin_x86_64.tar.gz
+tar -xzf s9s_0.7.0_Darwin_x86_64.tar.gz
 mkdir -p ~/.local/bin
 mv s9s ~/.local/bin/
 ```
 
-> **Note:** Replace `0.6.3` with the latest version from the [releases page](https://github.com/jontk/s9s/releases).
+> **Note:** Replace `0.7.0` with the latest version from the [releases page](https://github.com/jontk/s9s/releases).
 
 ### 3. Using Go Install
 
@@ -102,7 +102,7 @@ s9s --version
 
 You should see output like:
 ```
-s9s version 0.6.3
+s9s version 0.7.0
 ```
 
 ### 2. Initial Configuration


### PR DESCRIPTION
## Summary

- Move Unreleased changelog entries to [0.7.0] - 2026-03-16
- Update version references in installation docs and release workflow

## Test plan

- [ ] Changelog dates and version numbers correct
- [ ] Installation docs reference 0.7.0
- [ ] After merge, tag `v0.7.0` and push to trigger release workflow