### PR TITLE
docs: rewrite job-streaming guide and fix plugin development docs

### DIFF
--- a/docs/guides/job-streaming.md
+++ b/docs/guides/job-streaming.md
@@ -1,475 +1,125 @@
-# Job Streaming Guide
+# Job Output Streaming
 
-s9s provides powerful real-time job log streaming capabilities that allow you to monitor job output as it's being written, similar to `tail -f` but with advanced features for SLURM environments.
-
-## Overview
-
-The streaming system supports:
-- **Real-time log tailing**: Watch job stdout/stderr as it's written
-- **Multi-stream monitoring**: Monitor multiple jobs simultaneously
-- **SSH-based streaming**: Stream logs from compute nodes via SSH
-- **File-based streaming**: Monitor log files on shared filesystems
-- **Intelligent path resolution**: Automatically find job output files
-- **Advanced filtering**: Filter log content in real-time
-- **Buffer management**: Handle high-volume log streams efficiently
+s9s supports real-time job output streaming, allowing you to watch stdout and stderr as a job writes to its output files. This works similar to `tail -f` but is integrated directly into the TUI.
 
 ## Quick Start
 
-### Basic Streaming
-1. Open s9s: `s9s` or `s9s --mock`
-2. Navigate to Jobs view
-3. Select a running job
-4. Press `o` to view job output
-5. Press `s` to start streaming mode
+1. Open s9s and navigate to the **Jobs** view.
+2. Select a running job.
+3. Press `o` to open the Job Output Viewer.
+4. Press `t` to start real-time streaming.
 
-### Stream Monitor
-1. Press `Ctrl+s` to open Stream Monitor
-2. Add streams using `+` key
-3. Navigate between streams with arrow keys
-4. Use `Ctrl+f` for filtering
+Output appears in real time as the job writes to its log files.
 
-## Streaming Sources
+## Enabling Streaming
 
-### 1. File-based Streaming
+Streaming is enabled by default. You can toggle it in your configuration file:
 
-Monitor log files on shared storage:
-```bash
-# SLURM output files (default pattern)
-/path/to/slurm/output/job_%j.out
-/path/to/slurm/output/job_%j.err
-
-# Custom paths
-/shared/logs/job_123.log
-/nfs/user/logs/my_job.out
-```
-
-**Configuration:**
 ```yaml
-streaming:
-  file_paths:
-    base_dir: "/shared/slurm/logs"
-    stdout_pattern: "job_%j.out"
-    stderr_pattern: "job_%j.err"
-  polling_interval: 100ms
-  buffer_size: 64KB
+features:
+  streaming: true
 ```
 
-### 2. SSH-based Streaming
+Or set the default in `config.example.yaml`. When disabled, the Job Output Viewer still works for loading output on demand (press `r` to refresh), but real-time streaming is unavailable.
 
-Stream logs directly from compute nodes:
-```bash
-# Stream from specific node
-ssh node001 tail -f /tmp/job_123.out
+## Job Output Viewer
 
-# Auto-detect job location
-s9s stream --job 123 --auto-detect
-```
-
-**Configuration:**
-```yaml
-streaming:
-  ssh:
-    enabled: true
-    timeout: 30s
-    max_connections: 10
-    commands:
-      tail: "tail -f"
-      grep: "grep"
-```
-
-### 3. SLURM API Streaming
-
-Use SLURM's built-in streaming (if available):
-```yaml
-streaming:
-  slurm_api:
-    enabled: true
-    endpoint: "/slurm/v0.0.43/job/{job_id}/output"
-    chunk_size: 4KB
-```
-
-## Stream Monitor Interface
-
-### Multi-Stream Layout
-
-The Stream Monitor can display multiple job streams simultaneously:
-
-```
-┌─ Stream Monitor ─────────────────────────────────────┐
-│ ┌─Job 123─┐ ┌─Job 124─┐ ┌─Job 125─┐ ┌─Job 126─┐     │
-│ │[STDOUT] │ │[STDERR] │ │[STDOUT] │ │[STDOUT] │     │
-│ │Running  │ │Running  │ │Running  │ │Running  │     │
-│ │         │ │ERROR:   │ │Progress │ │Finished │     │
-│ │Output   │ │Failed   │ │50%      │ │Success  │     │
-│ │line 1   │ │to load  │ │Working  │ │100%     │     │
-│ │Output   │ │module   │ │...      │ │Done.    │     │
-│ │line 2   │ │         │ │         │ │         │     │
-│ └─────────┘ └─────────┘ └─────────┘ └─────────┘     │
-├─────────────────────────────────────────────────────┤
-│ Streams: 4 | Active: 3 | Ctrl+s:Add | q:Quit       │
-└─────────────────────────────────────────────────────┘
-```
+The Job Output Viewer is a modal that opens over the Jobs view. It displays the contents of a single job's stdout or stderr file.
 
 ### Key Bindings
 
