### PR TITLE
docs: fix remaining aspirational features across 5 doc files

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -264,7 +264,7 @@ Press `:` to enter command mode (vim-style) with intelligent autocomplete:
 ```bash
 :help              # Show help
 :quit              # Exit s9s
-:view nodes        # Switch to nodes view
+:nodes        # Switch to nodes view
 :refresh           # Force refresh
 ```
 
@@ -321,7 +321,7 @@ Now that you know the basics, explore:
 1. **Practice with mock mode** - `s9s --mock` is risk-free
 2. **Use keyboard shortcuts** - Faster than mouse for everything
 3. **Multi-select is powerful** - Batch operations save time
-4. **Pin important filters** - Save frequently used filters
+4. **Use quick filters** - Press `/` to filter any view instantly
 5. **Context help** - Press `?` in any view for specific shortcuts
 6. **Group nodes** - Makes large clusters manageable
 7. **SSH from UI** - No need to remember node names
@@ -353,7 +353,7 @@ A: Yes! Press `s/S` in Nodes view for SSH options.
 A: Use `/` and type `p:partitionname` or `partition:name`.
 
 **Q: Is there a way to save my filters?**
-A: Yes, see [Configuration Guide](configuration.md) for saved filters.
+A: Saved filters are a planned feature. For now, use `/` to quickly re-enter filters in any view.
 
 **Q: Can I customize colors/theme?**
 A: Yes, see [Configuration Guide](configuration.md) for theme options.

--- a/docs/guides/ssh-integration.md
+++ b/docs/guides/ssh-integration.md
@@ -29,7 +29,7 @@ From the Nodes View, press `s` on a selected node to open an interactive SSH ses
 **From Nodes View**:
 ```bash
 # Navigate to nodes view
-:view nodes
+:nodes
 
 # Select a node and press 's' to open SSH session
 node001  IDLE    16/32 cores  64GB/128GB  ← [s] SSH here
@@ -38,7 +38,7 @@ node001  IDLE    16/32 cores  64GB/128GB  ← [s] SSH here
 **From Jobs View**:
 ```bash
 # Navigate to jobs view
-:view jobs
+:jobs
 
 # Press 's' on a running job to SSH to its allocated nodes
 12345  alice  RUNNING  node[001-004]  ← [s] SSH to job nodes
@@ -261,7 +261,7 @@ If SSH connection fails:
 
 ```bash
 # 1. Navigate to jobs view
-:view jobs
+:jobs
 
 # 2. Find your running job
 12345  alice  RUNNING  node[001-004]
@@ -281,7 +281,7 @@ user@node001:~$ tail -f /path/to/job/output
 
 ```bash
 # 1. Navigate to nodes view
-:view nodes
+:nodes
 
 # 2. Select a problematic node
 # 3. Press 's' → choose "Get Node Info"

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -195,21 +195,18 @@ echo $SLURM_TOKEN
 **Solutions**:
 
 1. **Adjust refresh rate**:
-   ```bash
-   # Slower refresh
-   :set refresh 10s
-
-   # Disable auto-refresh
-   :set refresh 0
+   Change the `refreshRate` setting in your configuration file (`~/.s9s/config.yaml`):
+   ```yaml
+   preferences:
+     refreshRate: 10s  # Slower refresh (default is 30s)
    ```
 
-2. **Reduce data displayed**:
-   ```bash
-   # Limit results
-   :set pageSize 25
-
-   # Hide unnecessary columns
-   :columns JobID,Name,State,Time
+2. **Customize visible columns**:
+   Configure columns in your configuration file:
+   ```yaml
+   views:
+     jobs:
+       columns: [JobID, Name, State, Time]
    ```
 
 3. **Check system resources**:
@@ -228,16 +225,8 @@ echo $SLURM_TOKEN
 **Problem**: Missing or filtered jobs
 
 **Diagnostics**:
-```bash
-# Check active filters
-:filters show
-
-# Clear all filters
-:clear
-
-# Verify with squeue
-:!squeue -u $USER
-```
+- Press `/` to check if a filter is active, then press `Esc` to clear it
+- Press `R` to force a manual refresh
 
 **Solutions**:
 
@@ -260,10 +249,10 @@ echo $SLURM_TOKEN
 
 3. **Partition visibility**:
    ```bash
-   # List visible partitions
-   :partitions list
+   # Switch to partitions view in s9s
+   :partitions
 
-   # Check partition access
+   # Or check partition access from the command line
    sinfo -s
    ```
 
@@ -276,10 +265,7 @@ echo $SLURM_TOKEN
 1. **Force refresh**:
    ```bash
    # Manual refresh
-   Ctrl+R
-
-   # Clear cache
-   :cache clear
+   R       # Press R in any view
    ```
 
 2. **Check time sync**:
@@ -365,39 +351,19 @@ echo $SLURM_TOKEN
 
 ### Debug Mode
 
-Enable comprehensive debugging:
+Enable debug logging:
 
 ```bash
 # Start with debug logging
-s9s --debug --log-level=trace
+s9s --debug
 
-# Debug specific component
-s9s --debug-component=api
-s9s --debug-component=ui
-s9s --debug-component=ssh
-
-# Save debug session
+# Save debug output to a file
 s9s --debug 2>&1 | tee debug.log
-```
-
-### Configuration Validation
-
-Verify configuration:
-
-```bash
-# Validate syntax
-s9s config validate
-
-# Test specific cluster
-s9s config test --cluster production
-
-# Show effective configuration
-s9s config show --resolved
 ```
 
 ### API Testing
 
-Test SLURM API directly:
+Test the SLURM REST API directly to isolate connection issues:
 
 ```bash
 # Test API endpoint
@@ -407,10 +373,6 @@ curl -k -H "X-Auth-Token: $SLURM_TOKEN" \
 # List jobs via API
 curl -k -H "X-Auth-Token: $SLURM_TOKEN" \
      https://slurm.example.com/slurm/v0.0.40/jobs
-
-# Test with S9S
-s9s api GET /jobs
-s9s api GET /nodes
 ```
 
 ### Log Analysis
@@ -424,49 +386,29 @@ tail -n 100 ~/.s9s/s9s.log
 # Search for errors
 grep ERROR ~/.s9s/s9s.log
 
-# Monitor logs
+# Monitor logs in real time
 tail -f ~/.s9s/s9s.log
-
-# Rotate logs
-s9s logs rotate
 ```
 
-## Diagnostic Commands
+## Diagnostic Information
 
-### Built-in Diagnostics
+To view cluster health information, use the built-in health view:
 
 ```bash
-# System information
-:diag system
+# Switch to health view
+:health
 
-# Connection test
-:diag connection
-
-# Performance metrics
-:diag performance
-
-# Configuration check
-:diag config
-
-# Full diagnostic report
-:diag full > diagnostic-report.txt
+# Or press 9 to switch to the health view
 ```
 
-### Health Checks
+For configuration issues, use the config view:
 
 ```bash
-# API health
-:health api
-
-# Cache status
-:health cache
-
-# Plugin status
-:health plugins
-
-# Overall health
-:health all
+# Open configuration
+:config
 ```
+
+> **Note**: Additional diagnostic commands are planned. See [#119](https://github.com/jontk/s9s/issues/119) for planned diagnostic commands.
 
 ## Getting Help
 
@@ -475,13 +417,13 @@ s9s logs rotate
 When reporting issues, include:
 
 ```bash
-# Generate support bundle
-s9s support-bundle
+# Check s9s version
+s9s --version
 
-# Manual collection
-s9s --version > support.txt
-s9s config show --sanitized >> support.txt
-s9s diag full >> support.txt
+# Run with debug logging
+s9s --debug 2>&1 | tee debug.log
+
+# Collect log files if available
 tar czf s9s-debug.tar.gz ~/.s9s/logs/
 ```
 
@@ -509,24 +451,16 @@ Complete reset:
 # Backup configuration
 cp -r ~/.s9s ~/.s9s.backup
 
-# Reset to defaults
-s9s reset
-
-# Or manual reset
+# Manual reset
 rm -rf ~/.s9s
-s9s setup
+
+# S9S will recreate defaults on next launch
+s9s
 ```
 
 ### Clear Cache
 
 ```bash
-# Clear all caches
-s9s cache clear
-
-# Clear specific cache
-s9s cache clear --type=api
-s9s cache clear --type=ui
-
 # Manual cache clear
 rm -rf ~/.s9s/cache/
 ```

--- a/docs/user-guide/filtering.md
+++ b/docs/user-guide/filtering.md
@@ -24,8 +24,6 @@ Press `/` in any view to activate quick filter:
 ### Clear Filters
 
 - `Esc` - Clear current filter and exit search mode
-- `:clear` - Clear all active filters
-- `Ctrl+/` - Toggle last filter on/off
 
 ## Filter Syntax
 