-| Key | Action |
-|-----|--------|
-| `Ctrl+s` | Open Stream Monitor |
-| `+` | Add new stream |
-| `-` | Remove current stream |
-| `←/→` | Navigate between streams |
-| `↑/↓` | Scroll within stream |
-| `f` | Filter content |
-| `c` | Clear stream buffer |
-| `p` | Pause/resume streaming |
-| `s` | Save stream to file |
-| `r` | Restart stream |
-| `q` | Close Stream Monitor |
+| Key   | Action                                |
+|-------|---------------------------------------|
+| `o`   | Open Job Output Viewer (from Jobs)    |
+| `t`   | Toggle real-time streaming on/off     |
+| `a`   | Toggle auto-scroll                    |
+| `s`   | Switch between stdout and stderr      |
+| `f`   | Follow output (scroll to end + auto-refresh) |
+| `r`   | Refresh output manually               |
+| `e`   | Export output to file                 |
+| `Esc` | Close the viewer                      |
 
-## Advanced Features
+### Streaming Status
 
-### Real-time Filtering
+When streaming is active, the title bar shows a **LIVE** indicator. The status bar at the bottom displays:
 
-Apply filters to streaming content:
+- **Streaming ACTIVE** with buffer usage when a stream is running.
+- **Streaming stopped** with a hint to press `t` when idle.
+- **Streaming not available** if the `StreamManager` is not configured (for example, when the feature flag is off).
 
-```bash
-# Filter for errors
-s9s stream --job 123 --filter "ERROR"
+### Auto-Scroll
 
-# Multiple filters
-s9s stream --job 123 --filter "ERROR|WARN|FAIL"
+Auto-scroll is enabled by default. When new output arrives, the viewer automatically scrolls to the bottom. Press `a` to toggle this behavior if you need to review earlier output without being interrupted.
 
-# Exclude patterns
-s9s stream --job 123 --exclude "DEBUG|TRACE"
-```
+## How Streaming Works
 
-**Filter Configuration:**
-```yaml
-streaming:
-  filters:
-    - name: "errors"
-      pattern: "ERROR|FATAL|EXCEPTION"
-      color: "red"
-      highlight: true
-    - name: "warnings"
-      pattern: "WARN|WARNING"
-      color: "yellow"
-    - name: "progress"
-      pattern: "Progress:|\\d+%"
-      color: "green"
-```
+Behind the scenes, the `StreamManager` in `internal/streaming/` coordinates output streaming for a single job at a time.
 
-### Buffer Management
+### Path Resolution
 
-Handle high-volume streams efficiently:
+When you start a stream, the `PathResolver` determines where the output file lives:
 
-```yaml
-streaming:
-  buffer:
-    max_size: 10MB          # Maximum buffer size per stream
-    max_lines: 10000        # Maximum lines to keep
-    cleanup_threshold: 80   # Cleanup when buffer reaches 80%
-    compression: true       # Compress old buffer data
-```
+1. It queries the SLURM API (via `slurmrestd`) for the job's `StdOut` and `StdErr` paths.
+2. If the API does not provide a path, it falls back to the job's working directory or the configured SLURM spool directory.
+3. It checks whether the file is on the local filesystem or on a remote compute node.
 
-### Stream Persistence
+### Local File Streaming
 
-Save streaming sessions:
+For files on a shared filesystem (the common HPC setup with NFS or Lustre), the `StreamManager` uses `fsnotify` to watch for file changes. When the output file is written to, new content is read from the last known offset and pushed to the viewer.
 
-```yaml
-streaming:
-  persistence:
-    enabled: true
-    base_dir: "~/.s9s/streams"
-    auto_save: true
-    max_files: 100
-```
+### Remote File Streaming (SSH)
 
-## Configuration
+When the output file is on a remote compute node that is not accessible via a shared filesystem, the `StreamManager` falls back to SSH-based polling:
 
-### Complete Streaming Configuration
+- It connects to the compute node using the configured SSH credentials.
+- It periodically runs `tail -c +<offset>` to fetch new content since the last read.
+- The default polling interval is 3 seconds.
 