@@ -238,54 +236,11 @@ Use regex for complex pattern matching:
 /state:unusable       # down,drain,maint
 ```
 
-## Saved Filters
+## Saved Filters and Presets (Planned)
 
-### Creating Saved Filters
-
-Save frequently used filters:
-
-```bash
-# Save current filter
-:filter save my-jobs "/user:${USER} state:active"
-
-# Save with description
-:filter save gpu-pending "/partition:gpu state:PENDING" --desc "Pending GPU jobs"
-
-# Save complex filter
-:filter save inefficient "/state:RUNNING efficiency:<0.5 runtime:>1h"
-```
-
-### Using Saved Filters
-
-```bash
-# List saved filters
-:filter list
-
-# Load saved filter
-:filter load my-jobs
-# Or use shortcut
-/~my-jobs
-
-# Edit saved filter
-:filter edit gpu-pending
-
-# Delete saved filter
-:filter delete old-filter
-```
-
-### Filter Presets
-
-s9s includes built-in filter presets:
-
-| Preset | Description | Filter |
-|--------|-------------|--------|
-| `~active` | Active jobs | `state:RUNNING,PENDING` |
-| `~mine` | My jobs | `user:${USER}` |
-| `~recent` | Recent jobs | `submitted:<1d` |
-| `~failed` | Failed jobs | `state:FAILED,TIMEOUT` |
-| `~gpu` | GPU jobs | `gpus:>0` |
-| `~long` | Long jobs | `runtime:>1d` |
-| `~today` | Today's jobs | `submitted:today` |
+> **Note**: Saved filters, filter presets (`~` prefix shortcuts like `/~active`, `/~mine`), and `:filter save/load/list/delete` commands are planned features. See [#119](https://github.com/jontk/s9s/issues/119) for details.
+>
+> In the meantime, you can re-enter filters manually using `/` in any view.
 
 ## Dynamic Filters
 
@@ -310,14 +265,16 @@ Filters that adapt to current view:
 
 ```bash
 # In Jobs view
-/efficiency:<0.7      # Low efficiency jobs
+/state:RUNNING        # Running jobs
 
 # In Nodes view
-/load:>0.8           # High load nodes
+/state:idle           # Idle nodes
 
 # In Users view
-/active:true         # Users with running jobs
+/user:alice           # Specific user
 ```
+
+> **Note**: Advanced context-aware fields like `efficiency`, `load`, and `gpu_util` depend on those fields being available in the data returned by the SLURM REST API. Some advanced filter features are planned. See [#119](https://github.com/jontk/s9s/issues/119).
 
 ## Filter Examples
 
@@ -328,9 +285,9 @@ Filters that adapt to current view:
 /state:PENDING submitted:>1h reason:!Resources
 ```
 
-#### Inefficient GPU Jobs
+#### GPU Partition Jobs
 ```bash
-/partition:gpu state:RUNNING gpu_util:<50%
+/partition:gpu state:RUNNING
 ```
 
 #### Failed Jobs Today
@@ -369,10 +326,9 @@ Filters that adapt to current view:
 
 ### Efficient Filtering
 
-1. **Use indexes**: Filter by indexed fields first (JobID, User, State)
+1. **Use indexed fields**: Filter by indexed fields first (JobID, User, State)
 2. **Narrow scope**: Start with restrictive filters, then broaden
-3. **Save complex filters**: Reuse instead of retyping
-4. **Use shortcuts**: Learn preset filters for common queries
+3. **State first**: Filter by state for best performance
 
 ### Filter Optimization
 
@@ -393,23 +349,11 @@ Filters that adapt to current view:
 | `/` | Start filter | Enter filter mode |
 | `Tab` | Autocomplete | Complete filter fields |
 | `↑/↓` | History | Browse filter history |
-| `Ctrl+/` | Toggle | Toggle last filter |
-| `Alt+/` | Presets | Show filter presets |
 | `Esc` | Clear | Clear current filter |
 
-### Command Mode Filters
+### Using Filters
 
-```bash
-# Apply filter via command
-:filter "state:RUNNING nodes:>4"
-
-# Chain filters
-:filter add "user:alice"
-:filter add "partition:gpu"
-
-# Remove specific filter
-:filter remove "user:alice"
-```
+Use `/` in any view to enter filter mode and type your filter expression. Press `Esc` to clear the filter.
 
 ## Troubleshooting Filters
 
@@ -436,7 +380,6 @@ Filters that adapt to current view:
 ## Next Steps
 
 - Practice filters in [Mock Mode](../MOCK_MODE.md)
-- Set up [Saved Filters](../getting-started/configuration.md#filters)
 - Learn [Batch Operations](../user-guide/job-management.md) with filters
 - Explore filtering in specific views:
   - [Jobs View](../user-guide/views/jobs.md)

--- a/docs/user-guide/navigation.md
+++ b/docs/user-guide/navigation.md
@@ -78,7 +78,7 @@ These shortcuts work across all views:
 | `Ctrl+F` | Search | Global search |
 | `F1` | Actions Menu | Show actions menu |
 | `F2` | Templates | Show job templates |
-| `1-9` | Sort | Sort by column |
+| `S` | Sort | Open sort modal |
 | `R` | Refresh | Force refresh view |
 
 ### Nodes View
@@ -92,7 +92,7 @@ These shortcuts work across all views:
 | `/` | Filter | Filter nodes |
 | `F3` | Adv Filter | Advanced filter mode |
 | `Ctrl+F` | Search | Global search |
-| `1-9` | Sort | Sort by column |
+| `S` | Sort | Open sort modal |
 | `R` | Refresh | Force refresh view |
 | `p` | Partition | Filter by partition |
 | `a` | All States | Show all node states |
@@ -111,7 +111,7 @@ These shortcuts work across all views:
 | `/` | Filter | Filter partitions |
 | `F3` | Adv Filter | Advanced filter mode |
 | `Ctrl+F` | Search | Global search |
-| `1-9` | Sort | Sort by column |
+| `S` | Sort | Open sort modal |
 | `R` | Refresh | Force refresh view |
 
 ### QoS View
@@ -122,7 +122,7 @@ These shortcuts work across all views:
 | `/` | Filter | Filter QoS policies |
 | `F3` | Adv Filter | Advanced filter mode |
 | `Ctrl+F` | Search | Global search |
-| `1-9` | Sort | Sort by column |
+| `S` | Sort | Open sort modal |
 | `R` | Refresh | Force refresh view |
 
 ### Accounts View
@@ -134,7 +134,7 @@ These shortcuts work across all views:
 | `/` | Filter | Filter accounts |
 | `F3` | Adv Filter | Advanced filter mode |
 | `Ctrl+F` | Search | Global search |
-| `1-9` | Sort | Sort by column |
+| `S` | Sort | Open sort modal |
 | `R` | Refresh | Force refresh view |
 
 ### Users View
@@ -146,7 +146,7 @@ These shortcuts work across all views:
 | `/` | Filter | Filter users |
 | `F3` | Adv Filter | Advanced filter mode |
 | `Ctrl+F` | Search | Global search |
-| `1-9` | Sort | Sort by column |
+| `S` | Sort | Open sort modal |
 | `R` | Refresh | Force refresh view |
 
 ### Reservations View
@@ -159,7 +159,7 @@ These shortcuts work across all views:
 | `/` | Filter | Filter reservations |
 | `F3` | Adv Filter | Advanced filter mode |
 | `Ctrl+F` | Search | Global search |
-| `1-9` | Sort | Sort by column |
+| `S` | Sort | Open sort modal |
 | `R` | Refresh | Force refresh view |
 
 ### Dashboard View
@@ -217,7 +217,7 @@ Press `Ctrl+F` to search across all views simultaneously and jump to results.
 2. **Quick view switching**: Number keys `1-9` switch directly to views
 3. **Quick filters**: `/` for instant filtering in any view
 4. **Multi-select**: Use `v` in jobs view for batch operations
-5. **Sort quickly**: Use `1-9` to sort by different columns
+5. **Sort quickly**: Press `S` to open the sort modal
 
 ### Power User Workflows
 
@@ -264,7 +264,7 @@ See [Commands Reference](../reference/commands.md) for complete command document
 - **Command mode with autocomplete** - Vim-style `:` commands with Tab completion
 - **ASCII visualizations** - Resource usage shown with colored progress bars
 - **Advanced filtering** - Use `/` to filter data in any view or `F3` for advanced filters
-- **Sortable columns** - Use number keys `1-9` to sort
+- **Sortable columns** - Press `S` to open the sort modal
 - **Detailed analytics** - Press `A` or `W` in partitions for insights
 - **Node grouping** - Group nodes by partition, state, or features
 - **Wait time analysis** - Predictive queue analytics in partitions


### PR DESCRIPTION
## Summary

Final round of docs-vs-reality fixes from the comprehensive audit (#117). Fixes 5 files with 30+ references to unimplemented features.

Planned features tracked in #119.

### Changes

**troubleshooting.md** (-123 lines):
- Remove `:set`, `:cache`, `:diag`, `:health`, `:!command`, `s9s api`, `s9s logs`, `s9s reset`, `s9s support-bundle` (none implemented)
- Replace with actual alternatives (config keys, `R` for refresh, `--debug` flag)

**filtering.md** (-87 lines):
- Remove saved filters (`:filter save/load/list/delete`)
- Remove filter presets (`/~active`, `/~mine` with `~` prefix)
- Remove `Ctrl+/`, `Alt+/` shortcuts
- Keep basic filter syntax that works (`/`, `/user:`, `/state:`, `/partition:`)

**navigation.md**:
- Fix `1-9` from "Sort by column" to `S` "Open sort modal" in all view tables

**quickstart.md**, **ssh-integration.md**:
- Fix `:view nodes` → `:nodes`, `:view jobs` → `:jobs`

## Test plan

- [ ] No references to unimplemented commands remain in these files
- [ ] Troubleshooting steps use actual commands and config keys
- [ ] Filter docs only describe working syntax