-```yaml
-streaming:
-  # General settings
-  enabled: true
-  max_concurrent_streams: 20
-  default_buffer_size: 1MB
-  refresh_interval: 100ms
+If a local file watch fails because the file does not exist locally but a compute node is assigned to the job, the manager automatically falls back to SSH polling.
 
-  # File-based streaming
-  file_paths:
-    base_dir: "/shared/slurm/logs"
-    stdout_pattern: "slurm-%j.out"
-    stderr_pattern: "slurm-%j.err"
-    custom_patterns:
-      - "/nfs/logs/job_%j/*.log"
-      - "/tmp/slurm_%j_*.out"
+### Circular Buffer
 
-  # SSH streaming
-  ssh:
-    enabled: true
-    timeout: 30s
-    max_connections: 5
-    retry_attempts: 3
-    key_file: "~/.ssh/id_rsa"
+Each active stream maintains a `CircularBuffer` (default capacity: 10,000 lines) to store recent output efficiently. When the buffer reaches capacity, the oldest lines are discarded. This keeps memory usage bounded regardless of how much output a job produces.
 
-  # SLURM API streaming
-  slurm_api:
-    enabled: false
-    chunk_size: 8KB
-    poll_interval: 1s
+### Event Bus
 
-  # Filters
-  filters:
-    - name: "errors"
-      pattern: "(?i)error|fail|exception|fatal"
-      action: "highlight"
-      color: "red"
-    - name: "warnings"
-      pattern: "(?i)warn|warning"
-      action: "highlight"
-      color: "yellow"
-    - name: "progress"
-      pattern: "\\d+(\\.\\d+)?%|progress:"
-      action: "highlight"
-      color: "green"
+The streaming system uses an internal `EventBus` for pub/sub event delivery. The Job Output Viewer subscribes to events for the active job and output type. Events include:
 
-  # Buffer management
-  buffer:
-    max_size_per_stream: 10MB
-    max_total_size: 100MB
-    max_lines: 50000
-    cleanup_interval: 5m
+- `NEW_OUTPUT` -- new content available.
+- `JOB_COMPLETE` -- the job has finished.
+- `ERROR` -- a streaming error occurred.
+- `STREAM_START` / `STREAM_STOP` -- lifecycle events.
 
-  # Persistence
-  persistence:
-    enabled: true
-    directory: "~/.s9s/stream_history"
-    max_files: 50
-    max_file_size: 100MB
-    auto_cleanup_days: 7
-```
+## Export
+
+From the Job Output Viewer, press `e` to export the currently displayed output. Supported formats:
+
+- **Text** -- plain text with a header.
+- **JSON** -- structured output with metadata.
+- **CSV** -- line-by-line for analysis.
+- **Markdown** -- output in fenced code blocks.
+
+Exported files are saved to `~/slurm_exports/` by default.
 
 ## Troubleshooting
 
-### Common Issues
+### No output appears
 
-#### Stream Not Starting
+- Verify the job is running and has started writing output. Check with `scontrol show job <id> | grep StdOut`.
+- Confirm the output file exists and is readable: `ls -la <path>`.
+- If the file is on a remote node, verify SSH connectivity: `ssh <node> cat <path>`.
 
-**Symptoms**: No output appears when streaming
+### Streaming says "not available"
 
-**Causes**: File not found, permission issues, job not started
+- Check that `features.streaming: true` is set in your configuration.
+- Ensure the `StreamManager` was initialized at startup (check debug logs with `s9s --debug`).
 
-**Solutions**:
-```bash
-# Check if job output files exist
-scontrol show job 123 | grep StdOut
+### SSH streaming is slow or failing
 
-# Verify file permissions
-ls -la /path/to/job_output.out
-
-# Check SSH connectivity
-ssh node001 tail -f /tmp/job_123.out
-```
-
-#### High CPU/Memory Usage
-
-**Symptoms**: s9s consuming excessive resources
-
-**Causes**: Too many streams, large buffers, inefficient filtering
-
-**Solutions**:
-```yaml
-streaming:
-  max_concurrent_streams: 5    # Reduce concurrent streams
-  buffer:
-    max_size_per_stream: 1MB   # Smaller buffers
-  refresh_interval: 500ms      # Slower refresh rate
-```
-
-#### SSH Connection Failures
-
-**Symptoms**: "Connection refused" or timeout errors
-
-**Causes**: SSH not configured, firewall, authentication issues
-
-**Solutions**:
-```bash
-# Test SSH connectivity
-ssh -o ConnectTimeout=10 node001 echo "test"
-
-# Configure SSH keys
-ssh-copy-id node001
-
-# Update SSH config
-cat >> ~/.ssh/config << 'EOF'
-Host node*
-    StrictHostKeyChecking no
-    ConnectTimeout 30
-    ServerAliveInterval 60
-EOF
-```
-
-#### Missing Log Files
-
-**Symptoms**: "File not found" errors
-
-**Causes**: Incorrect paths, job not writing output, timing issues
-
-**Solutions**:
-```bash
-# Check SLURM output configuration
-scontrol show config | grep SlurmdLogFile
-
-# Verify job script output redirection
-cat job_script.sh | grep -E "(>|>>)"
-
-# Use custom path patterns
-s9s stream --job 123 --path "/custom/path/job_%j.log"
-```
-
-### Debug Mode
-
-Enable detailed logging for troubleshooting:
-
-```bash
-# Enable streaming debug
-export S9S_STREAMING_DEBUG=true
-s9s --debug
-
-# View streaming logs
-tail -f ~/.s9s/debug.log | grep STREAM
-```
-
-## Performance Optimization
-
-### For High-Volume Logs
-
-```yaml
-streaming:
-  # Larger buffers for efficiency
-  buffer:
-    max_size_per_stream: 50MB
-    max_lines: 100000
-
-  # Batch updates
-  refresh_interval: 200ms
-
-  # Compression
-  compression:
-    enabled: true
-    algorithm: "gzip"
-    level: 6
-```
-
-### For Many Streams
-
-```yaml
-streaming:
-  # Connection pooling
-  ssh:
-    connection_pooling: true
-    max_idle_connections: 10
-
-  # Efficient polling
-  file_polling:
-    use_inotify: true
-    batch_size: 100
-
-  # Resource limits
-  max_concurrent_streams: 10
-  memory_limit: 500MB
-```
-
-### For Slow Networks
-
-```yaml
-streaming:
-  # Larger chunks
-  ssh:
-    chunk_size: 64KB
-
-  # Compression
-  compression:
-    enabled: true
-
-  # Slower refresh
-  refresh_interval: 1s
-```
-
-## Integration Examples
-
-### With Monitoring Tools
-
-```bash
-# Export streaming metrics
-s9s stream --job 123 --export-metrics prometheus://localhost:9090
-
-# Forward to syslog
-s9s stream --job 123 --forward syslog://logserver:514
-```
-
-### With Alerting
-
-```yaml
-streaming:
-  alerts:
-    - pattern: "(?i)error|exception|fatal"
-      action: "webhook"
-      url: "https://alerts.example.com/webhook"
-    - pattern: "(?i)completed successfully"
-      action: "notification"
-      type: "success"
-```
-
-### Scripting Integration
-
-```bash
-#!/bin/bash
-# Start streaming and process output
-s9s stream --job $JOB_ID --output-format json | \
-jq -r '.content' | \
-while IFS= read -r line; do
-    if [[ $line == *"ERROR"* ]]; then
-        echo "Alert: $line" | mail -s "Job Error" admin@example.com
-    fi
-done
-```
-
-## API Reference
-
-### Streaming API
-
-```go
-// Start streaming a job
-manager.StartStream(jobID, "stdout")
-
-// Add filter
-manager.AddFilter("errors", "ERROR|FAIL")
-
-// Get stream data
-events := manager.GetStream(jobID)
-for event := range events {
-    fmt.Printf("%s: %s\n", event.Timestamp, event.Content)
-}
-```
-
-### Event Types
-
-```go
-type StreamEvent struct {
-    JobID     string    `json:"job_id"`
-    Type      string    `json:"type"`      // "stdout", "stderr"
-    Content   string    `json:"content"`
-    Timestamp time.Time `json:"timestamp"`
-    LineNum   int       `json:"line_num"`
-    Source    string    `json:"source"`    // "file", "ssh", "api"
-}
-```
+- The default SSH polling interval is 3 seconds. This is intentional to avoid overloading compute nodes.
+- Verify SSH key-based authentication is configured for the compute nodes.
+- Check that the SSH user has read access to the output file.
 
 ## Related Guides
 
-- [Configuration Guide](../CONFIGURATION.md)
-- [SSH Integration](./ssh-guide.md)
-- [Performance Analysis](./performance-analysis.md)
+- [Configuration Guide](../getting-started/configuration.md)

--- a/docs/plugins/development.md
+++ b/docs/plugins/development.md
@@ -8,10 +8,9 @@ This guide provides comprehensive instructions for developing plugins for the s9
 - [Plugin Architecture](#plugin-architecture)
 - [Project Structure](#project-structure)
 - [Basic Plugin Implementation](#basic-plugin-implementation)
-- [Adding Custom Commands](#adding-custom-commands)
 - [Creating Custom Views](#creating-custom-views)
-- [Custom Key Bindings](#custom-key-bindings)
-- [Event Handling](#event-handling)
+- [Creating Overlay Plugins](#creating-overlay-plugins)
+- [Event Handling with Hooks](#event-handling-with-hooks)
 - [Building Plugins](#building-plugins)
 - [Installation](#installation)
 - [Testing](#testing)
@@ -23,11 +22,11 @@ This guide provides comprehensive instructions for developing plugins for the s9
 ## Overview
 
 The s9s plugin system allows you to:
-- Add custom views to the TUI
-- Implement new commands
-- Define custom key bindings
-- React to application events
-- Integrate with external systems
+- Add custom views to the TUI (via `ViewPlugin`)
+- Overlay additional data on existing views (via `OverlayPlugin`)
+- Provide data to other plugins (via `DataPlugin`)
+- React to lifecycle and configuration events (via `LifecycleAware`)
+- Integrate with external systems through hooks (via `HookablePlugin`)
 
 ## Plugin Architecture
 
@@ -35,17 +34,38 @@ Plugins are implemented as Go shared libraries (`.so` files) that implement the 
 
 ### Plugin Interface
 
+Every plugin must implement the base `Plugin` interface defined in `internal/plugin/interface.go`:
+
 ```go
 type Plugin interface {
-    GetInfo() PluginInfo
-    Initialize(ctx context.Context, client dao.SlurmClient) error
-    GetCommands() []Command
-    GetViews() []View
-    GetKeyBindings() []KeyBinding
-    OnEvent(event Event) error
-    Cleanup() error
+    // GetInfo returns metadata about the plugin
+    GetInfo() Info
+
+    // Init initializes the plugin with configuration
+    Init(ctx context.Context, config map[string]interface{}) error
+
+    // Start starts the plugin's background processes
+    Start(ctx context.Context) error
+
+    // Stop gracefully stops the plugin
+    Stop(ctx context.Context) error
+
+    // Health returns the current health status of the plugin
+    Health() HealthStatus
 }
 ```
+
+Plugins can also implement additional interfaces for extended functionality:
+
+- **`ViewPlugin`** -- provides custom TUI views (`GetViews()`, `CreateView()`)
+- **`OverlayPlugin`** -- adds data overlays to existing views (`GetOverlays()`, `CreateOverlay()`)
+- **`DataPlugin`** -- provides data to other plugins via pub/sub (`Subscribe()`, `Query()`)
+- **`ConfigurablePlugin`** -- supports runtime configuration changes (`GetConfig()`, `SetConfig()`, `ValidateConfig()`)
+- **`HookablePlugin`** -- provides hooks for event-driven integration (`GetHooks()`, `RegisterHook()`)
+- **`LifecycleAware`** -- receives lifecycle events (`OnEnable()`, `OnDisable()`, `OnConfigChange()`)
+- **`Prioritizable`** -- controls initialization order (`GetPriority()`)
+
+See `internal/plugin/interface.go` for the full interface definitions.
 
 ## Project Structure
 
@@ -68,79 +88,81 @@ package main
 
 import (
     "context"
-    "github.com/jontk/s9s/internal/dao"
-    "github.com/jontk/s9s/internal/plugins"
+    "github.com/jontk/s9s/internal/plugin"
 )
 
 type MyPlugin struct {
-    client dao.SlurmClient
+    config map[string]interface{}
 }
 
 // Entry point - must be exported
-func NewPlugin() plugins.Plugin {
+func NewPlugin() plugin.Plugin {
     return &MyPlugin{}
 }
 
-func (p *MyPlugin) GetInfo() plugins.PluginInfo {
-    return plugins.PluginInfo{
+func (p *MyPlugin) GetInfo() plugin.Info {
+    return plugin.Info{
         Name:        "my-plugin",
         Version:     "1.0.0",
         Description: "My custom s9s plugin",
         Author:      "Your Name",
-        Website:     "https://example.com",
+        License:     "MIT",
+        Provides:    []string{"my-capability"},
+        ConfigSchema: map[string]plugin.ConfigField{
+            "api_key": {
+                Type:        "string",
+                Description: "API key for external service",
+                Required:    true,
+            },
+        },
     }
 }
 
-func (p *MyPlugin) Initialize(ctx context.Context, client dao.SlurmClient) error {
-    p.client = client
+func (p *MyPlugin) Init(ctx context.Context, config map[string]interface{}) error {
+    p.config = config
     return nil
 }
 
-func (p *MyPlugin) GetCommands() []plugins.Command {
-    return []plugins.Command{}
-}
-
-func (p *MyPlugin) GetViews() []plugins.View {
-    return []plugins.View{}
-}
-
-func (p *MyPlugin) GetKeyBindings() []plugins.KeyBinding {
-    return []plugins.KeyBinding{}
-}
-
-func (p *MyPlugin) OnEvent(event plugins.Event) error {
+func (p *MyPlugin) Start(ctx context.Context) error {
+    // Start background processes
     return nil
 }
 
-func (p *MyPlugin) Cleanup() error {
+func (p *MyPlugin) Stop(ctx context.Context) error {
+    // Clean up resources
     return nil
 }
-```
 
-## Adding Custom Commands
-
-Extend the `GetCommands()` method to provide custom commands:
-
-```go
-func (p *MyPlugin) GetCommands() []plugins.Command {
-    return []plugins.Command{
-        {
-            Name:        "status",
-            Description: "Show custom status information",
-            Usage:       "status [options]",
-            Handler: func(args []string) error {
-                // Your command logic here
-                fmt.Println("Custom status command executed")
-                return nil
-            },
-        },
+func (p *MyPlugin) Health() plugin.HealthStatus {
+    return plugin.HealthStatus{
+        Healthy: true,
+        Status:  "healthy",
+        Message: "Plugin is running normally",
     }
 }
 ```
 
 ## Creating Custom Views
 
+Implement the `ViewPlugin` interface to add custom views to the TUI. Your plugin must implement both `Plugin` and `ViewPlugin`.
+
+### ViewPlugin Interface
+
+```go
+type ViewPlugin interface {
+    Plugin
+
+    // GetViews returns the views provided by this plugin
+    GetViews() []ViewInfo
+
+    // CreateView creates a specific view instance
+    CreateView(ctx context.Context, viewID string) (View, error)
+}
+```
+
 ### View Structure
+
+Each view must implement the `View` interface:
 
 ```go
 type MyView struct {
@@ -148,14 +170,14 @@ type MyView struct {
 }
 
 func (v *MyView) GetName() string {
-    return "myview"
-}
-
-func (v *MyView) GetTitle() string {
     return "My Custom View"
 }
 
-func (v *MyView) Render() tview.Primitive {
+func (v *MyView) GetID() string {
+    return "my-view"
+}
+
+func (v *MyView) GetPrimitive() tview.Primitive {
     if v.content == nil {
         v.content = tview.NewTextView()
         v.content.SetBorder(true).SetTitle("My Plugin View")
@@ -164,73 +186,85 @@ func (v *MyView) Render() tview.Primitive {
     return v.content
 }
 
-func (v *MyView) OnKey(event *tcell.EventKey) *tcell.EventKey {
+func (v *MyView) Update(ctx context.Context) error {
+    // Refresh the view data
+    return nil
+}
+
+func (v *MyView) HandleKey(event *tcell.EventKey) bool {
     switch event.Rune() {
-    case 'q':
-        return nil // Close view
     case 'r':
-        v.Refresh()
+        v.Update(context.Background())
+        return true
     }
-    return event
+    return false
 }
 
-func (v *MyView) Refresh() error {
-    // Update view content
-    return nil
+func (v *MyView) SetFocus(app *tview.Application) {
+    app.SetFocus(v.content)
 }
 
-func (v *MyView) Init(ctx context.Context) error {
-    return nil
+func (v *MyView) GetHelp() string {
+    return "r=Refresh"
 }
 ```
 
 ### Registering Views
 
 ```go
-func (p *MyPlugin) GetViews() []plugins.View {
-    return []plugins.View{
-        &MyView{},
-    }
-}
-```
-
-## Custom Key Bindings
-
-Define custom key bindings for your plugin:
-
-```go
-func (p *MyPlugin) GetKeyBindings() []plugins.KeyBinding {
-    return []plugins.KeyBinding{
+func (p *MyPlugin) GetViews() []plugin.ViewInfo {
+    return []plugin.ViewInfo{
         {
-            Key:         'M',
-            Modifiers:   tcell.ModCtrl,
-            Description: "My custom action",
-            Handler: func() error {
-                // Your key binding logic
-                return nil
-            },
+            ID:          "my-view",
+            Name:        "My Custom View",
+            Description: "Displays custom information",
+            Icon:        "M",
+            Shortcut:    "Ctrl+M",
+            Category:    "monitoring",
         },
     }
 }
+
+func (p *MyPlugin) CreateView(ctx context.Context, viewID string) (plugin.View, error) {
+    if viewID == "my-view" {
+        return &MyView{}, nil
+    }
+    return nil, fmt.Errorf("unknown view: %s", viewID)
+}
 ```
 
-## Event Handling
+## Creating Overlay Plugins
 
-Respond to application events:
+Overlays add columns or modify data in existing views without replacing them. Implement the `OverlayPlugin` interface:
 
 ```go
-func (p *MyPlugin) OnEvent(event plugins.Event) error {
-    switch event.Type {
-    case plugins.EventJobSubmitted:
-        // React to job submission
-        jobData := event.Data.(JobData)
-        fmt.Printf("Job %s submitted\n", jobData.ID)
+type OverlayPlugin interface {
+    Plugin
 
-    case plugins.EventViewChanged:
-        // React to view changes
-        viewName := event.Data.(string)
-        fmt.Printf("Switched to view: %s\n", viewName)
+    GetOverlays() []OverlayInfo
+    CreateOverlay(ctx context.Context, overlayID string) (Overlay, error)
+}
+```
+
+Each overlay can define additional columns and provide cell data and styling for rows in target views.
+
+## Event Handling with Hooks
+
+Use the `HookablePlugin` interface to provide hooks that other plugins or the application can subscribe to:
+
+```go
+func (p *MyPlugin) GetHooks() []plugin.HookInfo {
+    return []plugin.HookInfo{
+        {
+            ID:          "on-metric-update",
+            Name:        "Metric Update",
+            Description: "Triggered when new metrics are collected",
+        },
     }
+}
+
+func (p *MyPlugin) RegisterHook(hookID string, callback plugin.HookCallback) error {
+    // Store and call the callback when the hook fires
     return nil
 }
 ```
@@ -291,13 +325,9 @@ plugins:
 
 ### Loading at Runtime
 
-```bash
-# Enable plugins
-s9s --plugins
+Plugins are loaded automatically from the configured directory when s9s starts with `plugins.enabled: true`. There are no CLI flags for loading individual plugins at this time.
 
-# Load specific plugin
-s9s --plugin my-plugin
-```
+> **Note:** See [#119](https://github.com/jontk/s9s/issues/119) for planned plugin CLI commands.
 
 ## Testing
 
@@ -307,56 +337,54 @@ s9s --plugin my-plugin
 // +build plugin
 
 func TestMyPlugin(t *testing.T) {
-    plugin := &MyPlugin{}
+    p := &MyPlugin{}
 
     // Test plugin info
-    info := plugin.GetInfo()
+    info := p.GetInfo()
     assert.Equal(t, "my-plugin", info.Name)
+    assert.NotEmpty(t, info.Version)
+    assert.NotEmpty(t, info.Description)
 
     // Test initialization
     ctx := context.Background()
-    err := plugin.Initialize(ctx, nil)
+    err := p.Init(ctx, map[string]interface{}{"api_key": "test"})
     assert.NoError(t, err)
 
-    // Test commands
-    commands := plugin.GetCommands()
-    assert.Len(t, commands, 1)
+    // Test start/stop lifecycle
+    err = p.Start(ctx)
+    assert.NoError(t, err)
+
+    health := p.Health()
+    assert.True(t, health.Healthy)
+
+    err = p.Stop(ctx)
+    assert.NoError(t, err)
 }
 ```
 
 ### Integration Testing
 
 ```bash
-# Build and test with s9s
-make build
-s9s --plugin ./my-plugin.so --mock
+# Build and install the plugin, then run s9s in mock mode
+make install
+s9s --mock
 ```
 
 ## Advanced Features
 
 ### SLURM Client Integration
 
-Access SLURM cluster information through the client:
+If your plugin needs access to SLURM data, accept a `dao.SlurmClient` via configuration or dependency injection during `Init()`:
 
 ```go
-func (p *MyPlugin) Initialize(ctx context.Context, client dao.SlurmClient) error {
-    p.client = client
-
-    // Access SLURM cluster information
-    info, err := client.ClusterInfo()
-    if err != nil {
-        return err
-    }
-
-    // Get job information
-    jobs, err := client.GetJobs()
-    if err != nil {
-        return err
-    }
-
+func (p *MyPlugin) Init(ctx context.Context, config map[string]interface{}) error {
+    // Configuration is passed as a map; extract what you need
+    p.config = config
     return nil
 }
 ```
+
+The plugin manager handles dependency resolution. Declare dependencies in your `Info.Requires` field to ensure required plugins are started first.
 
 ### SSH Integration
 
@@ -409,8 +437,8 @@ Always handle errors gracefully:
 
 ### 2. Resource Management
 
-- Clean up resources in the `Cleanup()` method
-- Cancel goroutines when plugin is unloaded
+- Clean up resources in the `Stop()` method
+- Cancel goroutines when plugin is stopped
 - Close file handles and network connections
 
 ### 3. Performance
@@ -438,25 +466,48 @@ Always handle errors gracefully:
 
 ### Monitoring Plugin
 
-This plugin displays custom metrics collected periodically:
+This plugin collects custom metrics periodically and exposes a view:
 
 ```go
 // Monitoring plugin that displays custom metrics
 type MonitoringPlugin struct {
-    client dao.SlurmClient
-    ticker *time.Ticker
+    ticker  *time.Ticker
     metrics map[string]interface{}
+    cancel  context.CancelFunc
 }
 
-func (p *MonitoringPlugin) Initialize(ctx context.Context, client dao.SlurmClient) error {
-    p.client = client
-    p.metrics = make(map[string]interface{})
+func (p *MonitoringPlugin) GetInfo() plugin.Info {
+    return plugin.Info{
+        Name:        "monitoring",
+        Version:     "1.0.0",
+        Description: "Collects and displays custom cluster metrics",
+        Author:      "Your Name",
+        Provides:    []string{"metrics"},
+    }
+}
 
-    // Start background metrics collection
+func (p *MonitoringPlugin) Init(ctx context.Context, config map[string]interface{}) error {
+    p.metrics = make(map[string]interface{})
+    return nil
+}
+
+func (p *MonitoringPlugin) Start(ctx context.Context) error {
+    ctx, p.cancel = context.WithCancel(ctx)
     p.ticker = time.NewTicker(30 * time.Second)
     go p.collectMetrics(ctx)
-
     return nil
+}
+
+func (p *MonitoringPlugin) Stop(ctx context.Context) error {
+    p.cancel()
+    if p.ticker != nil {
+        p.ticker.Stop()
+    }
+    return nil
+}
+
+func (p *MonitoringPlugin) Health() plugin.HealthStatus {
+    return plugin.HealthStatus{Healthy: true, Status: "healthy", Message: "OK"}
 }
 
 func (p *MonitoringPlugin) collectMetrics(ctx context.Context) {
@@ -465,31 +516,9 @@ func (p *MonitoringPlugin) collectMetrics(ctx context.Context) {
         case <-ctx.Done():
             return
         case <-p.ticker.C:
-            // Collect custom metrics
             p.updateMetrics()
         }
     }
-}
-```
-
-### Notification Plugin
-
-This plugin sends notifications for job events:
-
-```go
-// Plugin that sends notifications for job events
-type NotificationPlugin struct {
-    webhookURL string
-}
-
-func (p *NotificationPlugin) OnEvent(event plugins.Event) error {
-    switch event.Type {
-    case plugins.EventJobCompleted:
-        return p.sendNotification("Job completed", event.Data)
-    case plugins.EventNodeStateChanged:
-        return p.sendNotification("Node state changed", event.Data)
-    }
-    return nil
 }
 ```
 
@@ -510,34 +539,33 @@ func (p *NotificationPlugin) OnEvent(event plugins.Event) error {
 **Runtime panics**
 - Add proper error handling and validation
 - Test with mock data before integration
-- Check goroutine cleanup in Cleanup()
+- Check goroutine cleanup in Stop()
 
 **Memory leaks**
-- Implement proper cleanup in `Cleanup()` method
-- Cancel all goroutines on cleanup
+- Implement proper cleanup in `Stop()` method
+- Cancel all goroutines on stop
 - Close all file handles and connections
 
 ### Debugging
 
-Enable debug logging and validation:
+Enable debug logging to troubleshoot plugin loading issues:
 
 ```bash
 # Enable debug logging
-s9s --debug --plugin ./my-plugin.so
-
-# Check plugin loading
-s9s --list-plugins
-
-# Validate plugin
-s9s --validate-plugin ./my-plugin.so
+s9s --debug
 ```
+
+The plugin manager logs registration, initialization, start, stop, and health check events. Look for lines containing the plugin name in the debug output.
+
+> **Note:** See [#119](https://github.com/jontk/s9s/issues/119) for planned plugin CLI commands such as listing and validating plugins.
 
 ## API Reference
 
 For complete API documentation, see:
-- Plugin Interface: `/internal/plugins/interface.go`
+- Plugin Interface: `/internal/plugin/interface.go`
+- Plugin Manager: `/internal/plugin/manager.go`
+- Plugin Registry: `/internal/plugin/registry.go`
 - DAO Interface: `/internal/dao/interface.go`
-- Example Plugins: `/internal/plugins/examples/`
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Final docs audit findings — the last two files with inaccurate content.

### job-streaming.md (complete rewrite, -502/+284 lines)

The entire file documented a non-existent CLI streaming system:
- `s9s stream --job 123` command — doesn't exist
- `Ctrl+S` stream monitor — doesn't exist
- Multi-stream layout with `+`/`-` keys — doesn't exist
- Stream persistence, advanced filtering, Prometheus/syslog integration — doesn't exist

Replaced with accurate documentation of the actual implementation:
- Press `o` in Jobs view to open Job Output Viewer
- StreamManager with fsnotify file watching and SSH polling fallback
- Actual keybindings (`t` toggle, `a` auto-scroll, `s` switch stdout/stderr)
- `features.streaming: true` config flag
- Export formats (text, JSON, CSV, markdown)

### plugins/development.md (selective fixes)

- Update Plugin interface to match actual code (`GetInfo`, `Init`, `Start`, `Stop`, `Health`)
- Document all extended interfaces (`ViewPlugin`, `OverlayPlugin`, `DataPlugin`, etc.)
- Remove non-existent CLI flags (`--plugins`, `--list-plugins`, `--validate-plugin`)
- Fix import paths and code examples
- Link to #119 for planned features

## Context

This completes the comprehensive docs audit tracked in #117. All 20+ documentation files have now been reviewed and corrected.

## Test plan

- [ ] Job streaming guide accurately describes pressing `o` in Jobs view
- [ ] Plugin interface docs match `internal/plugin/interface.go`
- [ ] No references to non-existent CLI commands or flags