### PR TITLE
docs: final accuracy pass — fix all remaining inaccuracies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -486,7 +486,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Note**: Versions prior to 0.1.0 were in active development and did not follow semantic versioning.
 
-[Unreleased]: https://github.com/jontk/s9s/compare/v0.6.3...HEAD
+[Unreleased]: https://github.com/jontk/s9s/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/jontk/s9s/compare/v0.6.3...v0.7.0
 [0.6.3]: https://github.com/jontk/s9s/compare/v0.6.2...v0.6.3
 [0.6.2]: https://github.com/jontk/s9s/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/jontk/s9s/compare/v0.6.0...v0.6.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ By participating in this project, you agree to abide by our Code of Conduct:
 
 ### Prerequisites
 
-- Go 1.19 or higher
+- Go 1.24 or higher
 - Git
 - Make (optional but recommended)
 - golangci-lint (for linting)
@@ -63,7 +63,7 @@ By participating in this project, you agree to abide by our Code of Conduct:
 
 5. **Run the application in mock mode**
    ```bash
-   go run cmd/s9s/main.go --mock
+   S9S_ENABLE_MOCK=1 go run cmd/s9s/main.go --mock
    ```
 
 ## 🔄 Development Process
@@ -209,7 +209,7 @@ refactor: simplify job filtering logic
 
 ## 🔍 Linting and Code Quality
 
-We use **golangci-lint** with 15 enabled linters to maintain code quality and consistency throughout the project.
+We use **golangci-lint** with 14 enabled linters to maintain code quality and consistency throughout the project.
 
 ### Quick Start
 
@@ -233,7 +233,7 @@ All pull requests are automatically checked by our CI/CD pipeline. **Linting fai
 - ✅ Branch protection requires lint check
 - ✅ Pre-commit hooks catch issues before push
 
-See [docs/CI_CD_SETUP.md](docs/CI_CD_SETUP.md) for complete CI/CD documentation including:
+See [docs/development/ci-cd.md](docs/development/ci-cd.md) for complete CI/CD documentation including:
 - How the linting gate works
 - Troubleshooting failed CI checks
 - Branch protection rule configuration
@@ -245,7 +245,7 @@ As of **PR #29**, we completed a comprehensive 3-phase systematic fix of revive 
 - **460 revive violations reduced to 36** (92% reduction)
 - All violations fixed except 36 backward-compatible type aliases
 - Full backward compatibility maintained throughout
-- See [docs/LINTING.md](docs/LINTING.md#revive-linter-improvements) for details
+- See [docs/development/linting.md](docs/development/linting.md#revive-linter-improvements) for details
 
 ### Enabled Linters
 
@@ -259,20 +259,16 @@ The linters are organized by category:
   - Improve code quality and catch common mistakes
   - Ensure HTTP resources are properly closed
 
-- **Security**: gosec (configured with exclusions)
-  - Security-focused static analysis
-  - Detects vulnerabilities and unsafe patterns
-
 - **Style & Patterns**: gocritic, unused, nolintlint, revive
   - Code style and pattern checks
   - Identifies dead code and unused suppressions
   - Enforces Go idioms (revive: package comments, exported symbols, naming conventions)
 
-- **Advanced**: gocognit, dupl
-  - Cognitive complexity checking (threshold: 30)
-  - Code duplication detection
+- **Advanced**: cyclop (max-complexity: 10), noctx
+  - Cyclomatic complexity checking
+  - Context propagation verification
 
-See [docs/LINTING.md](docs/LINTING.md) for complete linting standards, configuration details, and best practices.
+See [docs/development/linting.md](docs/development/linting.md) for complete linting standards, configuration details, and best practices.
 
 ### Pre-commit Hooks
 
@@ -297,7 +293,7 @@ The hooks automatically:
 - Tidy go.mod and go.sum
 - Run golangci-lint to check for violations
 
-See [docs/PRE_COMMIT_SETUP.md](docs/PRE_COMMIT_SETUP.md) for detailed pre-commit hook setup, usage, and troubleshooting guide.
+Pre-commit hooks are configured in `.pre-commit-config.yaml`. Run `pre-commit install` to set up.
 
 ### CI Requirements
 
@@ -327,7 +323,7 @@ var globalState int
 
 ```
 internal/views/jobs_test.go      # Unit tests for views
-pkg/slurm/mock_test.go          # Mock implementation tests
+pkg/slurm/mock.go               # Mock SLURM implementation
 test/integration/               # Integration tests
 test/performance/              # Performance benchmarks
 ```
@@ -528,10 +524,9 @@ Look for issues labeled:
 - [Go Documentation](https://golang.org/doc/)
 - [tview Documentation](https://github.com/rivo/tview/wiki)
 - [SLURM Documentation](https://slurm.schedmd.com/documentation.html)
-- [s9s Architecture](docs/ARCHITECTURE.md)
-- [CI/CD Setup & Linting Gate](docs/CI_CD_SETUP.md)
-- [Linting Standards](docs/LINTING.md)
-- [Pre-commit Hook Setup](docs/PRE_COMMIT_SETUP.md)
+- [s9s Architecture](docs/development/architecture.md)
+- [CI/CD Setup & Linting Gate](docs/development/ci-cd.md)
+- [Linting Standards](docs/development/linting.md)
 
 ## 🤝 Getting Help
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Press `:` to enter vim-style command mode with intelligent Tab completion:
 | `s` | Submit new job |
 | `b` | Batch operations |
 | `m` | Toggle auto-refresh |
-| `q` | Requeue job |
+| `q` | Requeue job (use `:requeue` if `q` quits) |
 | `e` | Export data |
 | `v` | Toggle multi-select mode |
 | `a` | Filter all states |

--- a/README.md
+++ b/README.md
@@ -79,10 +79,12 @@ go install github.com/jontk/s9s/cmd/s9s@latest
 ```bash
 git clone https://github.com/jontk/s9s.git
 cd s9s
-go build -o s9s cmd/s9s/main.go
+make build
 mkdir -p ~/.local/bin
-mv s9s ~/.local/bin/
+mv build/s9s ~/.local/bin/
 ```
+
+> **Note:** `go build -o s9s cmd/s9s/main.go` works but will not embed version info. Use `make build` to include version, commit, and build date via `-ldflags`.
 
 ### Basic Usage
 
@@ -90,8 +92,8 @@ mv s9s ~/.local/bin/
 # Connect to your SLURM cluster
 s9s
 
-# Use mock mode for testing (no SLURM required)
-s9s --mock
+# Use mock mode for testing (requires S9S_ENABLE_MOCK env var)
+S9S_ENABLE_MOCK=1 s9s --mock
 
 # Connect to a specific cluster
 s9s --cluster production
@@ -127,10 +129,11 @@ This configures your cluster endpoint and optional JWT token.
 #### Manual Configuration
 
 s9s looks for configuration in the following order:
-1. `~/.s9s/config.yaml`
-2. `~/.config/s9s/config.yaml`
-3. Environment variables
-4. Command-line flags
+1. `.` (current directory)
+2. `~/.s9s/config.yaml`
+3. `/etc/s9s/config.yaml`
+4. Environment variables
+5. Command-line flags
 
 Example configuration:
 
@@ -142,7 +145,7 @@ clusters:
   - name: production
     cluster:
       endpoint: "https://slurm-api.example.com:6820"
-      token: "${SLURM_TOKEN}"
+      token: "${SLURM_JWT}"
       apiVersion: v0.0.44
 
   - name: development
@@ -151,7 +154,7 @@ clusters:
       token: "${SLURM_DEV_TOKEN}"
       apiVersion: v0.0.43
 
-refreshRate: 5s
+refreshRate: 2s
 ```
 
 ## 🎮 Key Bindings
@@ -164,10 +167,9 @@ refreshRate: 5s
 | `q` | Quit |
 | `:` | Command mode |
 | `/` | Search/filter |
-| `e` | Export view data |
 | `Tab` | Switch view |
 | `Ctrl+K` | Switch cluster |
-| `F5` / `R` | Force refresh |
+| `F5` | Force refresh |
 
 #### Command Mode with Autocomplete
 
@@ -194,13 +196,20 @@ Press `:` to enter vim-style command mode with intelligent Tab completion:
 | Key | Action |
 |-----|--------|
 | `c` | Cancel job |
-| `h` | Hold job |
+| `H` | Hold job |
 | `r` | Release job |
-| `d` | Show job details |
+| `d` | Show job dependencies |
+| `Enter` | Show job details |
 | `o` | View job output |
 | `s` | Submit new job |
 | `b` | Batch operations |
 | `m` | Toggle auto-refresh |
+| `q` | Requeue job |
+| `e` | Export data |
+| `v` | Toggle multi-select mode |
+| `a` | Filter all states |
+| `p` | Filter pending jobs |
+| `u` | Filter by user |
 
 ### Nodes View
 
@@ -209,7 +218,12 @@ Press `:` to enter vim-style command mode with intelligent Tab completion:
 | `d` | Drain node |
 | `r` | Resume node |
 | `s` | SSH to node |
-| `i` | Node info |
+| `Enter` | Node details |
+| `i` | Filter idle nodes |
+| `m` | Filter mixed nodes |
+| `g` | Group by |
+| `e` | Export data |
+| `p` | Filter by partition |
 
 ## 🏗️ Architecture
 
@@ -219,15 +233,22 @@ s9s follows a modular architecture with clear separation of concerns:
 cmd/s9s/          # Main application entry point
 internal/
   ├── app/        # Application lifecycle management
-  ├── dao/        # Data Access Objects (SLURM client abstraction)
-  ├── views/      # Terminal UI views
+  ├── cli/        # CLI commands and flags
+  ├── auth/       # Authentication
   ├── config/     # Configuration management
-  ├── ui/         # UI components and utilities
+  ├── dao/        # Data Access Objects (SLURM client abstraction)
+  ├── debug/      # Debug utilities
+  ├── discovery/  # Cluster auto-discovery
+  ├── export/     # Export functionality
   ├── monitoring/ # Health monitoring and alerts
   ├── performance/# Performance profiling and optimization
-  └── plugins/    # Plugin system implementation
+  ├── plugin/     # Plugin interfaces (compile-time registration)
+  ├── plugins/    # Plugin system (.so loading)
+  ├── ssh/        # SSH integration
+  ├── ui/         # UI components and utilities
+  └── views/      # Terminal UI views
 pkg/
-  └── slurm/      # SLURM client and mock implementation
+  └── slurm/      # Mock SLURM implementation
 ```
 
 For more information about the project structure, see the [docs/](docs/) directory.
@@ -247,11 +268,11 @@ go mod download
 # Run tests
 go test ./...
 
-# Run with mock data
-go run cmd/s9s/main.go --mock
+# Run with mock data (requires S9S_ENABLE_MOCK env var)
+S9S_ENABLE_MOCK=1 go run cmd/s9s/main.go --mock
 
-# Build binary
-go build -o s9s cmd/s9s/main.go
+# Build binary (use make build for version info)
+make build
 ```
 
 ### Running Tests
@@ -277,13 +298,9 @@ Enable debug logging to troubleshoot issues:
 
 ```bash
 s9s --debug
-
-# Or set environment variable
-export S9S_DEBUG=true
-s9s
 ```
 
-Debug logs are written to `~/.s9s/debug.log`.
+Debug logs are written to `s9s-debug.log` in the current directory.
 
 ## 🤝 Contributing
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -12,7 +12,7 @@ Configurable job submission templates and full SLURM field support:
 
 - **Configurable Templates**: Define custom job templates in config YAML with pre-filled defaults, hidden fields, and restricted dropdown options
 - **3-Tier Template Merge**: Built-in, config YAML, and user-saved JSON templates merge with name-based override
-- **86 sbatch Fields**: Job submission wizard supports 86 of 117 SLURM fields (was 12) — fields like QoS, GPUs, array, constraints, dependencies now actually reach slurmrestd
+- **84 sbatch Fields**: Job submission wizard supports 84 of 117 SLURM fields (was 12) -- fields like QoS, GPUs, array, constraints, dependencies now actually reach slurmrestd
 - **Smart Field Visibility**: Advanced fields hidden by default, shown automatically when a template sets them
 - **CLI Template Management**: `s9s templates list` and `s9s templates export` commands for viewing and exporting templates
 - **SubmitRaw Integration**: Bypasses lossy intermediate struct, maps directly to SLURM OpenAPI `JobCreate`
@@ -60,7 +60,7 @@ Key features:
 - **Cluster Switcher**: Show active cluster name in header, press `Ctrl+K` to switch clusters at runtime
 - **`--cluster` Flag**: Select cluster context from the command line; fix `--config` flag being ignored
 - **Table Export**: Press `e` in any view to export data (CSV, JSON, Text, Markdown, HTML)
-- **VHS Integration Tests**: Regression testing against real Slurm clusters (24.05, 24.11, 25.11)
+- **VHS Integration Tests**: Regression testing against real Slurm clusters (24.05, 24.11, 25.05, 25.11)
 - **Breaking**: Config keys renamed `contexts` → `clusters`, `currentContext` → `defaultCluster`
 
 ### Version 0.5.0 (2026-02-18)
@@ -111,7 +111,8 @@ For a complete list of all changes, features, and fixes across all versions, ref
 
 ## Version History
 
-- [v0.6.3](../CHANGELOG.md#063---2026-03-14) - Latest release
+- [v0.7.0](../CHANGELOG.md#070---2026-03-16) - Latest release
+- [v0.6.3](../CHANGELOG.md#063---2026-03-14) - Performance and responsiveness
 - [v0.6.2](../CHANGELOG.md#062---2026-03-10) - Setup wizard fixes
 - [v0.6.1](../CHANGELOG.md#061---2026-03-09) - Node metrics, job times, dashboard fixes
 - [v0.6.0](../CHANGELOG.md#060---2026-03-08) - Cluster switcher, export, config rename

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-This page provides an overview of notable changes to the s9s project. For a complete and detailed changelog, please see the [full changelog](../CHANGELOG.md).
+This page provides an overview of notable changes to the s9s project. For a complete and detailed changelog, please see the [full changelog](../../CHANGELOG.md).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
@@ -107,20 +107,20 @@ Initial stable release with core features:
 
 ## Viewing the Full Changelog
 
-For a complete list of all changes, features, and fixes across all versions, refer to the [full CHANGELOG.md](../CHANGELOG.md).
+For a complete list of all changes, features, and fixes across all versions, refer to the [full CHANGELOG.md](../../CHANGELOG.md).
 
 ## Version History
 
-- [v0.7.0](../CHANGELOG.md#070---2026-03-16) - Latest release
-- [v0.6.3](../CHANGELOG.md#063---2026-03-14) - Performance and responsiveness
-- [v0.6.2](../CHANGELOG.md#062---2026-03-10) - Setup wizard fixes
-- [v0.6.1](../CHANGELOG.md#061---2026-03-09) - Node metrics, job times, dashboard fixes
-- [v0.6.0](../CHANGELOG.md#060---2026-03-08) - Cluster switcher, export, config rename
-- [v0.5.0](../CHANGELOG.md#050---2026-02-18) - Auto-discovery, static builds
-- [v0.4.0](../CHANGELOG.md#040---2026-02-08) - Performance view, sorting, command mode
-- [v0.3.0](../CHANGELOG.md#030---2026-01-30) - Vim navigation, search, filters
-- [v0.1.0](../CHANGELOG.md#010---2026-01-21) - Initial release
-- [Unreleased](../CHANGELOG.md#unreleased) - Upcoming changes
+- [v0.7.0](../../CHANGELOG.md#070---2026-03-16) - Latest release
+- [v0.6.3](../../CHANGELOG.md#063---2026-03-14) - Performance and responsiveness
+- [v0.6.2](../../CHANGELOG.md#062---2026-03-10) - Setup wizard fixes
+- [v0.6.1](../../CHANGELOG.md#061---2026-03-09) - Node metrics, job times, dashboard fixes
+- [v0.6.0](../../CHANGELOG.md#060---2026-03-08) - Cluster switcher, export, config rename
+- [v0.5.0](../../CHANGELOG.md#050---2026-02-18) - Auto-discovery, static builds
+- [v0.4.0](../../CHANGELOG.md#040---2026-02-08) - Performance view, sorting, command mode
+- [v0.3.0](../../CHANGELOG.md#030---2026-01-30) - Vim navigation, search, filters
+- [v0.1.0](../../CHANGELOG.md#010---2026-01-21) - Initial release
+- [Unreleased](../../CHANGELOG.md#unreleased) - Upcoming changes
 
 ## Semantic Versioning
 

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -93,13 +93,16 @@ Views implement the UI for different resources:
 - **PartitionsView**: Partition information
 - **Additional Views**: Users, QoS, Reservations, etc.
 
-Key interfaces:
+Key interfaces (see `internal/views/base.go` for full definition):
 ```go
 type View interface {
     Name() string
-    Title() string
-    SetupView() tview.Primitive
     Refresh() error
+    OnKey(event *tcell.EventKey) *tcell.EventKey
+    OnFocus() error
+    OnLoseFocus() error
+    Hints() []string
+    // ... and more
 }
 ```
 
@@ -177,22 +180,15 @@ func NewJobsView(client dao.SlurmClient) *JobsView {
 }
 ```
 
-### Observer Pattern
-
-Views can subscribe to refresh events:
-```go
-type RefreshObserver interface {
-    OnRefresh() error
-}
-```
-
 ### Command Pattern
 
-User actions are encapsulated as commands:
+Commands are represented as structs (see `internal/plugins/interface.go`):
 ```go
-type Command interface {
-    Execute() error
-    Undo() error
+type Command struct {
+    Name        string
+    Description string
+    Usage       string
+    Handler     func(args []string) error
 }
 ```
 
@@ -377,15 +373,32 @@ type MockTimeProvider struct {
 
 ## Extension Points
 
-### Plugin System (Planned)
+### Plugin System (Implemented)
 
+s9s has two plugin systems:
+
+**Compile-time registration** (`internal/plugin/interface.go`):
 ```go
 type Plugin interface {
-    Name() string
-    Version() string
-    Init(api PluginAPI) error
-    RegisterCommands() []Command
-    RegisterViews() []View
+    GetInfo() Info
+    Init(ctx context.Context, config map[string]interface{}) error
+    Start(ctx context.Context) error
+    Stop(ctx context.Context) error
+    Health() HealthStatus
+}
+```
+With specialized interfaces: `ViewPlugin`, `OverlayPlugin`, `DataPlugin`, `ConfigurablePlugin`, `HookablePlugin`.
+
+**Shared library loading** (`internal/plugins/interface.go`):
+```go
+type Plugin interface {
+    GetInfo() PluginInfo
+    Initialize(ctx context.Context, client dao.SlurmClient) error
+    GetCommands() []Command
+    GetViews() []View
+    GetKeyBindings() []KeyBinding
+    OnEvent(event Event) error
+    Cleanup() error
 }
 ```
 
@@ -411,11 +424,10 @@ type Exporter interface {
 
 ### Planned Improvements
 
-1. **Plugin System**: Dynamic loading of extensions
-2. **Event Bus**: Decoupled component communication
-3. **State Store**: Centralized state management
-4. **API Gateway**: Multiple backend support
-5. **Metrics Collection**: Performance monitoring
+1. **Event Bus**: Decoupled component communication
+2. **State Store**: Centralized state management
+3. **API Gateway**: Multiple backend support
+4. **Metrics Collection**: Performance monitoring
 
 ### Scalability
 

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -75,9 +75,11 @@ The entry point of the application that:
 ```go
 // cmd/s9s/main.go
 func main() {
-    app := app.New()
-    if err := app.Run(); err != nil {
-        log.Fatal(err)
+    logging.Init(logging.DefaultConfig())
+    logger := logging.GetLogger()
+    if err := cli.Execute(); err != nil {
+        logger.Error().Err(err).Msg("Failed to execute command")
+        os.Exit(1)
     }
 }
 ```
@@ -223,17 +225,22 @@ Error Occurs -> Log Error -> User-Friendly Message -> Status Bar Display -> Opti
 
 ```go
 type Config struct {
-    Clusters      map[string]*ClusterConfig
-    Preferences   *UserPreferences
-    Debug         bool
-    LogFile       string
+    RefreshRate    string
+    MaxRetries     int
+    DefaultCluster string
+    Clusters       []ClusterContext
+    UI             UIConfig
+    Views          ViewsConfig
+    Features       FeaturesConfig
+    UseMockClient  bool
 }
 
-type ClusterConfig struct {
-    URL           string
-    Auth          AuthConfig
-    Timeout       time.Duration
-    RetryAttempts int
+type ClusterContext struct {
+    Endpoint   string
+    Token      string
+    APIVersion string
+    Insecure   bool
+    Timeout    string
 }
 ```
 
@@ -411,14 +418,7 @@ Developers can add custom views by:
 
 ### Export Formats
 
-New export formats can be added by implementing:
-```go
-type Exporter interface {
-    Export(data interface{}, writer io.Writer) error
-    FileExtension() string
-    MimeType() string
-}
-```
+The export package uses concrete types rather than a shared interface. The main exporters are `TableExporter`, `PerformanceExporter`, and `JobOutputExporter`. New export formats can be added by creating a new concrete exporter type in the export package following the patterns established by these existing types.
 
 ## Future Architectural Considerations
 

--- a/docs/development/ci-cd.md
+++ b/docs/development/ci-cd.md
@@ -269,7 +269,7 @@ pre-commit install
 # - golangci-lint (full linting)
 ```
 
-See `.pre-commit-config.yaml` in the repository root for detailed setup guide.
+Note: A `.pre-commit-config.yaml` file is not currently included in the repository. The pre-commit hooks above should be set up manually using the commands shown.
 
 ### Manual Testing
 

--- a/docs/development/ci-cd.md
+++ b/docs/development/ci-cd.md
@@ -16,9 +16,9 @@ This document explains the s9s CI/CD pipeline, linting enforcement, and how to c
 
 The s9s project uses GitHub Actions to enforce code quality standards automatically. Every pull request is checked for:
 
-1. **Code Style & Quality** - golangci-lint validates 15+ code quality rules
+1. **Code Style & Quality** - golangci-lint validates 14 code quality rules
 2. **Unit Tests** - Tested on Go 1.23 and 1.24
-3. **Build Verification** - Ensures code compiles for 6 platform combinations
+3. **Build Verification** - Ensures code compiles for 5 platform combinations
 4. **Security** - Trivy and gosec security scanners detect vulnerabilities
 
 All checks must pass before code can be merged to main.
@@ -35,7 +35,7 @@ All checks must pass before code can be merged to main.
        ├─> ┌──────────────────────┐
        │   │  Lint Job (5-8 min)  │ <-- BLOCKS BUILD IF FAILS
        │   │ - golangci-lint      │
-       │   │ - 15 linters         │
+       │   │ - 14 linters         │
        │   └──────────┬───────────┘
        │              │
        ├─> ┌──────────v────────────┐
@@ -74,17 +74,18 @@ jobs:
     - uses: actions/setup-go@v5
       with:
         go-version: '1.24'
-    - name: Install golangci-lint
-      run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.3.0
     - name: Run golangci-lint
-      run: golangci-lint run --timeout 10m
+      uses: golangci/golangci-lint-action@v9
+      with:
+        version: v2.8.0
+        args: --timeout 10m
 ```
 
 **What this does**:
 - Checks out your code
 - Sets up Go 1.24 environment
-- Installs golangci-lint v2.3.0
-- Runs all 15 enabled linters with 10-minute timeout
+- Installs golangci-lint v2.8.0 via GitHub Action
+- Runs all enabled linters with 10-minute timeout
 - Fails the job if ANY linting violation is found
 
 #### Build Job Dependencies
@@ -121,8 +122,8 @@ The CI enforces the same linters as `.golangci.yml`:
 - `revive` - Go idioms enforcement
 
 **Advanced**:
-- `gocognit` - Cognitive complexity (threshold: 50)
-- `dupl` - Code duplication (threshold: 150 lines)
+- `cyclop` - Cyclomatic complexity (max: 10)
+- `noctx` - Context propagation
 
 See `.golangci.yml` and [Linting Standards](linting.md) for complete configuration.
 
@@ -268,7 +269,7 @@ pre-commit install
 # - golangci-lint (full linting)
 ```
 
-See [docs/PRE_COMMIT_SETUP.md](../../docs/PRE_COMMIT_SETUP.md) for detailed setup guide.
+See `.pre-commit-config.yaml` in the repository root for detailed setup guide.
 
 ### Manual Testing
 
@@ -409,7 +410,7 @@ return fmt.Errorf("failed operation: %w", err)
 **Problem**: `golangci-lint run` passes locally but fails in CI
 
 **Causes**:
-- Different golangci-lint version (CI uses v2.3.0)
+- Different golangci-lint version (CI uses v2.8.0)
 - Different Go version (CI uses 1.24, you might have 1.23)
 - Incomplete module cache
 
@@ -419,8 +420,8 @@ return fmt.Errorf("failed operation: %w", err)
 # 1. Check your local version
 golangci-lint version
 
-# 2. If different from v2.3.0, install correct version
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.3.0
+# 2. If different from v2.8.0, install correct version
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.8.0
 
 # 3. Update Go modules
 go mod tidy
@@ -538,7 +539,7 @@ See [Linting Standards](linting.md#using-nolint-directives) for complete guideli
 
 - [CONTRIBUTING.md](contributing.md) - Contribution guidelines and setup
 - [LINTING.md](linting.md) - Linting standards and rules
-- [PRE_COMMIT_SETUP.md](../../docs/PRE_COMMIT_SETUP.md) - Pre-commit hook configuration
+- `.pre-commit-config.yaml` - Pre-commit hook configuration
 - [.golangci.yml](../../.golangci.yml) - Linting configuration
 - [.github/workflows/ci.yml](../../.github/workflows/ci.yml) - CI/CD workflow
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -222,6 +222,8 @@ make lint
 make fmt
 
 # Install pre-commit hooks (recommended)
+# Note: .pre-commit-config.yaml is not currently included in the repository.
+# This step will work once the configuration file is added to the project.
 pre-commit install
 ```
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -28,7 +28,7 @@ By participating in this project, you agree to abide by our Code of Conduct:
 
 ### Prerequisites
 
-- Go 1.19 or higher
+- Go 1.24 or higher
 - Git
 - Make (optional but recommended)
 - golangci-lint (for linting)
@@ -64,7 +64,7 @@ By participating in this project, you agree to abide by our Code of Conduct:
 
 5. **Run the application in mock mode**
    ```bash
-   go run cmd/s9s/main.go --mock
+   S9S_ENABLE_MOCK=1 go run cmd/s9s/main.go --mock
    ```
 
 ## Development Process
@@ -210,7 +210,7 @@ refactor: simplify job filtering logic
 
 ## Linting and Code Quality
 
-We use **golangci-lint** with 15 enabled linters to maintain code quality and consistency throughout the project.
+We use **golangci-lint** with 14 enabled linters to maintain code quality and consistency throughout the project.
 
 ### Quick Start
 
@@ -248,18 +248,14 @@ The linters are organized by category:
   - Improve code quality and catch common mistakes
   - Ensure HTTP resources are properly closed
 
-- **Security**: gosec (configured with exclusions)
-  - Security-focused static analysis
-  - Detects vulnerabilities and unsafe patterns
-
 - **Style & Patterns**: gocritic, unused, nolintlint, revive
   - Code style and pattern checks
   - Identifies dead code and unused suppressions
   - Enforces Go idioms
 
-- **Advanced**: gocognit, dupl
-  - Cognitive complexity checking
-  - Code duplication detection
+- **Advanced**: cyclop (max-complexity: 10), noctx
+  - Cyclomatic complexity checking
+  - Context propagation verification
 
 See [Linting Standards](linting.md) for complete linting standards and configuration details.
 
@@ -286,7 +282,7 @@ The hooks automatically:
 - Tidy go.mod and go.sum
 - Run golangci-lint to check for violations
 
-See [PRE_COMMIT_SETUP.md](../../docs/PRE_COMMIT_SETUP.md) for detailed pre-commit hook setup.
+Pre-commit hooks are configured in `.pre-commit-config.yaml`. Run `pre-commit install` to set up.
 
 ### CI Requirements
 
@@ -316,7 +312,7 @@ var globalState int
 
 ```
 internal/views/jobs_test.go      # Unit tests for views
-pkg/slurm/mock_test.go          # Mock implementation tests
+pkg/slurm/mock.go               # Mock SLURM implementation
 test/integration/               # Integration tests
 test/performance/              # Performance benchmarks
 ```

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -85,7 +85,7 @@ golangci-lint run     # Detailed linting
 ```bash
 # See architecture.md#debugging-and-diagnostics
 s9s --debug           # Enable debug logging
-tail -f ~/.s9s/debug.log
+tail -f ./s9s-debug.log
 ```
 
 ## Document Overview
@@ -223,7 +223,7 @@ pre-commit install        # Install pre-commit hooks
 make fmt                  # Format code
 make lint                 # Run linter
 make build               # Build application
-go run cmd/s9s/main.go --mock  # Run in mock mode
+S9S_ENABLE_MOCK=1 go run cmd/s9s/main.go --mock  # Run in mock mode
 
 # Testing
 make test                # Run unit tests

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -150,7 +150,7 @@ Covers:
 
 Covers:
 - Linting philosophy and goals
-- 15 enabled linters with explanations
+- 14 enabled linters with explanations
 - Linter configuration in `.golangci.yml`
 - Running linters (make lint, manual execution)
 - Fixing lint issues by category
@@ -193,7 +193,7 @@ Covers:
 ### Code Quality Requirements
 - 80%+ test coverage for new code
 - All tests must pass before merge
-- Code must pass all 15 linters
+- Code must pass all 14 linters
 - Code must be formatted with gofumpt
 - Imports must be organized with goimports
 - go.mod must be tidy

--- a/docs/development/linting.md
+++ b/docs/development/linting.md
@@ -328,6 +328,8 @@ cmd := exec.CommandContext(ctx, "ssh-keygen", args...)
 
 ## Pre-commit Hooks
 
+> **Note:** The `.pre-commit-config.yaml` file is not currently included in the repository. This section describes planned configuration. You can set up pre-commit hooks manually or wait until the configuration file is added to the project.
+
 ### Installation
 
 Pre-commit hooks automatically run linting before each commit, preventing bad code from being committed:

--- a/docs/development/linting.md
+++ b/docs/development/linting.md
@@ -60,7 +60,7 @@ As of **PR #29**, we systematically fixed all revive linter violations through a
 
 ## Enabled Linters
 
-s9s uses **15 enabled linters** configured in `.golangci.yml`. They are organized by category:
+s9s uses **14 enabled linters** configured in `.golangci.yml`. They are organized by category:
 
 ### Core Linters
 
@@ -111,13 +111,6 @@ These improve code quality and catch common issues:
   - Similar to ineffassign but for different patterns
   - Helps identify unnecessary variables
 
-### Security Linters
-
-- **gosec** (configured): Security-focused static analysis
-  - Detects security vulnerabilities
-  - Checks for weak randomness, SQL injection, path traversal, etc.
-  - Configured with exclusions for accepted patterns
-
 ### Style and Pattern Linters
 
 - **gocritic**: Style and code pattern checks
@@ -144,15 +137,14 @@ These improve code quality and catch common issues:
 
 ### Advanced Linters
 
-- **gocognit**: Cognitive complexity checking
-  - Measures how difficult code is to understand
-  - Threshold: 30 (allows moderate complexity)
-  - Helps identify hard-to-understand code
+- **cyclop**: Cyclomatic complexity checking
+  - Measures cyclomatic complexity of functions
+  - Max complexity: 10 (with file-specific exclusions)
+  - Helps keep functions simple and testable
 
-- **dupl**: Code duplication detection
-  - Detects duplicated code blocks
-  - Threshold: 150 lines
-  - Helps identify abstraction opportunities
+- **noctx**: Context propagation checking
+  - Ensures context.Context is passed to HTTP requests
+  - Prevents missing context in API calls
 
 ## Linter Configuration
 
@@ -162,13 +154,11 @@ The `.golangci.yml` file contains our linter configuration with three main secti
 
 - **timeout**: 10m - Linting timeout (prevents hanging on large files)
 - **tests**: true - Include test files in linting
-- **skip-dirs**: Excludes vendor, .git, .github directories
+- **exclusions.paths**: Excludes vendor, .git, .github directories
 
 ### linters
 
-- **disable-all**: true - Start with all linters disabled, explicitly enable only those we want
-- **enable**: List of 15 enabled linters
-- **disable**: List of linters we deliberately don't use
+- **enable**: List of enabled linters (explicitly listed)
 
 ### linters-settings
 
@@ -180,10 +170,9 @@ Specific configuration for each linter:
 - **gocritic**: Enables diagnostic, performance, and style check tags
 - **errorlint**: Checks errorf with %w, type assertions, and error comparisons
 - **misspell**: US English locale
-- **gocognit**: Cognitive complexity minimum of 30
 - **nolintlint**: Validates nolint directives
 - **dupl**: Minimum 150 lines to consider as duplication
-- **containedctx**: Prevents context in struct fields
+- **cyclop**: Max complexity of 10 with file-specific exclusions
 
 ## Running Linters
 
@@ -195,9 +184,6 @@ make lint
 
 # Fix formatting issues (gofumpt and goimports)
 make fmt
-
-# Run all checks (lint + fmt)
-make check
 ```
 
 ### Manual golangci-lint Execution
@@ -394,26 +380,23 @@ If any hook fails, the commit is aborted. You must fix the issues and try again.
 
 Some linters are **disabled** because they require substantial refactoring or don't fit our project patterns.
 
-### cyclop - Cyclomatic Complexity
+### gosec - Security Analysis
 
 **Status**: Disabled
 
-**Reason**: Configuration issues and high issue count (136 violations)
+**Reason**: Exclusion rules not being respected by golangci-lint. All security issues are documented as acceptable. See `.golangci.yml` for details.
+
+### dupl - Code Duplication
+
+**Status**: Disabled
+
+**Reason**: 16 violations in UI code (views and layouts), acceptable duplication for UI patterns.
 
 ### containedctx - Context in Structs
 
 **Status**: Disabled
 
 **Reason**: Architectural pattern used throughout codebase (22+ instances)
-
-### gosec - Security Analysis
-
-**Status**: Enabled but heavily configured
-
-**Excluded rules**:
-- **G204**: exec.Command flagged as unsafe (false positive with safe arg separation)
-- **G304**: File inclusion via variable (acceptable for app-controlled paths)
-- **G115**: Integer overflow conversions (safe in metrics/test code)
 
 ## CI/CD Integration
 
@@ -545,7 +528,7 @@ git commit -m "fix: address linting issues"
 
 ## Summary
 
-Linting is essential for maintaining code quality in s9s. Our 15-linter configuration balances comprehensiveness with practicality. The key principles are:
+Linting is essential for maintaining code quality in s9s. Our 14-linter configuration balances comprehensiveness with practicality. The key principles are:
 
 1. **Automatic enforcement**: Pre-commit hooks catch issues before they're committed
 2. **Team consistency**: All developers use the same linting rules

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -13,7 +13,7 @@ This guide covers everything you need to set up your development environment for
 
 ### Go Installation
 
-1. **Go 1.19+**
+1. **Go 1.24 or higher**
    ```bash
    # Check version
    go version
@@ -23,8 +23,8 @@ This guide covers everything you need to set up your development environment for
    brew install go
 
    # Linux
-   wget https://go.dev/dl/go1.21.0.linux-amd64.tar.gz
-   sudo tar -C /usr/local -xzf go1.21.0.linux-amd64.tar.gz
+   wget https://go.dev/dl/go1.24.4.linux-amd64.tar.gz
+   sudo tar -C /usr/local -xzf go1.24.4.linux-amd64.tar.gz
    ```
 
 ### Development Tools
@@ -82,10 +82,7 @@ go install honnef.co/go/tools/cmd/staticcheck@latest
          "request": "launch",
          "mode": "debug",
          "program": "${workspaceFolder}/cmd/s9s",
-         "args": ["--mock", "--debug"],
-         "env": {
-           "S9S_DEBUG": "true"
-         }
+         "args": ["--mock", "--debug"]
        }
      ]
    }
@@ -96,7 +93,7 @@ go install honnef.co/go/tools/cmd/staticcheck@latest
 1. Open project as Go module
 2. Configure Run Configuration:
    - Program arguments: `--mock --debug`
-   - Environment: `S9S_DEBUG=true`
+   - Program arguments include `--debug`
 3. Enable Go modules support
 
 ## Development Workflow
@@ -199,8 +196,8 @@ make build
 # Install to $GOPATH/bin
 make install
 
-# Build for all platforms
-make build-all
+# Build for all platforms (Linux, macOS, Windows)
+make ci-build
 ```
 
 ### Manual Build
@@ -210,7 +207,7 @@ make build-all
 go build -o s9s cmd/s9s/main.go
 
 # Build with version info
-go build -ldflags "-X main.version=1.0.0 -X main.commit=$(git rev-parse HEAD)" \
+go build -ldflags "-X github.com/jontk/s9s/internal/version.Version=1.0.0 -X github.com/jontk/s9s/internal/version.Commit=$(git rev-parse HEAD)" \
   -o s9s cmd/s9s/main.go
 
 # Optimized build
@@ -236,14 +233,9 @@ GOOS=windows GOARCH=amd64 go build -o s9s-windows-amd64.exe cmd/s9s/main.go
 ### Running Mock Mode
 
 ```bash
-# Basic mock mode
+# Mock mode (requires S9S_ENABLE_MOCK=1)
+export S9S_ENABLE_MOCK=1
 s9s --mock
-
-# Customize mock data
-s9s --mock --mock-jobs 500 --mock-nodes 200
-
-# With specific scenarios
-S9S_MOCK_SCENARIO=high-load s9s --mock
 ```
 
 ### Extending Mock Data
@@ -270,28 +262,9 @@ func (m *MockClient) generateMockJobs(count int) {
 }
 ```
 
-### Mock Scenarios
+### Mock Data
 
-Create scenario in `pkg/slurm/mock_scenarios.go`:
-
-```go
-func (m *MockClient) LoadScenario(name string) {
-    switch name {
-    case "high-load":
-        m.generateMockJobs(10000)
-        m.generateMockNodes(500)
-
-    case "failing-jobs":
-        // Generate jobs that fail
-        for i := 0; i < 100; i++ {
-            m.AddJob(&dao.Job{
-                ID:    fmt.Sprintf("fail_%d", i),
-                State: dao.JobStateFailed,
-            })
-        }
-    }
-}
-```
+Mock data is generated in `pkg/slurm/mock.go`. The mock client simulates a SLURM cluster with realistic job and node data for development and testing.
 
 ## Troubleshooting
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -57,12 +57,12 @@ Integration tests verify component interactions and full workflows.
 make test-integration
 
 # Or manually
-go test -tags=integration ./test/integration
+go test -timeout 300s -v ./test/integration/...
 
 # With specific SLURM cluster
 SLURM_URL=https://test.example.com \
 SLURM_JWT=token123 \
-go test -tags=integration ./test/integration
+go test -timeout 300s -v ./test/integration/...
 ```
 
 ## Benchmarks
@@ -264,12 +264,10 @@ go test -short ./...
 
 ### CPU Profiling
 
-```bash
-# Run with CPU profiling
-go run cmd/s9s/main.go -cpuprofile=cpu.prof --mock
-go tool pprof cpu.prof
+Profiling is done via Go's standard `go test -bench` and `pprof` tools. The `-cpuprofile` and `-memprofile` flags are `go test` flags, not `go run` flags.
 
-# Or from tests
+```bash
+# CPU profiling from benchmarks
 go test -cpuprofile=cpu.prof -bench=. ./test/performance
 go tool pprof -http=:8080 cpu.prof
 ```
@@ -277,11 +275,7 @@ go tool pprof -http=:8080 cpu.prof
 ### Memory Profiling
 
 ```bash
-# Run with memory profiling
-go run cmd/s9s/main.go -memprofile=mem.prof --mock
-go tool pprof mem.prof
-
-# Or from tests
+# Memory profiling from benchmarks
 go test -memprofile=mem.prof -bench=. ./test/performance
 go tool pprof -http=:8080 mem.prof
 ```

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -61,7 +61,7 @@ go test -tags=integration ./test/integration
 
 # With specific SLURM cluster
 SLURM_URL=https://test.example.com \
-SLURM_TOKEN=token123 \
+SLURM_JWT=token123 \
 go test -tags=integration ./test/integration
 ```
 
@@ -75,14 +75,14 @@ Performance benchmarks measure and track code performance over time.
 # Run all benchmarks
 make bench
 
-# Or manually
-go test -bench=. ./test/performance
+# Or manually (both performance and integration directories)
+go test -bench=. -benchmem ./test/performance/... ./test/integration/...
 
 # Run specific benchmark
-go test -bench=BenchmarkJobRefresh ./test/performance
+go test -bench=BenchmarkJobRefresh ./test/performance/...
 
 # With memory profiling
-go test -bench=. -benchmem ./test/performance
+go test -bench=. -benchmem ./test/performance/...
 ```
 
 ## Test Coverage
@@ -173,7 +173,7 @@ func TestParseState(t *testing.T) {
 
 ```
 internal/views/jobs_test.go      # Unit tests for views
-pkg/slurm/mock_test.go          # Mock implementation tests
+pkg/slurm/mock.go               # Mock SLURM implementation
 test/integration/               # Integration tests
 test/performance/              # Performance benchmarks
 ```
@@ -366,12 +366,8 @@ for _, id := range jobIDs {
 # Enable debug logging
 s9s --debug
 
-# Or with environment variable
-export S9S_DEBUG=true
-s9s
-
-# Check debug log location
-tail -f ~/.s9s/debug.log
+# Check debug log location (written to current directory)
+tail -f s9s-debug.log
 ```
 
 ### Add Debug Statements

--- a/docs/enterprise/features.md
+++ b/docs/enterprise/features.md
@@ -137,10 +137,11 @@ FROM alpine:latest
 COPY s9s /usr/local/bin/s9s
 RUN chmod +x /usr/local/bin/s9s
 
-# Run in non-interactive mode for monitoring
+# s9s is an interactive TUI application
 ENTRYPOINT ["/usr/local/bin/s9s"]
-CMD ["jobs", "--format", "json"]
 ```
+
+> **Note:** s9s is a terminal UI application and does not have a non-interactive `jobs --format json` mode. For non-interactive SLURM data access, use `scontrol` or `sacct` directly, or the SLURM REST API.
 
 ### SSH Integration
 

--- a/docs/enterprise/features.md
+++ b/docs/enterprise/features.md
@@ -145,16 +145,9 @@ ENTRYPOINT ["/usr/local/bin/s9s"]
 
 ### SSH Integration
 
-For direct node access in enterprise environments:
+For direct node access in enterprise environments, s9s uses your system's default SSH configuration automatically. There is no `ssh:` section in the s9s configuration file.
 
-```yaml
-ssh:
-  enabled: true
-  multiplexing: true
-  control_path: "/tmp/s9s-ssh-%r@%h:%p"
-```
-
-See [SSH Integration Guide](../guides/ssh-integration.md) for details.
+See the [SSH Integration Guide](../guides/ssh-integration.md) for details on how SSH connections are handled.
 
 ## Future Development
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -13,7 +13,6 @@ S9s offers extensive configuration options to customize your experience. This gu
 - [UI and Display Configuration](#ui-and-display-configuration)
 - [Advanced Configuration](#advanced-configuration)
 - [Security Configuration](#security-configuration)
-- [Configuration Management](#configuration-management)
 - [Best Practices](#best-practices)
 
 ## Quick Start
@@ -45,13 +44,12 @@ See the [Mock Mode Guide](../guides/mock-mode.md) for details.
 
 ## Configuration Files
 
-S9s looks for configuration files in the following order (later files override earlier ones):
+S9s looks for `config.yaml` in the following paths (first match wins):
 
-1. `/etc/s9s/config.yaml` - System-wide configuration
-2. `~/.config/s9s/config.yaml` - User configuration (XDG standard)
-3. `~/.s9s/config.yaml` - User configuration (legacy location)
-4. `./.s9s.yaml` - Project-specific configuration
-5. File specified by `--config` flag
+1. `./config.yaml` - Current directory
+2. `$HOME/.s9s/config.yaml` - User configuration
+3. `/etc/s9s/config.yaml` - System-wide configuration
+4. File specified by `--config` flag (overrides search)
 
 ### File Format
 
@@ -80,70 +78,37 @@ ui:
   skin: default
 ```
 
-### Project-Specific Configuration
-
-Create `.s9s.yaml` in your project directory for project-specific settings:
-
-```yaml
-# Project-specific settings
-defaultCluster: project-cluster
-
-clusters:
-  - name: project-cluster
-    cluster:
-      endpoint: https://project.slurm.local:6820
-      token: ${SLURM_JWT}
-```
-
 ## Environment Variables
 
-All environment variables are prefixed with `S9S_`.
-
-### Core Variables
-
-| Variable | Description | Default | Example |
-|----------|-------------|---------|---------|
-| `S9S_CONFIG` | Configuration file path | `~/.s9s/config.yaml` | `/etc/s9s/config.yaml` |
-| `S9S_DEBUG` | Enable debug mode | `false` | `true` |
-| `S9S_LOG_FILE` | Debug log file path | `~/.s9s/debug.log` | `/var/log/s9s.log` |
-| `S9S_MOCK` | Enable mock mode | `false` | `true` |
-| `S9S_CLUSTER` | Default cluster name | First in config | `production` |
-| `S9S_THEME` | Color theme | `dark` | `light` |
-| `S9S_REFRESH_INTERVAL` | Auto-refresh interval | `30s` | `1m` |
-| `S9S_DEFAULT_VIEW` | Starting view | `jobs` | `nodes` |
+S9s uses the `S9S_` prefix for its own environment variables and also supports unprefixed SLURM variables. Viper's `AutomaticEnv()` maps environment variables to config keys using the `S9S_` prefix with `.` replaced by `_` (e.g., `S9S_UI_SKIN` maps to `ui.skin`).
 
 ### SLURM Connection Variables
 
 | Variable | Description | Default | Example |
 |----------|-------------|---------|---------|
-| `SLURM_URL` | SLURM REST API URL | - | `https://slurm.example.com:6820` |
-| `SLURM_API_VERSION` | API version | auto-detected | `v0.0.43` |
-| `SLURM_JWT` | Authentication token (auto-discovered via `scontrol token` if not set) | - | `eyJhbGci...` |
-| `SLURM_INSECURE` | Skip TLS verification | `false` | `true` |
+| `SLURM_REST_URL` or `S9S_SLURM_REST_URL` | SLURM REST API URL | - | `https://slurm.example.com:6820` |
+| `SLURM_JWT` or `S9S_SLURM_JWT` | Authentication token (auto-discovered via `scontrol token` if not set) | - | `eyJhbGci...` |
+| `SLURM_API_VERSION` | API version | `v0.0.43` | `v0.0.40` |
 
-### UI Variables
+### Mock Mode Variable
 
 | Variable | Description | Default | Example |
 |----------|-------------|---------|---------|
-| `S9S_EDITOR` | External editor | `$EDITOR` or `vi` | `vim` |
-| `S9S_PAGER` | External pager | `$PAGER` or `less` | `more` |
+| `S9S_ENABLE_MOCK` | Enable mock mode (required for `--mock` flag); any non-empty value enables it | unset | `1`, `true`, `dev` |
 
 ### Environment Variable Substitution
 
-Use `${VAR_NAME}` syntax in configuration files:
+Use `${VAR_NAME}` syntax in configuration files to reference environment variables:
 
 ```yaml
 clusters:
-  default:
-    url: ${SLURM_API_URL}
-    auth:
-      token: ${SLURM_TOKEN}
-
-# With defaults
-preferences:
-  theme: ${S9S_THEME:-dark}
-  refreshInterval: ${S9S_REFRESH:-5s}
+  - name: default
+    cluster:
+      endpoint: ${SLURM_REST_URL}
+      token: ${SLURM_JWT}
 ```
+
+> **Note:** The `${VAR:-default}` syntax with fallback values is not supported. Use plain `${VAR}` references only.
 
 ## Command-line Flags
 
@@ -154,158 +119,123 @@ Command-line flags override all other configuration sources.
 ```bash
 s9s [flags]
 
-# Connection
---cluster NAME          Select cluster from config
---url URL              SLURM REST API URL
---token TOKEN          Authentication token
---api-version VERSION  SLURM API version (default: auto-detected)
---insecure            Skip TLS certificate verification
+# Configuration
+--config PATH          Custom config file location
+--cluster NAME         Select cluster from config
+--debug                Enable debug logging
 
-# Mock mode (requires S9S_ENABLE_MOCK=true)
---mock                 Run in mock mode (no SLURM required)
-```
+# Discovery
+--no-discovery         Disable auto-discovery
+--discovery-timeout    Timeout for auto-discovery (e.g., 10s, 30s)
 
-### UI Flags
-
-```bash
-# UI preferences
---theme THEME          Color theme (dark|light)
---refresh INTERVAL     Auto-refresh interval (e.g., 30s, 1m)
---no-refresh          Disable auto-refresh
---view VIEW           Start with specific view
-
-# Output
---export FORMAT       Export data and exit (csv|json|yaml)
---output FILE         Output file for export
---quiet              Suppress non-error output
-```
-
-### Debug Flags
-
-```bash
-# Debugging
---debug               Enable debug mode
---log-file FILE       Debug log file path
---trace              Enable trace logging
---profile            Enable profiling
+# Version
+--version, -v          Show version information
 ```
 
 ## Configuration Schema
 
 ### Complete Schema
 
-> **Note:** Some configuration options shown below are planned features. See [#117](https://github.com/jontk/s9s/issues/117) for status. The currently implemented config struct supports: `RefreshRate`, `MaxRetries`, `DefaultCluster`, `Clusters[]` (with `Endpoint`, `Token`, `APIVersion`, `Insecure`, `Timeout`), `UI` (skin, logoless, crumbsless, statusless, headless, noIcons, enableMouse), `Views` (jobs, nodes, partitions), `Features` (streaming, pulseye, xray), `Shortcuts[]`, `Aliases`, `Plugins[]`, `UseMockClient`, `PluginSettings`, and `Discovery`.
+The following schema reflects the actual `Config` struct in the codebase. All field names use camelCase as defined by the `mapstructure` tags.
 
 ```yaml
-# Configuration file version
-version: string  # Required: "1.0"
+# General settings
+refreshRate: duration        # Auto-refresh interval (default: 2s)
+maxRetries: integer          # Max API retry attempts (default: 3)
+defaultCluster: string       # Active cluster name (default: "default")
+useMockClient: boolean       # Enable mock SLURM client (default: false)
 
-# Default cluster
-default_cluster: string  # Optional
-
-# Cluster configurations
+# Cluster configurations (list format with name field)
 clusters:
-  <cluster_name>:
-    # Connection settings
-    url: string              # Required: SLURM REST API URL
-    api_version: string      # Optional: API version (default: auto-detected)
-    timeout: duration        # Optional: Request timeout (default: 30s)
-    retry_attempts: integer  # Optional: Retry attempts (default: 3)
-    retry_delay: duration    # Optional: Retry delay (default: 1s)
+  - name: string             # Cluster identifier
+    cluster:
+      endpoint: string       # SLURM REST API URL
+      token: string          # JWT token or ${SLURM_JWT} env var reference
+      apiVersion: string     # API version (default: auto-detected, e.g., v0.0.43)
+      insecure: boolean      # Skip TLS verification (default: false)
+      timeout: duration      # Request timeout (default: 30s)
+    namespace: string        # Optional namespace
+    readOnly: boolean        # Prevent write operations (default: false)
 
-    # Authentication (token-based via SLURM JWT)
-    token: string            # JWT token or env var reference (e.g., ${SLURM_JWT})
-                             # Auto-discovered via scontrol token if not set
-    insecure: boolean        # Skip TLS verification (default: false)
+# UI settings
+ui:
+  skin: string               # Theme name (default: "default")
+  logoless: boolean          # Hide logo (default: false)
+  crumbsless: boolean        # Hide breadcrumbs (default: false)
+  statusless: boolean        # Hide status bar (default: false)
+  headless: boolean          # Hide header (default: false)
+  noIcons: boolean           # Disable icons (default: false)
+  enableMouse: boolean       # Enable mouse support (default: true)
 
-# User preferences (many of these are planned -- see note above)
-preferences:
-  # UI settings
-  theme: string              # dark|light (default: dark)
-  refresh_interval: duration # Auto-refresh (default: 30s)
-  default_view: string       # Starting view (default: jobs)
-
-  # Job view settings
+# View-specific settings
+views:
   jobs:
-    default_filter: string   # Default filter
-    show_completed: boolean  # Show completed jobs (default: false)
-    columns: [string]        # Visible columns
-    sort_by: string          # Default sort column
-    sort_order: string       # asc|desc
+    columns: [string]        # Visible columns (default: [id, name, user, state, time, nodes, priority])
+    showOnlyActive: boolean  # Show only active jobs (default: true)
+    defaultSort: string      # Default sort column (default: "time")
+    maxJobs: integer         # Max jobs to display (default: 1000)
+    submission:              # Job submission wizard settings
+      formDefaults: map      # Default form values
+      hiddenFields: [string] # Fields to hide
+      fieldOptions: map      # Restrict dropdown options
+      showBuiltinTemplates: boolean  # Legacy: show built-in templates
+      templateSources: [string]      # Template sources: builtin, config, saved
+      templates:             # Custom job templates
+        - name: string
+          description: string
+          defaults: map
+          hiddenFields: [string]
 
-  # Node view settings
   nodes:
-    show_offline: boolean    # Show offline nodes (default: true)
-    group_by: string         # Group by partition|state|none
-    columns: [string]        # Visible columns
+    groupBy: string          # Group by: partition|state|feature|none (default: "partition")
+    showUtilization: boolean # Show utilization bars (default: true)
+    maxNodes: integer        # Max nodes to display (default: 500)
 
-  # SSH settings
-  ssh:
-    command: string          # SSH command (default: ssh)
-    options: [string]        # Additional SSH options
-    user: string             # Default SSH user
-    key_file: string         # SSH key file path
-    known_hosts_file: string # Known hosts file
+  partitions:
+    showQueueDepth: boolean  # Show queue depth (default: true)
+    showWaitTime: boolean    # Show wait time (default: true)
 
-  # Export settings
-  export:
-    default_format: string   # csv|json|yaml|markdown
-    csv_separator: string    # CSV separator (default: ,)
-    json_indent: integer     # JSON indent (default: 2)
+# Feature flags
+features:
+  streaming: boolean         # Real-time updates via WebSocket (default: true)
+  pulseye: boolean           # Health scanner (default: true)
+  xray: boolean              # Deep inspection mode (default: false)
+  appDiagnostics: boolean    # Application diagnostics (default: false)
 
-# Column configuration
-columns:
-  jobs:
-    - JobID
-    - Name
-    - User
-    - State
-  nodes:
-    - NodeName
-    - State
-    - CPULoad
+# Custom keyboard shortcuts (list of objects)
+shortcuts:
+  - key: string              # Key combination (e.g., "ctrl+j")
+    action: string           # Action to perform (e.g., "view:jobs")
+    description: string      # Human-readable description
 
-# Keyboard bindings
-keybindings:
-  global:
-    "ctrl+q": "quit"
-    "ctrl+s": "save"
-  jobs:
-    "d": "delete"
+# Command aliases
+aliases:
+  string: string             # e.g., ctx: "context", kj: "kill job"
 
-# Filter presets
-filters:
-  my-jobs:
-    view: jobs
-    filter: "user:${USER}"
+# Plugin configuration
+plugins:
+  - name: string             # Plugin name
+    enabled: boolean         # Enable/disable
+    path: string             # Plugin binary path
+    config: map              # Plugin-specific settings
 
-# Notification settings (planned)
-notifications:
-  enabled: boolean
-  desktop: boolean
-  sound: boolean
-  webhook:
-    url: string
-    events: [string]
+# Plugin global settings
+pluginSettings:
+  enableAll: boolean         # Enable all plugins (default: false)
+  pluginDir: string          # Plugin directory (default: "$HOME/.s9s/plugins")
+  autoDiscover: boolean      # Auto-discover plugins (default: true)
+  safeMode: boolean          # Disable external plugins (default: false)
+  maxMemoryMB: integer       # Memory limit per plugin (default: 100)
+  maxCPUPercent: float       # CPU limit per plugin (default: 25.0)
 
-# Logging settings
-logging:
-  level: string              # debug|info|warn|error (default: info)
-  file: string               # Log file path
-  max_size: integer          # Max file size in MB
-  max_backups: integer       # Number of backups
-  max_age: integer           # Max age in days
-
-# Performance settings (planned)
-performance:
-  max_concurrent: integer    # Max concurrent operations
-  cache_ttl: duration        # Cache TTL
-  batch_size: integer        # Batch operation size
-
-# Security settings (planned)
-security:
-  keyring: boolean           # Use system keyring (default: true)
-  encrypt_config: boolean    # Encrypt sensitive config
+# Auto-discovery settings
+discovery:
+  enabled: boolean           # Enable auto-discovery (default: true)
+  enableEndpoint: boolean    # Auto-discover slurmrestd endpoint (default: true)
+  enableToken: boolean       # Auto-discover token via scontrol (default: true)
+  timeout: duration          # Discovery timeout (default: 10s)
+  defaultPort: integer       # Default slurmrestd port (default: 6820)
+  scontrolPath: string       # Path to scontrol binary (default: "scontrol")
 ```
 
 ## Authentication
@@ -338,56 +268,33 @@ If you are running s9s on a node where `scontrol` is available and your user has
 ### Basic UI Settings
 
 ```yaml
-preferences:
-  # Theme settings
-  theme: dark|light
+ui:
+  skin: default              # Theme skin
+  logoless: false            # Hide the logo
+  crumbsless: false          # Hide breadcrumbs
+  statusless: false          # Hide status bar
+  headless: false            # Hide header
+  noIcons: false             # Disable icons
+  enableMouse: true          # Enable mouse support
 
-  # View settings
-  default_view: jobs|nodes|dashboard
-  refresh_interval: 5s|10s|30s|0 (disabled)
-
-  # Display options
-  show_relative_time: true|false
-  use_24hour_time: true|false
-  show_seconds: true|false
-  date_format: "2006-01-02 15:04:05"
-  timezone: "UTC"|"Local"|"America/New_York"
-
-  # Behavior
-  confirm_actions: true|false
-  auto_refresh: true|false
-  show_hints: true|false
+refreshRate: 2s              # Auto-refresh interval
 ```
 
 ### Column Configuration
 
-Customize visible columns per view:
+Customize visible columns in the jobs view:
 
 ```yaml
-columns:
+views:
   jobs:
-    - JobID
-    - Name
-    - User
-    - State
-    - Time
-    - Nodes
-    - Partition
-    - Priority
-    - QoS
-    - Account
-
-  nodes:
-    - NodeName
-    - State
-    - CPULoad
-    - Memory
-    - RealMemory
-    - AllocMemory
-    - FreeMem
-    - GPUs
-    - Jobs
-    - Features
+    columns:
+      - id
+      - name
+      - user
+      - state
+      - time
+      - nodes
+      - priority
 ```
 
 ### Job Submission Configuration
@@ -496,31 +403,27 @@ Values are applied in this order (later overrides earlier):
 
 > `showBuiltinTemplates` (boolean) is the legacy equivalent of `templateSources`. Setting `showBuiltinTemplates: false` is equivalent to `templateSources: ["config", "saved"]`. If both are set, `templateSources` takes precedence. New configurations should use `templateSources`.
 
-### Custom Keybindings
+### Custom Shortcuts
 
-Override default shortcuts:
+Define custom keyboard shortcuts as a list of objects:
 
 ```yaml
-keybindings:
-  # Global shortcuts (work everywhere)
-  global:
-    "ctrl+q": "quit"
-    "ctrl+s": "save"
-    "ctrl+/": "search"
-    "f1": "help"
-    "ctrl+\\": "toggle-sidebar"
+shortcuts:
+  - key: ctrl+j
+    action: "view:jobs"
+    description: "Switch to jobs view"
 
-  # View-specific shortcuts
-  jobs:
-    "d": "delete"
-    "D": "delete --force"
-    "ctrl+c": "cancel"
-    "ctrl+h": "hold"
-    "ctrl+r": "release"
+  - key: ctrl+n
+    action: "view:nodes"
+    description: "Switch to nodes view"
 
-  nodes:
-    "shift+d": "drain --reason='Maintenance'"
-    "shift+r": "resume"
+  - key: ctrl+x
+    action: "xray:toggle"
+    description: "Toggle Xray mode"
+
+  - key: ctrl+h
+    action: "pulseye:scan"
+    description: "Run health scan"
 ```
 
 ### UI Skin
@@ -562,118 +465,10 @@ Switch clusters:
 # Use flag
 s9s --cluster development
 
-# Or environment
-export S9S_CLUSTER=development
-s9s
-
 # Or interactively with Ctrl+K while s9s is running
 ```
 
 When multiple clusters are configured, the active cluster name is shown in the header bar. Press `Ctrl+K` to open the cluster switcher and select a different cluster without restarting.
-
-### Filter Presets
-
-Create commonly used filters:
-
-```yaml
-filters:
-  my-jobs:
-    view: jobs
-    filter: "user:${USER}"
-  gpu-jobs:
-    view: jobs
-    filter: "partition:gpu state:RUNNING"
-  failed-today:
-    view: jobs
-    filter: "state:FAILED time:>today"
-```
-
-### Notification Settings
-
-```yaml
-notifications:
-  enabled: true
-  desktop: true
-  sound: true
-  webhook:
-    url: https://slack.example.com/webhook
-    events:
-      - job_complete
-      - job_failed
-      - node_down
-```
-
-### Logging Configuration
-
-```yaml
-logging:
-  level: debug|info|warn|error
-  file: ~/.s9s/s9s.log
-  max_size: 100MB
-  max_backups: 3
-  max_age: 30d
-  compress: true
-
-  # Separate log levels
-  levels:
-    api: debug
-    ui: info
-    ssh: warn
-```
-
-### Performance Tuning
-
-```yaml
-performance:
-  # Connection pooling
-  max_idle_connections: 100
-  max_connections_per_host: 10
-  idle_connection_timeout: 90s
-
-  # Caching
-  cache:
-    enabled: true
-    size: 100MB
-    ttl: 60s
-    compression: true
-
-  # Request handling
-  request_timeout: 30s
-  response_timeout: 60s
-  keep_alive: 30s
-
-  # UI performance
-  virtual_scrolling: true
-  lazy_loading: true
-  debounce_delay: 300ms
-```
-
-### SSH Configuration
-
-```yaml
-preferences:
-  ssh:
-    command: ssh
-    user: ${USER}
-    key_file: ~/.ssh/id_rsa
-    known_hosts_file: ~/.ssh/known_hosts
-    compression: true
-    forward_agent: true
-    extra_args: "-o StrictHostKeyChecking=ask"
-```
-
-### Export Settings
-
-```yaml
-preferences:
-  export:
-    default_format: csv
-    default_path: ~/Documents/s9s-exports
-    include_headers: true
-    date_format: RFC3339
-    csv_separator: ","
-    json_indent: 2
-```
 
 ## Security Configuration
 
@@ -697,26 +492,6 @@ preferences:
    ```
 
 ## Configuration Management
-
-### Validate Configuration
-
-```bash
-s9s config validate
-s9s config test --cluster production
-```
-
-### Export/Import Configuration
-
-```bash
-# Export current config
-s9s config export > config-backup.yaml
-
-# Import configuration
-s9s config import config-backup.yaml
-
-# Merge configurations
-s9s config merge additional-config.yaml
-```
 
 ### Configuration Wizard
 
@@ -752,7 +527,7 @@ clusters:
       timeout: 60s
       insecure: false
 
-refreshRate: 15s
+refreshRate: 2s
 maxRetries: 5
 
 ui:
@@ -767,22 +542,28 @@ features:
 ### Development Configuration
 
 ```yaml
-version: "1.0"
+defaultCluster: dev
 
-preferences:
-  theme: dark
-  refresh_interval: 5s
-  default_view: jobs
+clusters:
+  - name: dev
+    cluster:
+      endpoint: https://slurm-dev.example.com:6820
+      token: ${SLURM_JWT}
 
-logging:
-  level: debug
-  file: ./s9s-debug.log
+refreshRate: 2s
+
+ui:
+  skin: default
+
+features:
+  streaming: true
+  pulseye: true
 ```
 
 Run with:
 
 ```bash
-s9s --mock --config dev-config.yaml
+s9s --config dev-config.yaml
 ```
 
 ## Migration Guide
@@ -792,32 +573,20 @@ s9s --mock --config dev-config.yaml
 If migrating from environment-only setup:
 
 ```bash
-# Old way
-export SLURM_URL=https://slurm.example.com
+# Environment variables still work
+export SLURM_REST_URL=https://slurm.example.com:6820
 export SLURM_JWT=abc123
 s9s
 
-# New way - create config
+# Or create a config file
 cat > ~/.s9s/config.yaml <<EOF
 clusters:
   - name: default
     cluster:
-      endpoint: ${SLURM_URL}
-      token: ${SLURM_JWT}
+      endpoint: https://slurm.example.com:6820
+      token: \${SLURM_JWT}
 EOF
 s9s
-```
-
-### From Other Tools
-
-Import settings from other SLURM tools:
-
-```bash
-# Import from squeue defaults
-s9s import squeue > ~/.s9s/config.yaml
-
-# Import from existing config
-s9s import --from /etc/slurm/config.yaml
 ```
 
 ## Configuration Validation
@@ -825,30 +594,18 @@ s9s import --from /etc/slurm/config.yaml
 S9s validates configuration on startup:
 
 1. **Syntax validation**: YAML parsing
-2. **Schema validation**: Required fields, types
-3. **Connection validation**: Can connect to cluster
-4. **Permission validation**: Can perform basic operations
-
-Validation errors are reported clearly:
-
-```
-Error: Invalid configuration
-  - clusters[0].cluster.endpoint: required field missing
-  - preferences.refresh_interval: invalid duration format
-```
+2. **Schema validation**: Required fields and types
+3. **Cluster resolution**: The `defaultCluster` must match a cluster name in the `clusters` list (unless auto-discovery is enabled)
 
 ## Best Practices
 
-1. **Use environment variables** for sensitive data
+1. **Use environment variables** for sensitive data (tokens, endpoints)
 2. **Version control** your config (exclude secrets with `.gitignore`)
-3. **Test changes** with `s9s config test`
-4. **Backup** before major changes
-5. **Use keyring** for token storage
-6. **Separate** dev/prod configurations
-7. **Document** custom settings
-8. **Set proper file permissions** on configuration files
-9. **Validate** configuration after changes
-10. **Keep tokens** in files with restricted permissions
+3. **Backup** before major changes
+4. **Separate** dev/prod configurations using multiple cluster entries
+5. **Document** custom settings
+6. **Set proper file permissions** on configuration files (`chmod 600 ~/.s9s/config.yaml`)
+7. **Use auto-discovery** when running on SLURM nodes to avoid hardcoding tokens
 
 ## Next Steps
 
@@ -856,4 +613,3 @@ Error: Invalid configuration
 - Check [Quick Start](./quickstart.md) to get started
 - Explore [User Guide](../user-guide/index.md) for feature documentation
 - Learn about [SSH Integration](../guides/ssh-integration.md)
-- Set up [Notifications](../guides/notifications.md)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -5,7 +5,7 @@ s9s can be installed using several methods. Choose the one that best fits your e
 ## System Requirements
 
 - **Operating System**: Linux, macOS, or Windows
-- **Go Version**: 1.19 or higher (for building from source)
+- **Go Version**: 1.24 or higher (for building from source)
 - **Terminal**: 256 color support recommended
 - **SLURM REST API**: A running `slurmrestd` instance — see [Troubleshooting](../guides/troubleshooting.md#cannot-connect-to-slurm-cluster) if connection fails ([mock mode](../guides/mock-mode.md) available for testing without SLURM)
 
@@ -83,12 +83,12 @@ cd s9s
 # Build the binary
 make build
 
-# Install to system path
-sudo make install
+# Install to GOPATH/bin
+make install
 
 # Or install to user directory
 mkdir -p ~/.local/bin
-cp ./bin/s9s ~/.local/bin/
+cp ./build/s9s ~/.local/bin/
 export PATH=$PATH:~/.local/bin
 ```
 
@@ -102,7 +102,7 @@ s9s --version
 
 You should see output like:
 ```
-s9s version 0.7.0
+S9S - SLURM Terminal UI version 0.7.0
 ```
 
 ### 2. Initial Configuration
@@ -179,10 +179,9 @@ rm ~/.local/bin/s9s
 
 # Remove configuration (optional)
 rm -rf ~/.s9s
-rm -rf ~/.config/s9s
 
 # Remove cache (optional)
-rm -rf ~/.cache/s9s
+rm -rf ~/.s9s/cache
 ```
 
 ## Troubleshooting Installation
@@ -224,12 +223,14 @@ If `s9s` is not found after installation:
 
 If you encounter SSL certificate errors:
 
-```bash
-# For self-signed certificates
-export S9S_INSECURE_TLS=true
+Set `insecure: true` in the cluster config for self-signed certificates:
 
-# Or add to config
-echo "insecureTLS: true" >> ~/.s9s/config.yaml
+```yaml
+clusters:
+  - name: default
+    cluster:
+      endpoint: https://slurm.example.com:6820
+      insecure: true
 ```
 
 ### Connection Refused
@@ -242,7 +243,7 @@ If you cannot connect to SLURM:
    ```
 
 2. **Verify authentication**:
-   - Ensure SLURM_TOKEN is set
+   - Ensure SLURM_JWT is set
    - Check token is valid
    - Verify API URL is correct
 
@@ -261,10 +262,10 @@ On Linux, if you get "cannot execute binary file":
 uname -m
 
 # For x86_64/AMD64
-wget https://github.com/jontk/s9s/releases/latest/download/s9s-linux-amd64
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.7.0_Linux_x86_64.tar.gz
 
 # For ARM64/aarch64
-wget https://github.com/jontk/s9s/releases/latest/download/s9s-linux-arm64
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.7.0_Linux_arm64.tar.gz
 ```
 
 ## Upgrading
@@ -275,11 +276,11 @@ To upgrade to the latest version:
 # If installed via script
 curl -sSL https://get.s9s.dev | bash
 
-# If installed via binary download
-wget https://github.com/jontk/s9s/releases/latest/download/s9s-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)
-chmod +x s9s-*
+# If installed via binary download (replace version and arch as needed)
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.7.0_Linux_x86_64.tar.gz
+tar -xzf s9s_0.7.0_Linux_x86_64.tar.gz
 mkdir -p ~/.local/bin
-mv s9s-* ~/.local/bin/s9s
+mv s9s ~/.local/bin/
 
 # If installed via Go
 go install github.com/jontk/s9s/cmd/s9s@latest

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -239,7 +239,7 @@ If you cannot connect to SLURM:
 
 1. **Check SLURM API access**:
    ```bash
-   curl https://your-slurm-api.example.com/slurm/v0.0.40/jobs
+   curl https://your-slurm-api.example.com/slurm/v0.0.43/jobs
    ```
 
 2. **Verify authentication**:

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -120,7 +120,7 @@ The Jobs view is where you'll manage your workload:
 | Key | Action | Use Case |
 |-----|--------|----------|
 | `Enter` | View details | See full job information |
-| `s/S` | Submit job | Launch job submission wizard |
+| `s` | Submit job | Launch job submission wizard |
 | `c/C` | Cancel job | Cancel a running/pending job |
 | `H` | Hold job | Prevent job from starting |
 | `r` | Release job | Release a held job |
@@ -142,7 +142,7 @@ Use `/` to filter jobs:
 
 Press `ESC` to clear filters.
 
-For complex filtering, press `Ctrl+F` (in Jobs/Nodes views) to open the advanced filter with field-specific syntax:
+For complex filtering, press `Ctrl+F` to open global search across all entity types (available in all data views). In data views, you can also use field-specific syntax in the filter bar:
 ```
 state=RUNNING partition=gpu
 user=alice priority>500
@@ -162,15 +162,15 @@ Monitor and manage compute nodes:
 | `Enter` | Details | Node information and metrics |
 | `d/D` | Drain | Mark node for maintenance |
 | `r` | Resume | Return drained node to service |
-| `s/S` | SSH | Connect to node via SSH |
+| `s` | SSH | Connect to node via SSH |
 | `g/G` | Group by | Group nodes (partition/state/features) |
 
 ### Node States
 
 - **IDLE** (Green) - Available for jobs
-- **ALLOCATED** (Cyan) - Running jobs
-- **MIXED** (Yellow) - Partially allocated
-- **DRAIN** (Orange) - Scheduled for maintenance
+- **ALLOCATED** (Blue) - Running jobs
+- **MIXED** (Blue) - Partially allocated
+- **DRAIN** (Red) - Scheduled for maintenance
 - **DOWN** (Red) - Offline/unavailable
 
 ### Resource Usage
@@ -236,20 +236,9 @@ Press `/` to filter the current view:
 # Shows matching rows in the current view
 ```
 
-### Advanced Filtering
+### Global Search
 
-Press `Ctrl+F` (in Jobs/Nodes views) to open the advanced filter with expression-based filtering:
-
-```bash
-# Jobs view
-state=RUNNING partition=gpu nodes>4
-
-# Nodes view
-state=idle partition=compute cpus>64
-
-# Partitions view
-efficiency>80 qos=high
-```
+Press `Ctrl+F` in any data view to open global search, which searches across all entity types (jobs, nodes, partitions, users, accounts, QoS, reservations).
 
 ### Batch Operations
 
@@ -257,7 +246,7 @@ Select multiple items:
 
 1. Press `v/V` to enter multi-select mode
 2. Press `Space` on items to select
-3. Press `V` to select all visible
+3. Press `Ctrl+A` to select all visible
 4. Press `b/B` for batch menu
 5. Choose operation (cancel, hold, release, etc.)
 
@@ -316,7 +305,7 @@ Now that you know the basics, explore:
 
 ## 💡 Pro Tips
 
-1. **Practice with mock mode** - `s9s --mock` is risk-free
+1. **Practice with mock mode** - `S9S_ENABLE_MOCK=1 s9s --mock` is risk-free
 2. **Use keyboard shortcuts** - Faster than mouse for everything
 3. **Multi-select is powerful** - Batch operations save time
 4. **Use quick filters** - Press `/` to filter any view instantly
@@ -328,7 +317,7 @@ Now that you know the basics, explore:
 ## 🆘 Getting Help
 
 - **In-app help**: Press `?` anywhere for context-sensitive help
-- **View documentation**: Press `F1` for help
+- **Help modal**: Press `F1` for help
 - **Full docs**: [https://s9s.dev/docs](https://s9s.dev/docs)
 - **Troubleshooting**: [Troubleshooting Guide](../guides/troubleshooting.md)
 - **GitHub Issues**: [Report bugs](https://github.com/jontk/s9s/issues)

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -186,7 +186,7 @@ CPU: ████████░░░░░░░░ 8/16 (Load: 7.5)
 
 ### Example 1: Submit a New Job
 
-1. Press `s/S` in Jobs view
+1. Press `s` in Jobs view
 2. Fill in job submission wizard:
    - Job name
    - Partition
@@ -334,10 +334,10 @@ A: Yes! Use `S9S_ENABLE_MOCK=1 s9s --mock` for a fully functional demo mode.
 A: Use multi-select (`v/V`), select jobs with `Space`, then press `b/B` for batch operations.
 
 **Q: Can I SSH to nodes from s9s?**
-A: Yes! Press `s/S` in Nodes view for SSH options.
+A: Yes! Press `s` in Nodes view for SSH options.
 
 **Q: How do I filter by partition?**
-A: Use `/` and type `p:partitionname` for quick filter, or press `Ctrl+F` and type `partition=name` for advanced filter.
+A: Use `/` and type `p:partitionname` for quick filter, or press `Ctrl+F` for global search across all resources.
 
 **Q: Is there a way to save my filters?**
 A: Saved filters are a planned feature. For now, use `/` to quickly re-enter filters in any view.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -22,7 +22,7 @@ Try s9s without a SLURM cluster:
 
 ```bash
 # Launch in mock mode with simulated data
-s9s --mock
+S9S_ENABLE_MOCK=1 s9s --mock
 ```
 
 ![Overview Demo](/assets/demos/overview.gif)
@@ -41,20 +41,26 @@ s9s organizes information into focused views. Switch between them using:
 
 - **Tab** - Cycle forward through views
 - **Shift+Tab** - Cycle backward through views
-- **J** - Jump to Jobs view
-- **N** - Jump to Nodes view
-- **P** - Jump to Partitions view
+- **1** - Jobs view
+- **2** - Nodes view
+- **3** - Partitions view
+- **4** - Reservations view
+- **5-7** - QoS, Accounts, Users
+- **8** - Dashboard view
+- **9** - Health view
+- **0** - Performance view
 
 Common views:
-1. **Dashboard** - Cluster overview with metrics
-2. **Jobs** - Monitor and manage jobs
-3. **Nodes** - View and manage compute nodes
-4. **Partitions** - Monitor partitions and queues
-5. **Users** - View user accounts
+1. **Jobs** - Monitor and manage jobs
+2. **Nodes** - View and manage compute nodes
+3. **Partitions** - Monitor partitions and queues
+4. **Reservations** - Resource reservations
+5. **QoS** - Quality of Service policies
 6. **Accounts** - Account hierarchy
-7. **QoS** - Quality of Service policies
-8. **Reservations** - Resource reservations
+7. **Users** - View user accounts
+8. **Dashboard** - Cluster overview with metrics
 9. **Health** - Cluster health monitoring
+0. **Performance** - Performance metrics
 
 ### Essential Keyboard Shortcuts
 
@@ -63,12 +69,11 @@ Common views:
 | `?` | Help | Show context-sensitive keyboard shortcuts |
 | `q` | Quit | Exit s9s |
 | `/` | Filter | Filter current view |
-| `F3` | Advanced filter | Expression-based filtering |
-| `Ctrl+F` | Global search | Search across all resources |
+| `F3` | Preferences | Open preferences dialog |
 | `Tab` | Next view | Cycle through views |
 | `Enter` | Details | View detailed information |
 | `ESC` | Cancel | Exit dialog/filter/modal |
-| `R` | Refresh | Manual data refresh |
+| `F5` | Refresh | Manual data refresh |
 
 See [Keyboard Shortcuts](../user-guide/keyboard-shortcuts.md) for complete reference.
 
@@ -91,11 +96,11 @@ The Dashboard is your cluster command center:
 
 | Key | Action |
 |-----|--------|
-| `J` | Jump to Jobs view |
-| `N` | Jump to Nodes view |
-| `P` | Jump to Partitions view |
-| `A` | Advanced analytics |
-| `H` | Health check details |
+| `1` | Jobs view |
+| `2` | Nodes view |
+| `3` | Partitions view |
+| `Tab` | Next view |
+| `?` | Help |
 
 ## 📊 Jobs View
 
@@ -106,8 +111,8 @@ The Jobs view is where you'll manage your workload:
 ### View Jobs
 
 ```bash
-# Launch s9s directly to jobs view
-s9s --view jobs
+# Launch s9s and switch to jobs view with keyboard shortcut
+# Press 1 to jump to Jobs view
 ```
 
 ### Common Operations
@@ -132,16 +137,16 @@ Use `/` to filter jobs:
 /RUNNING        # Show only running jobs
 /gpu            # Find jobs with "gpu" in any field
 /p:gpu          # Filter by partition "gpu"
-/user:alice     # Jobs by user alice
+/alice          # Find jobs with "alice" in any field
 ```
 
 Press `ESC` to clear filters.
 
-For complex filtering, press `F3`:
+For complex filtering, press `Ctrl+F` (in Jobs/Nodes views) to open the advanced filter with field-specific syntax:
 ```
-state:RUNNING partition:gpu
-user:alice priority:>500
-nodes:>=8
+state=RUNNING partition=gpu
+user=alice priority>500
+nodes>=8
 ```
 
 ## 💻 Nodes View
@@ -199,7 +204,7 @@ CPU: ████████░░░░░░░░ 8/16 (Load: 7.5)
 
 ### Example 3: SSH to a Node
 
-1. Switch to Nodes view (press `N`)
+1. Switch to Nodes view (press `2`)
 2. Find your node (use `/nodename` to filter)
 3. Press `s` to open SSH menu
 4. Select "Quick Connect"
@@ -221,29 +226,29 @@ CPU: ████████░░░░░░░░ 8/16 (Load: 7.5)
 
 ## 🔍 Advanced Features
 
-### Global Search
+### Quick Filter
 
-Press `Ctrl+F` for cluster-wide search:
+Press `/` to filter the current view:
 
 ```
-# Search finds jobs, nodes, partitions, etc.
-Ctrl+F → type "gpu001"
-# Shows: gpu001 node, jobs on gpu001, etc.
+# Type to filter — matches across all columns
+/ → type "gpu001"
+# Shows matching rows in the current view
 ```
 
 ### Advanced Filtering
 
-Press `F3` for expression-based filtering:
+Press `Ctrl+F` (in Jobs/Nodes views) to open the advanced filter with expression-based filtering:
 
 ```bash
 # Jobs view
-state:RUNNING partition:gpu nodes:>4
+state=RUNNING partition=gpu nodes>4
 
 # Nodes view
-state:IDLE partition:compute cpus:>64
+state=idle partition=compute cpus>64
 
 # Partitions view
-efficiency:>80 qos:high
+efficiency>80 qos=high
 ```
 
 ### Batch Operations
@@ -252,7 +257,7 @@ Select multiple items:
 
 1. Press `v/V` to enter multi-select mode
 2. Press `Space` on items to select
-3. Press `Ctrl+A` to select all
+3. Press `V` to select all visible
 4. Press `b/B` for batch menu
 5. Choose operation (cancel, hold, release, etc.)
 
@@ -291,13 +296,6 @@ See [Commands Reference](../reference/commands.md) for complete command document
 
 ## 🎨 Quick Customization
 
-### Auto-Refresh
-
-In Jobs view:
-```
-Press m/M to toggle auto-refresh on/off
-```
-
 ### Grouping (Nodes)
 
 ```
@@ -330,7 +328,7 @@ Now that you know the basics, explore:
 ## 🆘 Getting Help
 
 - **In-app help**: Press `?` anywhere for context-sensitive help
-- **View documentation**: Press `F1` for action menu
+- **View documentation**: Press `F1` for help
 - **Full docs**: [https://s9s.dev/docs](https://s9s.dev/docs)
 - **Troubleshooting**: [Troubleshooting Guide](../guides/troubleshooting.md)
 - **GitHub Issues**: [Report bugs](https://github.com/jontk/s9s/issues)
@@ -341,7 +339,7 @@ Now that you know the basics, explore:
 A: Press `q` to quit.
 
 **Q: Can I use s9s without SLURM?**
-A: Yes! Use `s9s --mock` for a fully functional demo mode.
+A: Yes! Use `S9S_ENABLE_MOCK=1 s9s --mock` for a fully functional demo mode.
 
 **Q: How do I cancel multiple jobs?**
 A: Use multi-select (`v/V`), select jobs with `Space`, then press `b/B` for batch operations.
@@ -350,7 +348,7 @@ A: Use multi-select (`v/V`), select jobs with `Space`, then press `b/B` for batc
 A: Yes! Press `s/S` in Nodes view for SSH options.
 
 **Q: How do I filter by partition?**
-A: Use `/` and type `p:partitionname` or `partition:name`.
+A: Use `/` and type `p:partitionname` for quick filter, or press `Ctrl+F` and type `partition=name` for advanced filter.
 
 **Q: Is there a way to save my filters?**
 A: Saved filters are a planned feature. For now, use `/` to quickly re-enter filters in any view.

--- a/docs/guides/job-streaming.md
+++ b/docs/guides/job-streaming.md
@@ -88,6 +88,7 @@ The streaming system uses an internal `EventBus` for pub/sub event delivery. The
 - `NEW_OUTPUT` -- new content available.
 - `JOB_COMPLETE` -- the job has finished.
 - `ERROR` -- a streaming error occurred.
+- `FILE_ROTATED` -- the output file was rotated or truncated.
 - `STREAM_START` / `STREAM_STOP` -- lifecycle events.
 
 ## Export

--- a/docs/guides/mock-mode.md
+++ b/docs/guides/mock-mode.md
@@ -8,32 +8,15 @@ s9s includes environment variable gating for mock mode to prevent accidental use
 
 ### Environment Variable Gating
 
-Mock mode requires `S9S_ENABLE_MOCK` environment variable to be set to specific values:
+Mock mode requires the `S9S_ENABLE_MOCK` environment variable to be set. Any non-empty value enables mock mode:
 
 ```bash
-# Allowed values (case insensitive)
-S9S_ENABLE_MOCK=development  # Recommended for development
-S9S_ENABLE_MOCK=testing      # For testing environments
-S9S_ENABLE_MOCK=debug        # For debugging purposes
-S9S_ENABLE_MOCK=dev          # Short form for development
-S9S_ENABLE_MOCK=local        # For local usage
-S9S_ENABLE_MOCK=true         # Generic enablement
+# Any non-empty value works
+export S9S_ENABLE_MOCK=1
+export S9S_ENABLE_MOCK=true
+export S9S_ENABLE_MOCK=yes
+export S9S_ENABLE_MOCK=development
 ```
-
-### Production Environment Detection
-
-The system automatically detects production environments by checking:
-- `ENVIRONMENT=production`
-- `NODE_ENV=production`
-- `GO_ENV=production`
-- `RAILS_ENV=production`
-
-### Production Safety Features
-
-When mock mode is requested in a production environment:
-1. **Warning Display**: Shows prominent warning about mock usage
-2. **Interactive Confirmation**: Requires explicit user confirmation
-3. **Non-Interactive Protection**: Automatically denies in non-interactive terminals
 
 ## Usage Examples
 
@@ -41,7 +24,7 @@ When mock mode is requested in a production environment:
 
 ```bash
 # Set environment variable (permanent)
-echo 'export S9S_ENABLE_MOCK=development' >> ~/.bashrc
+echo 'export S9S_ENABLE_MOCK=1' >> ~/.bashrc
 source ~/.bashrc
 
 # Use mock mode
@@ -52,11 +35,11 @@ s9s --mock
 
 ```bash
 # Set for current session only
-export S9S_ENABLE_MOCK=development
+export S9S_ENABLE_MOCK=1
 s9s --mock
 
 # Or inline
-S9S_ENABLE_MOCK=development s9s --mock
+S9S_ENABLE_MOCK=1 s9s --mock
 ```
 
 ### Check Mock Status
@@ -84,49 +67,34 @@ s9s mock status         # Show mock mode status and configuration
 
 ### Mock Disabled
 
+When mock mode is requested without the environment variable set, the following error is displayed:
+
 ```
-Mock mode disabled
+mock mode disabled
 
-To enable mock mode, set one of these environment variables:
-  S9S_ENABLE_MOCK=development  # For development
-  S9S_ENABLE_MOCK=testing      # For testing
-  S9S_ENABLE_MOCK=debug        # For debugging
-  S9S_ENABLE_MOCK=true         # Generic enable
-
-Example:
-  export S9S_ENABLE_MOCK=development
+To enable mock mode, set the S9S_ENABLE_MOCK environment variable:
+  export S9S_ENABLE_MOCK=1
   s9s --mock
-```
-
-### Production Warning
-
-```
-WARNING: Mock SLURM client enabled in production environment!
-   This should only be used for debugging purposes.
-   Mock mode provides simulated data, not real cluster information.
-
-Are you sure you want to continue with mock mode in production? (yes/no):
 ```
 
 ## Configuration File Behavior
 
 If `useMockClient: true` is set in the config file but `S9S_ENABLE_MOCK` is not set:
-- Mock mode is automatically disabled
-- Real SLURM client mode is used instead
-- Warning message is displayed about the environment override
+- The application exits with an error message
+- The error instructs the user to set the environment variable
+- Setup suggestions are displayed via `SuggestMockSetup()`
 
 ## Implementation Details
 
 ### Mock Validator (`internal/mock/validator.go`)
-- `IsMockEnabled()`: Checks if mock mode is allowed via environment variables
-- `IsProductionEnvironment()`: Detects production environment indicators
-- `ValidateMockUsage()`: Main validation logic with user prompts
-- `GetMockStatusMessage()`: User-friendly status messages
+- `IsMockEnabled()`: Returns true if `S9S_ENABLE_MOCK` environment variable is set to any non-empty value
+- `ValidateMockUsage(useMockClient bool)`: Returns an error if mock is requested but not enabled via the environment variable
+- `SuggestMockSetup()`: Prints setup instructions for enabling mock mode
 
 ### CLI Integration (`internal/cli/root.go`)
 - Environment validation before application startup
-- Graceful fallback from config-enabled mock to real mode
-- Clear error messages and setup suggestions
+- If validation fails, the error is displayed and `SuggestMockSetup()` is called
+- The application returns an error and does not start
 
 ## Testing
 
@@ -138,8 +106,6 @@ bash test_mock_validation.sh
 Tests cover:
 - Mock blocking without environment variable
 - Mock allowance with valid environment variables
-- Production environment detection and warnings
-- Invalid environment variable rejection
 
 ## Benefits
 
@@ -147,10 +113,8 @@ Tests cover:
 2. **Flexibility**: Allows controlled testing/debugging when needed
 3. **Simplicity**: Single binary works across all environments
 4. **Visibility**: Clear status and configuration commands
-5. **Safety**: Multiple layers of protection for production environments
 
 ## Related Guides
 
-- [Configuration Guide](../CONFIGURATION.md)
-- [Getting Started](../getting-started.md)
-- [Development Setup](./development-setup.md)
+- [Configuration Reference](../reference/configuration.md)
+- [Getting Started](../getting-started/quickstart.md)

--- a/docs/guides/mock-mode.md
+++ b/docs/guides/mock-mode.md
@@ -100,7 +100,7 @@ If `useMockClient: true` is set in the config file but `S9S_ENABLE_MOCK` is not 
 
 Run the included test suite:
 ```bash
-bash test_mock_validation.sh
+go test -v ./internal/mock/...
 ```
 
 Tests cover:

--- a/docs/guides/ssh-integration.md
+++ b/docs/guides/ssh-integration.md
@@ -103,24 +103,12 @@ SSH directly to nodes running specific jobs:
 
 ## SSH Features
 
-### Connection Testing
-
-Test SSH connectivity to a node before opening a session:
-
-```bash
-# From the SSH options menu, select "Test Connection"
-# S9S will verify:
-# - SSH connectivity
-# - Authentication
-# - Basic command execution
-```
-
 ### Node Information Retrieval
 
-Gather basic node information via SSH:
+Gather basic node information via SSH from within the SSH Terminal Manager:
 
 ```bash
-# From the SSH options menu, select "Get Node Info"
+# In the SSH Terminal Manager, press 'i' to get node info
 # Retrieves:
 # - Hostname
 # - Uptime
@@ -129,14 +117,9 @@ Gather basic node information via SSH:
 # - Disk usage
 ```
 
-### SSH Options Menu
+### SSH Terminal Manager Access
 
-When initiating SSH from the Nodes View, S9S presents options:
-
-- **SSH Terminal Manager** - Advanced session management interface
-- **Quick Connect** - Direct SSH connection (fastest)
-- **Test Connection** - Verify SSH connectivity
-- **Get Node Info** - Retrieve basic node information
+When you press `s` on a node in the Nodes View, S9S opens the SSH Terminal Manager directly. From there, you use keyboard shortcuts to perform various actions such as connecting to sessions, retrieving node information, and managing terminals. See the [Keyboard Reference](#keyboard-reference) below for available keybindings.
 
 ## SSH Security
 
@@ -245,7 +228,8 @@ user@node001:~$ tail -f /path/to/job/output
 :nodes
 
 # 2. Select a problematic node
-# 3. Press 's' → choose "Get Node Info"
+# 3. Press 's' to open the SSH Terminal Manager
+# 4. Press 'i' to retrieve node info
 
 # S9S retrieves and displays:
 # - Uptime
@@ -253,7 +237,7 @@ user@node001:~$ tail -f /path/to/job/output
 # - Disk space
 # - CPU count
 
-# Or choose "Quick Connect" for full SSH access
+# Or press Enter/t to open a full SSH terminal session
 ```
 
 ### Investigate Failed Job
@@ -293,6 +277,9 @@ SSH access integrates seamlessly with S9S cluster management:
 - `i` - Show node information
 - `t` - Open terminal session
 - `s` - Show system information
+- `m` or `M` - Monitor session status
+- `x` or `X` - Close selected session
+- `r` or `R` - Refresh sessions
 - `Esc` - Close SSH interface
 
 ## Next Steps

--- a/docs/guides/ssh-integration.md
+++ b/docs/guides/ssh-integration.md
@@ -46,41 +46,16 @@ node001  IDLE    16/32 cores  64GB/128GB  ← [s] SSH here
 
 ## SSH Configuration
 
-### Basic Configuration
+S9S uses your system's default SSH configuration (`~/.ssh/config`, SSH agent, etc.). There is no `ssh:` section in the S9S configuration file. SSH connection parameters (username, port, key file) are handled programmatically per-connection based on the node being accessed.
 
-S9S uses your system's SSH configuration by default. Configure SSH settings in `~/.s9s/config.yaml`:
+To customize SSH behavior, configure your system SSH settings in `~/.ssh/config`:
 
-```yaml
-ssh:
-  # Default SSH user
-  defaultUser: ${USER}
-
-  # SSH key file
-  keyFile: ~/.ssh/id_rsa
-
-  # Connection options
-  compression: true
-  forwardAgent: true
-  connectTimeout: 10s
-
-  # Additional SSH arguments
-  extraArgs: "-o StrictHostKeyChecking=ask -o ServerAliveInterval=60"
 ```
-
-### SSH Key Management
-
-S9S leverages your existing SSH infrastructure:
-
-```yaml
-ssh:
-  keys:
-    # Default key
-    default: ~/.ssh/id_rsa
-
-  # Key agent settings
-  agent:
-    useAgent: true
-    addKeysOnConnect: true
+Host node*
+  User your-username
+  IdentityFile ~/.ssh/cluster_key
+  StrictHostKeyChecking no
+  ServerAliveInterval 60
 ```
 
 ## Interactive SSH Sessions
@@ -165,35 +140,22 @@ When initiating SSH from the Nodes View, S9S presents options:
 
 ## SSH Security
 
-### Authentication Methods
+### Authentication
 
-S9S uses SSH key authentication by default:
-
-```yaml
-ssh:
-  auth:
-    method: key
-    keyFile: ~/.ssh/id_rsa
-```
+S9S relies on your system SSH configuration for authentication. SSH key authentication is recommended.
 
 ### Security Best Practices
 
-```yaml
-ssh:
-  security:
-    # Require host key verification (recommended for production)
-    strictHostKeyChecking: true
-    knownHostsFile: ~/.ssh/known_hosts
+Configure security settings in your system SSH config (`~/.ssh/config`):
 
-    # Connection limits
-    connectTimeout: 30s
-
-    # Audit logging
-    logConnections: true
-    logFile: ~/.s9s/ssh.log
+```
+Host node*
+  StrictHostKeyChecking yes
+  UserKnownHostsFile ~/.ssh/known_hosts
+  ConnectTimeout 30
 ```
 
-**Important Security Note**: By default, S9S disables strict host key checking for cluster environments where nodes are frequently rebuilt. For production use, enable strict host key checking in your configuration.
+**Important Security Note**: For production environments, enable strict host key checking in your SSH configuration. In cluster environments where nodes are frequently rebuilt, you may choose to disable it, but be aware of the security implications.
 
 ## SSH Troubleshooting
 
@@ -216,11 +178,10 @@ If SSH connection fails:
    chmod 600 ~/.ssh/id_rsa
    ```
 
-4. **Check S9S SSH configuration**:
-   ```yaml
-   ssh:
-     keyFile: ~/.ssh/id_rsa  # Verify this path is correct
-     defaultUser: ${USER}    # Verify username
+4. **Check system SSH configuration**:
+   ```bash
+   # Verify your SSH config for cluster nodes
+   cat ~/.ssh/config
    ```
 
 ### Common SSH Issues
@@ -336,6 +297,5 @@ SSH access integrates seamlessly with S9S cluster management:
 
 ## Next Steps
 
-- Learn more about [Node Operations](../node-operations.md)
-- Explore [Job Management](../job-management.md) with SSH debugging
-- Review [Troubleshooting Guide](../troubleshooting.md) for common issues
+- Explore [Job Management](job-management.md) with SSH debugging
+- Review [Troubleshooting Guide](troubleshooting.md) for common issues

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -229,8 +229,9 @@ echo $SLURM_JWT
    ```yaml
    # Update API version
    clusters:
-     default:
-       apiVersion: v0.0.43  # or latest
+     - name: "default"
+       cluster:
+         apiVersion: v0.0.43  # or latest
    ```
 
 3. **Partition visibility**:
@@ -283,7 +284,10 @@ echo $SLURM_JWT
    # Enable debug logging
    s9s --debug
 
-   # Check debug log (written to ~/.s9s/s9s.log)
+   # Check debug log (written to ./s9s-debug.log in current directory)
+   tail -f ./s9s-debug.log
+
+   # Check app log (general application log)
    tail -f ~/.s9s/s9s.log
    ```
 
@@ -363,17 +367,20 @@ curl -k -H "X-Auth-Token: $SLURM_JWT" \
 
 ### Log Analysis
 
-Check S9S logs (debug logging must be enabled with `--debug`):
+The `--debug` flag writes a debug log to `./s9s-debug.log` in the current working directory. The general app log is at `~/.s9s/s9s.log`.
 
 ```bash
-# View recent logs
+# View recent debug log (created by --debug flag)
+tail -n 100 ./s9s-debug.log
+
+# Search for errors in debug log
+grep ERROR ./s9s-debug.log
+
+# Monitor debug log in real time
+tail -f ./s9s-debug.log
+
+# View general app log
 tail -n 100 ~/.s9s/s9s.log
-
-# Search for errors
-grep ERROR ~/.s9s/s9s.log
-
-# Monitor logs in real time
-tail -f ~/.s9s/s9s.log
 ```
 
 ## Diagnostic Information
@@ -409,8 +416,8 @@ s9s --version
 # Run with debug logging
 s9s --debug 2>&1 | tee debug.log
 
-# Collect log file if available
-tar czf s9s-debug.tar.gz ~/.s9s/s9s.log
+# Collect debug log if available
+tar czf s9s-debug.tar.gz ./s9s-debug.log ~/.s9s/s9s.log
 ```
 
 ### Community Support

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -59,13 +59,13 @@ ss -tlnp | grep 6820
 
 # Test connection
 s9s --debug
-s9s config test
+s9s config validate
 
 # Check API endpoint
-curl -k https://your-slurm-api.com/slurm/v0.0.40/ping
+curl -k https://your-slurm-api.com/slurm/v0.0.43/ping
 
 # Verify credentials
-echo $SLURM_TOKEN
+echo $SLURM_JWT
 ```
 
 **Solutions**:
@@ -83,14 +83,14 @@ echo $SLURM_TOKEN
    curl http://localhost:6820/slurm/v0.0.43/ping
    ```
 
-2. **Check URL format**:
+2. **Check endpoint format**:
    ```yaml
    # Correct
-   url: https://slurm.example.com:6820
+   endpoint: "https://slurm.example.com:6820"
 
    # Incorrect
-   url: slurm.example.com  # Missing protocol
-   url: https://slurm.example.com:6820/  # Trailing slash
+   endpoint: "slurm.example.com"  # Missing protocol
+   endpoint: "https://slurm.example.com:6820/"  # Trailing slash
    ```
 
 3. **Verify network access**:
@@ -107,14 +107,10 @@ echo $SLURM_TOKEN
    ```yaml
    # For self-signed certificates
    clusters:
-     default:
-       insecureTLS: true
-
-   # Or specify CA certificate
-   clusters:
-     default:
-       tls:
-         caFile: /path/to/ca.crt
+     - name: "default"
+       cluster:
+         endpoint: "https://slurm.example.com:6820"
+         insecure: true
    ```
 
 #### Authentication failures
@@ -126,31 +122,23 @@ echo $SLURM_TOKEN
 1. **Token authentication**:
    ```bash
    # Verify token
-   echo $SLURM_TOKEN
+   echo $SLURM_JWT
 
    # Test token directly
-   curl -H "X-Auth-Token: $SLURM_TOKEN" \
-        https://slurm.example.com/slurm/v0.0.40/jobs
+   curl -H "X-Auth-Token: $SLURM_JWT" \
+        https://slurm.example.com/slurm/v0.0.43/jobs
 
    # Refresh token
    scontrol token
    ```
 
-2. **Basic authentication**:
-   ```yaml
-   auth:
-     method: basic
-     username: ${SLURM_USER}
-     password: ${SLURM_PASS}
-   ```
-
-3. **OAuth2 issues**:
+2. **Generate a new token**:
    ```bash
-   # Test OAuth2 flow
-   s9s auth login --cluster production
+   # Generate a new SLURM JWT token
+   scontrol token
 
-   # Clear cached tokens
-   rm -rf ~/.s9s/tokens/
+   # Set it in your environment
+   export SLURM_JWT="<new-token>"
    ```
 
 ### Display Issues
@@ -182,10 +170,9 @@ echo $SLURM_TOKEN
 
 3. **Adjust S9S settings**:
    ```yaml
-   preferences:
-     unicodeSupport: false
-     colorMode: 16  # Fallback to 16 colors
-     theme: simple  # Basic theme
+   ui:
+     skin: "default"
+     noIcons: true  # Disable icons if they render incorrectly
    ```
 
 #### Screen flickering or slow updates
@@ -197,8 +184,7 @@ echo $SLURM_TOKEN
 1. **Adjust refresh rate**:
    Change the `refreshRate` setting in your configuration file (`~/.s9s/config.yaml`):
    ```yaml
-   preferences:
-     refreshRate: 10s  # Slower refresh (default is 30s)
+   refreshRate: "10s"  # Slower refresh (default is 2s)
    ```
 
 2. **Customize visible columns**:
@@ -206,7 +192,7 @@ echo $SLURM_TOKEN
    ```yaml
    views:
      jobs:
-       columns: [JobID, Name, State, Time]
+       columns: [id, name, state, time]
    ```
 
 3. **Check system resources**:
@@ -226,7 +212,7 @@ echo $SLURM_TOKEN
 
 **Diagnostics**:
 - Press `/` to check if a filter is active, then press `Esc` to clear it
-- Press `R` to force a manual refresh
+- Press `F5` to force a manual refresh
 
 **Solutions**:
 
@@ -244,7 +230,7 @@ echo $SLURM_TOKEN
    # Update API version
    clusters:
      default:
-       apiVersion: v0.0.40  # or latest
+       apiVersion: v0.0.43  # or latest
    ```
 
 3. **Partition visibility**:
@@ -265,7 +251,7 @@ echo $SLURM_TOKEN
 1. **Force refresh**:
    ```bash
    # Manual refresh
-   R       # Press R in any view
+   F5       # Press F5 in any view
    ```
 
 2. **Check time sync**:
@@ -285,29 +271,29 @@ echo $SLURM_TOKEN
 
 **Solutions**:
 
-1. **Optimize queries**:
+1. **Limit displayed jobs**:
    ```yaml
-   performance:
-     maxResults: 100  # Limit results
-     cacheEnabled: true
-     cacheTTL: 60s
+   views:
+     jobs:
+       maxJobs: 100  # Limit results (default 1000)
    ```
 
 2. **Debug mode analysis**:
    ```bash
-   # Enable profiling
-   s9s --profile
+   # Enable debug logging
+   s9s --debug
 
-   # Check debug log
-   tail -f ~/.s9s/debug.log
+   # Check debug log (written to ~/.s9s/s9s.log)
+   tail -f ~/.s9s/s9s.log
    ```
 
-3. **Network optimization**:
+3. **Increase cluster timeout**:
    ```yaml
    clusters:
-     default:
-       timeout: 60s  # Increase timeout
-       compression: true  # Enable compression
+     - name: "default"
+       cluster:
+         endpoint: "https://slurm.example.com:6820"
+         timeout: "60s"  # Increase timeout
    ```
 
 ### SSH Issues
@@ -318,12 +304,12 @@ echo $SLURM_TOKEN
 
 **Solutions**:
 
-1. **Configure SSH settings**:
-   ```yaml
-   ssh:
-     defaultUser: ${USER}
-     keyFile: ~/.ssh/id_rsa
-     extraArgs: "-o StrictHostKeyChecking=no"
+1. **Configure SSH via system settings** (`~/.ssh/config`):
+   ```
+   Host node*
+     User your-username
+     IdentityFile ~/.ssh/id_rsa
+     StrictHostKeyChecking no
    ```
 
 2. **Test SSH manually**:
@@ -367,17 +353,17 @@ Test the SLURM REST API directly to isolate connection issues:
 
 ```bash
 # Test API endpoint
-curl -k -H "X-Auth-Token: $SLURM_TOKEN" \
-     https://slurm.example.com/slurm/v0.0.40/ping
+curl -k -H "X-Auth-Token: $SLURM_JWT" \
+     https://slurm.example.com/slurm/v0.0.43/ping
 
 # List jobs via API
-curl -k -H "X-Auth-Token: $SLURM_TOKEN" \
-     https://slurm.example.com/slurm/v0.0.40/jobs
+curl -k -H "X-Auth-Token: $SLURM_JWT" \
+     https://slurm.example.com/slurm/v0.0.43/jobs
 ```
 
 ### Log Analysis
 
-Check S9S logs:
+Check S9S logs (debug logging must be enabled with `--debug`):
 
 ```bash
 # View recent logs
@@ -423,8 +409,8 @@ s9s --version
 # Run with debug logging
 s9s --debug 2>&1 | tee debug.log
 
-# Collect log files if available
-tar czf s9s-debug.tar.gz ~/.s9s/logs/
+# Collect log file if available
+tar czf s9s-debug.tar.gz ~/.s9s/s9s.log
 ```
 
 ### Community Support
@@ -493,7 +479,5 @@ cp ~/s9s-config-backup.yaml ~/.s9s/config.yaml
 
 ## Next Steps
 
-- Review [Configuration Guide](../configuration.md) for optimization
-- Learn [Performance Tuning](../performance.md)
-- Set up [Monitoring](../monitoring.md)
+- Review [Configuration Reference](../reference/configuration.md) for optimization
 - Join our [Community](https://discord.gg/s9s) for help

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,8 +28,8 @@ curl -sSL https://get.s9s.dev | bash
 # Launch s9s
 s9s
 
-# Or try mock mode (no SLURM required)
-s9s --mock
+# Or try mock mode (no SLURM required, requires S9S_ENABLE_MOCK env var)
+S9S_ENABLE_MOCK=1 s9s --mock
 ```
 
 ### Documentation Sections

--- a/docs/plugins/development.md
+++ b/docs/plugins/development.md
@@ -21,20 +21,29 @@ This guide provides comprehensive instructions for developing plugins for the s9
 
 ## Overview
 
-The s9s plugin system allows you to:
+s9s has two plugin systems:
+
+1. **Compile-time plugins** (`internal/plugin/interface.go`) -- registered at build time, support advanced features like overlays, data providers, hooks, and lifecycle events.
+2. **Shared library plugins** (`internal/plugins/interface.go`) -- loaded as `.so` files at runtime, receive a `dao.SlurmClient` and can provide commands, views, and key bindings.
+
+The compile-time system allows you to:
 - Add custom views to the TUI (via `ViewPlugin`)
 - Overlay additional data on existing views (via `OverlayPlugin`)
-- Provide data to other plugins (via `DataPlugin`)
+- Provide data to other plugins (via `DataPlugin` with `GetDataProviders()`, `Subscribe()`, `Unsubscribe()`, `Query()`)
 - React to lifecycle and configuration events (via `LifecycleAware`)
 - Integrate with external systems through hooks (via `HookablePlugin`)
 
+The shared library system allows you to:
+- Provide CLI commands (`GetCommands()`)
+- Provide TUI views (`GetViews()`)
+- Add key bindings (`GetKeyBindings()`)
+- React to application events (`OnEvent()`)
+
 ## Plugin Architecture
 
-Plugins are implemented as Go shared libraries (`.so` files) that implement the `Plugin` interface. They are loaded dynamically at runtime.
+### Compile-time Plugin Interface
 
-### Plugin Interface
-
-Every plugin must implement the base `Plugin` interface defined in `internal/plugin/interface.go`:
+Every compile-time plugin must implement the base `Plugin` interface defined in `internal/plugin/interface.go`:
 
 ```go
 type Plugin interface {
@@ -59,7 +68,7 @@ Plugins can also implement additional interfaces for extended functionality:
 
 - **`ViewPlugin`** -- provides custom TUI views (`GetViews()`, `CreateView()`)
 - **`OverlayPlugin`** -- adds data overlays to existing views (`GetOverlays()`, `CreateOverlay()`)
-- **`DataPlugin`** -- provides data to other plugins via pub/sub (`Subscribe()`, `Query()`)
+- **`DataPlugin`** -- provides data to other plugins via pub/sub (`GetDataProviders()`, `Subscribe()`, `Unsubscribe()`, `Query()`)
 - **`ConfigurablePlugin`** -- supports runtime configuration changes (`GetConfig()`, `SetConfig()`, `ValidateConfig()`)
 - **`HookablePlugin`** -- provides hooks for event-driven integration (`GetHooks()`, `RegisterHook()`)
 - **`LifecycleAware`** -- receives lifecycle events (`OnEnable()`, `OnDisable()`, `OnConfigChange()`)

--- a/docs/plugins/development.md
+++ b/docs/plugins/development.md
@@ -91,7 +91,7 @@ my-plugin/
 ### Step 1: Create the main module
 
 ```go
-// +build plugin
+//go:build plugin
 
 package main
 
@@ -325,16 +325,17 @@ cp my-plugin.so ~/.s9s/plugins/
 Add to your s9s config file:
 
 ```yaml
+pluginSettings:
+  pluginDir: "~/.s9s/plugins"
 plugins:
-  enabled: true
-  directory: ~/.s9s/plugins
-  autoload:
-    - my-plugin
+  - name: my-plugin
+    enabled: true
+    config: {}
 ```
 
 ### Loading at Runtime
 
-Plugins are loaded automatically from the configured directory when s9s starts with `plugins.enabled: true`. There are no CLI flags for loading individual plugins at this time.
+Plugins are loaded automatically from the configured `pluginSettings.pluginDir` directory when s9s starts. There are no CLI flags for loading individual plugins at this time.
 
 > **Note:** See [#119](https://github.com/jontk/s9s/issues/119) for planned plugin CLI commands.
 
@@ -343,7 +344,7 @@ Plugins are loaded automatically from the configured directory when s9s starts w
 ### Unit Testing
 
 ```go
-// +build plugin
+//go:build plugin
 
 func TestMyPlugin(t *testing.T) {
     p := &MyPlugin{}

--- a/docs/plugins/development.md
+++ b/docs/plugins/development.md
@@ -69,7 +69,7 @@ Plugins can also implement additional interfaces for extended functionality:
 - **`ViewPlugin`** -- provides custom TUI views (`GetViews()`, `CreateView()`)
 - **`OverlayPlugin`** -- adds data overlays to existing views (`GetOverlays()`, `CreateOverlay()`)
 - **`DataPlugin`** -- provides data to other plugins via pub/sub (`GetDataProviders()`, `Subscribe()`, `Unsubscribe()`, `Query()`)
-- **`ConfigurablePlugin`** -- supports runtime configuration changes (`GetConfig()`, `SetConfig()`, `ValidateConfig()`)
+- **`ConfigurablePlugin`** -- supports runtime configuration changes (`GetConfig()`, `SetConfig()`, `ValidateConfig()`, `GetConfigUI()`)
 - **`HookablePlugin`** -- provides hooks for event-driven integration (`GetHooks()`, `RegisterHook()`)
 - **`LifecycleAware`** -- receives lifecycle events (`OnEnable()`, `OnDisable()`, `OnConfigChange()`)
 - **`Prioritizable`** -- controls initialization order (`GetPriority()`)

--- a/docs/plugins/observability.md
+++ b/docs/plugins/observability.md
@@ -78,6 +78,8 @@ A comprehensive observability plugin for the s9s SLURM management interface that
 
 ### Basic Configuration
 
+> **Note:** The configuration below uses `observability:` as a top-level key for illustration purposes. In practice, these settings are passed via the `plugins[].config` section of the main s9s configuration file (see [Installation](#installation) above for the correct structure).
+
 ```yaml
 observability:
   # Prometheus connection settings
@@ -394,11 +396,17 @@ The efficiency analyzer uses a multi-factor scoring system:
 
 ### Debug Mode
 
-Enable debug logging by setting log level to debug:
+Enable debug logging by setting the log level in the plugin's config section of your s9s configuration:
 
-```bash
-export LOG_LEVEL=debug
+```yaml
+plugins:
+  - name: observability
+    enabled: true
+    config:
+      log_level: "debug"
 ```
+
+> **Note:** Debug logging is configured via the `plugins[].config` section, not via environment variable.
 
 ### Health Checks
 

--- a/docs/plugins/observability.md
+++ b/docs/plugins/observability.md
@@ -166,7 +166,7 @@ observability:
 
 ### Web Interface
 
-1. **Observability View**: Access the main observability dashboard by pressing 'o' in the s9s interface
+1. **Observability View**: Access the main observability dashboard via the plugin's registered view
 2. **Metric Overlays**: View real-time metrics overlaid on jobs and nodes views
 3. **Historical Charts**: Access time-series charts and trend analysis
 4. **Efficiency Dashboard**: Review resource efficiency scores and recommendations

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -13,29 +13,45 @@ The s9s plugin system allows extending the functionality of s9s through modular 
 
 ## Plugin Architecture
 
-Plugins in s9s are implemented as Go shared libraries (`.so` files) that implement specific interfaces. They are loaded dynamically at runtime and managed through a centralized plugin system.
+s9s has two plugin systems:
 
-### Core Components
+### 1. Compile-time Plugin System (`internal/plugin/`)
 
-1. **Plugin Interface** (`internal/plugin/interface.go`)
-   - Base `Plugin` interface that all plugins must implement
-   - Specialized interfaces for different plugin types:
-     - `ViewPlugin` - Provides custom views
-     - `OverlayPlugin` - Overlays data on existing views
-     - `DataPlugin` - Provides data to other plugins
-     - `ConfigurablePlugin` - Runtime configuration support
-     - `HookablePlugin` - Event hooks
+The primary plugin system uses compile-time registration. Plugins implement interfaces from `internal/plugin/interface.go` and are registered at build time.
 
-2. **Plugin Manager** (`internal/plugin/manager.go`)
-   - Manages plugin lifecycle (init, start, stop)
-   - Handles plugin dependencies
-   - Performs health checks
-   - Manages plugin state
+**Base `Plugin` interface** -- all plugins must implement:
+- `GetInfo() Info` -- metadata (name, version, author, dependencies, config schema)
+- `Init(ctx, config)` -- initialize with configuration
+- `Start(ctx)` / `Stop(ctx)` -- lifecycle management
+- `Health() HealthStatus` -- health reporting
 
-3. **Plugin Registry** (`internal/plugin/registry.go`)
-   - Registers and indexes plugins
-   - Resolves dependencies
-   - Manages plugin metadata
+**Specialized interfaces:**
+- `ViewPlugin` -- provides custom TUI views (`GetViews()`, `CreateView()`)
+- `OverlayPlugin` -- overlays data on existing views (`GetOverlays()`, `CreateOverlay()`)
+- `DataPlugin` -- provides data to other plugins (`GetDataProviders()`, `Subscribe()`, `Unsubscribe()`, `Query()`)
+- `ConfigurablePlugin` -- runtime configuration support (`GetConfig()`, `SetConfig()`, `ValidateConfig()`, `GetConfigUI()`)
+- `HookablePlugin` -- event hooks (`GetHooks()`, `RegisterHook()`)
+- `LifecycleAware` -- lifecycle events (`OnEnable()`, `OnDisable()`, `OnConfigChange()`)
+- `Prioritizable` -- controls initialization order (`GetPriority()`)
+
+**Plugin Manager** (`internal/plugin/manager.go`) -- manages plugin lifecycle, dependencies, and health checks.
+
+**Plugin Registry** (`internal/plugin/registry.go`) -- registers and indexes plugins, resolves dependencies.
+
+### 2. Shared Library Plugin System (`internal/plugins/`)
+
+The secondary system loads `.so` shared libraries at runtime. Plugins implement interfaces from `internal/plugins/interface.go`:
+
+**Base `Plugin` interface:**
+- `GetInfo() PluginInfo` -- basic plugin info (name, version, description, author, website)
+- `Initialize(ctx, client dao.SlurmClient)` -- initialize with SLURM client access
+- `GetCommands() []Command` -- provide CLI commands (Name, Description, Usage, Handler)
+- `GetViews() []View` -- provide TUI views (GetName, GetTitle, Render, OnKey, Refresh, Init)
+- `GetKeyBindings() []KeyBinding` -- custom key bindings
+- `OnEvent(event Event)` -- react to application events (ViewChanged, JobSubmitted, etc.)
+- `Cleanup()` -- cleanup on unload
+
+**Plugin Manager** (`internal/plugins/interface.go: PluginManager`) -- loads/unloads `.so` plugins from directories, sends events to all plugins.
 
 ## Creating a Plugin
 
@@ -257,7 +273,6 @@ func TestMyPlugin(t *testing.T) {
 
 ## Future Enhancements
 
-- External plugin loading (shared libraries)
 - Plugin marketplace/registry
 - Plugin sandboxing
 - Inter-plugin communication

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -4,7 +4,7 @@
 
 ## What is s9s?
 
-s9s is a client-side TUI application that runs in your terminal to monitor and manage SLURM clusters. It connects directly to SLURM using SLURM's native command-line tools (squeue, scontrol, sacct, etc.) and the SLURM client library.
+s9s is a client-side TUI application that runs in your terminal to monitor and manage SLURM clusters. It connects to SLURM via the SLURM REST API (slurmrestd). The `scontrol` CLI tool is only used for auto-discovery of the slurmrestd endpoint and for JWT token generation.
 
 s9s does NOT:
 - Run as a server or daemon

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -47,6 +47,6 @@ Go client library for SLURM REST API:
 ## Using s9s
 
 For information on using the s9s TUI application, see:
-- [Views Guide](../guides/views.md) - Overview of all TUI views
+- [Views Guide](../user-guide/views/index.md) - Overview of all TUI views
 - [Configuration](./configuration.md) - Configuration options
-- [Keyboard Shortcuts](./keyboard-shortcuts.md) - Navigation and commands
+- [Command Reference](../reference/commands.md) - Navigation and commands

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -117,6 +117,7 @@ S9S provides interactive keyboard shortcuts for common operations within each vi
 |-----|--------|
 | `s` | SSH to selected node |
 | `d` | Drain selected node |
+| `r` | Resume drained node |
 | `i` | Toggle idle state filter |
 | `Enter` | Show node details |
 | `Space` | Toggle group expansion |

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -25,16 +25,16 @@ Press `:` to enter command mode (vim-style). Commands support tab completion for
 ### Navigation Commands
 | Command | Description | Shortcut |
 |---------|-------------|----------|
-| `:jobs` | Switch to jobs view | `1` or `j` |
-| `:nodes` | Switch to nodes view | `2` or `n` |
-| `:users` | Switch to users view | `3` |
-| `:partitions` | Switch to partitions view | `4` or `p` |
-| `:dashboard` | Switch to dashboard | `0` |
-| `:reservations` | Switch to reservations view | - |
-| `:qos` | Switch to QoS view | - |
-| `:accounts` | Switch to accounts view | - |
-| `:health` | Switch to health view | - |
-| `:performance` | Switch to performance view | - |
+| `:jobs` | Switch to jobs view | `1` |
+| `:nodes` | Switch to nodes view | `2` |
+| `:partitions` | Switch to partitions view | `3` |
+| `:reservations` | Switch to reservations view | `4` |
+| `:qos` | Switch to QoS view | `5` |
+| `:accounts` | Switch to accounts view | `6` |
+| `:users` | Switch to users view | `7` |
+| `:dashboard` | Switch to dashboard | `8` |
+| `:health` | Switch to health view | `9` |
+| `:performance` | Switch to performance view | `0` |
 | `:help` or `:h` | Show help | `?` |
 | `:quit` or `:q` | Exit S9S | `q` |
 
@@ -90,12 +90,11 @@ My Custom Job          saved     Custom template from user
 
 See [Job Submission Configuration](../getting-started/configuration.md#job-submission-configuration) for details on defining templates in your configuration file.
 
-### Filtering and Search
-| Command | Description | Example |
-|---------|-------------|---------|
-| `/` | Quick filter | `/user:alice` |
-| `:filter` | Advanced filter | `:filter "state:RUNNING nodes:>4"` |
-| `:clear` | Clear all filters | `:clear` |
+### Filtering
+| Key | Action |
+|-----|--------|
+| `/` | Quick filter (type to filter current view) |
+| `Esc` | Clear filter |
 
 ### Interactive Operations
 
@@ -105,7 +104,7 @@ S9S provides interactive keyboard shortcuts for common operations within each vi
 | Key | Action |
 |-----|--------|
 | `c` | Cancel selected job |
-| `h` | Hold selected job |
+| `h` | Hold selected job (view-specific; `h` is also global previous-view) |
 | `r` | Release selected job |
 | `d` | Show job details |
 | `o` | Show job output |
@@ -136,7 +135,7 @@ Export functionality is available through the interactive UI:
 - Text (`.txt`)
 
 **Access Export:**
-- Press `Ctrl+E` in any view to open export dialog
+- Press `e` in any view to open export dialog
 - Select format and destination
 - Configure export options interactively
 
@@ -145,23 +144,29 @@ Export functionality is available through the interactive UI:
 ### Global Shortcuts
 | Key | Action |
 |-----|--------|
-| `q` | Quit |
+| `q` / `Q` | Quit |
 | `?` | Help |
-| `r` | Refresh |
-| `Ctrl+C` | Interrupt/Cancel |
+| `Ctrl+C` | Quit |
+| `Ctrl+K` | Cluster switcher |
 | `Esc` | Clear/Cancel |
+| `F1` | Help |
+| `F5` | Refresh |
 
 ### Navigation Shortcuts
 | Key | Action |
 |-----|--------|
-| `0` | Dashboard view |
 | `1` | Jobs view |
 | `2` | Nodes view |
-| `3` | Users view |
-| `4` | Partitions view |
-| `j` | Jobs view |
-| `n` | Nodes view |
-| `p` | Partitions view |
+| `3` | Partitions view |
+| `4` | Reservations view |
+| `5` | QoS view |
+| `6` | Accounts view |
+| `7` | Users view |
+| `8` | Dashboard view |
+| `9` | Health view |
+| `0` | Performance view |
+| `h` | Previous view |
+| `l` | Next view |
 | `Tab` | Next view |
 | `Shift+Tab` | Previous view |
 
@@ -171,11 +176,11 @@ Export functionality is available through the interactive UI:
 | Key | Action |
 |-----|--------|
 | `c` | Cancel job |
-| `h` | Hold job |
+| `h` | Hold job (note: `h` is also global previous-view; global handler takes priority) |
 | `r` | Release job |
 | `d` | Show details |
 | `o` | Show output |
-| `l` | Show logs |
+| `l` | Show logs (note: `l` is also global next-view; global handler takes priority) |
 
 **Nodes View:**
 | Key | Action |
@@ -188,20 +193,18 @@ Export functionality is available through the interactive UI:
 | Key | Action |
 |-----|--------|
 | `Space` | Toggle selection |
-| `v` | Visual selection mode |
-| `V` | Visual line mode |
-| `Ctrl+A` | Select all |
+| `v` / `V` | Toggle multi-select mode |
 
 ### Filtering Shortcuts
 | Key | Action |
 |-----|--------|
 | `/` | Quick filter |
-| `Ctrl+/` | Clear filter |
+| `Esc` | Clear filter |
 
 ### Export Shortcuts
 | Key | Action |
 |-----|--------|
-| `Ctrl+E` | Export dialog |
+| `e` | Export dialog (Jobs and Nodes views) |
 
 ## Advanced Features
 
@@ -224,23 +227,24 @@ Press r to release selected jobs
 
 ### Filter Syntax
 
-The filter system supports various filter expressions:
+Press `/` for plain text search across all columns. Press `Ctrl+F` (available in Jobs and Nodes views) for the advanced filter with field-specific expressions:
 
 ```bash
+# Advanced filter examples (Ctrl+F)
 # Filter by user
-/user:alice
+user=alice
 
 # Filter by state
-/state:RUNNING
+state=RUNNING
 
 # Filter by partition
-/partition:gpu
+partition=gpu
 
 # Combine filters
-/user:alice state:RUNNING partition:gpu
+user=alice state=RUNNING partition=gpu
 
 # Numeric comparisons
-/nodes:>4 time:>2h
+nodes>4 priority>=1000
 ```
 
 See the [Filtering Guide](../user-guide/filtering.md) for comprehensive filter documentation.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -135,6 +135,7 @@ Export functionality is available through the interactive UI:
 - JSON (`.json`)
 - Markdown (`.md`)
 - Text (`.txt`)
+- HTML (`.html`)
 
 **Access Export:**
 - Press `e` in any view to open export dialog
@@ -191,7 +192,6 @@ Export functionality is available through the interactive UI:
 | `d` | Drain node |
 | `i` | Toggle idle filter |
 | `Enter` | Node details |
-| `d` | Show details |
 
 **Selection Shortcuts:**
 | Key | Action |
@@ -231,7 +231,7 @@ Press r to release selected jobs
 
 ### Filter Syntax
 
-Press `/` for plain text search across all columns. Press `Ctrl+F` (available in Jobs and Nodes views) for the advanced filter with field-specific expressions:
+Press `/` for plain text search across all columns. Press `Ctrl+F` in any data view to open global search across all entity types. The advanced filter bar supports field-specific expressions:
 
 ```bash
 # Advanced filter examples (Ctrl+F)

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -104,10 +104,11 @@ S9S provides interactive keyboard shortcuts for common operations within each vi
 | Key | Action |
 |-----|--------|
 | `c` | Cancel selected job |
-| `h` | Hold selected job (view-specific; `h` is also global previous-view) |
+| `H` | Hold selected job |
 | `r` | Release selected job |
-| `d` | Show job details |
+| `d` | Show job dependencies |
 | `o` | Show job output |
+| `Enter` | Show job details |
 | `Space` | Toggle selection |
 | `v` | Visual selection mode |
 
@@ -115,9 +116,10 @@ S9S provides interactive keyboard shortcuts for common operations within each vi
 | Key | Action |
 |-----|--------|
 | `s` | SSH to selected node |
-| `d` | Show node details |
-| `i` | Node info |
-| `Space` | Toggle selection |
+| `d` | Drain selected node |
+| `i` | Toggle idle state filter |
+| `Enter` | Show node details |
+| `Space` | Toggle group expansion |
 
 **Batch Operations:**
 - Select multiple items using `Space` or `v` (visual mode)
@@ -176,17 +178,19 @@ Export functionality is available through the interactive UI:
 | Key | Action |
 |-----|--------|
 | `c` | Cancel job |
-| `h` | Hold job (note: `h` is also global previous-view; global handler takes priority) |
+| `H` | Hold job |
 | `r` | Release job |
-| `d` | Show details |
+| `d` | Show dependencies |
 | `o` | Show output |
-| `l` | Show logs (note: `l` is also global next-view; global handler takes priority) |
+| `Enter` | Show details |
 
 **Nodes View:**
 | Key | Action |
 |-----|--------|
 | `s` | SSH to node |
-| `i` | Node info |
+| `d` | Drain node |
+| `i` | Toggle idle filter |
+| `Enter` | Node details |
 | `d` | Show details |
 
 **Selection Shortcuts:**
@@ -204,7 +208,7 @@ Export functionality is available through the interactive UI:
 ### Export Shortcuts
 | Key | Action |
 |-----|--------|
-| `e` | Export dialog (Jobs and Nodes views) |
+| `e` | Export dialog (all data views) |
 
 ## Advanced Features
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,8 +1,6 @@
 # Configuration Reference
 
-> **Note:** This reference describes both implemented and planned configuration options. Features marked with "(planned)" are not yet available. See [#117](https://github.com/jontk/s9s/issues/117) for details. For the currently implemented configuration, see [config.example.yaml](https://github.com/jontk/s9s/blob/main/config.example.yaml) and the [Getting Started Configuration Guide](../getting-started/configuration.md).
-
-Complete reference for all S9S configuration options, settings, and customization possibilities.
+Complete reference for all S9S configuration options, settings, and customization.
 
 ## Configuration Files
 
@@ -18,28 +16,38 @@ S9S uses a hierarchical configuration system with the following precedence (high
 
 ```yaml
 # ~/.s9s/config.yaml
-version: 1
+
+# General settings
+refreshRate: "2s"
+maxRetries: 3
+defaultCluster: "default"
 
 # Cluster connections
-clusters: {}
+clusters: []
 
-# UI preferences
-preferences: {}
+# UI settings
+ui: {}
 
-# Authentication settings
-auth: {}
+# View settings
+views: {}
+
+# Feature flags
+features: {}
+
+# Custom keyboard shortcuts
+shortcuts: []
+
+# Command aliases
+aliases: {}
 
 # Plugin configuration
-plugins: {}
+plugins: []
 
-# Performance tuning
-performance: {}
+# Plugin global settings
+pluginSettings: {}
 
-# Security settings
-security: {}
-
-# Integration settings
-integrations: {}
+# Auto-discovery settings
+discovery: {}
 ```
 
 ## Cluster Configuration
@@ -47,849 +55,359 @@ integrations: {}
 ### Basic Cluster Setup
 ```yaml
 clusters:
-  default:
-    # Required: SLURM REST API endpoint
-    url: "https://slurm.example.com:6820"
+  - name: "default"
+    cluster:
+      # Required: SLURM REST API endpoint
+      endpoint: "https://slurm.example.com:6820"
 
-    # Authentication configuration
-    auth:
-      method: "token"
-      token: "${SLURM_TOKEN}"
+      # JWT authentication token
+      token: "${SLURM_JWT}"
 
-    # Optional settings
-    name: "Production Cluster"
-    description: "Main production HPC cluster"
-    default: true
-    timeout: 30s
-    retries: 3
+      # API version (auto-detected if omitted)
+      apiVersion: "v0.0.43"
+
+      # Skip TLS certificate verification
+      insecure: false
+
+      # Request timeout
+      timeout: "30s"
+
+    # Optional: namespace for multi-tenant setups
+    namespace: ""
+
+    # Optional: prevent write operations
+    readOnly: false
 ```
 
-### Advanced Cluster Options
+### Multiple Clusters
 ```yaml
 clusters:
-  production:
-    url: "https://prod-slurm.example.com:6820"
+  - name: "production"
+    cluster:
+      endpoint: "https://slurm-prod.example.com:6820"
+      token: "${SLURM_JWT}"
+      timeout: "30s"
 
-    # Authentication methods
-    auth:
-      method: "oauth2"  # token, basic, oauth2, cert
-      client_id: "${OAUTH_CLIENT_ID}"
-      client_secret: "${OAUTH_CLIENT_SECRET}"
-      token_url: "https://auth.example.com/oauth/token"
-      scopes: ["slurm.read", "slurm.write"]
+  - name: "development"
+    cluster:
+      endpoint: "https://slurm-dev.example.com:6820"
+      token: "${DEV_SLURM_JWT}"
+      insecure: true
 
-    # TLS configuration
-    tls:
-      verify: true
-      ca_file: "/etc/ssl/certs/ca-bundle.crt"
-      cert_file: "/etc/s9s/client.crt"
-      key_file: "/etc/s9s/client.key"
-      insecure_skip_verify: false
-
-    # Connection settings
-    connection:
-      timeout: 30s
-      keep_alive: 60s
-      max_idle_conns: 10
-      max_conns_per_host: 5
-
-    # HTTP settings
-    http:
-      headers:
-        X-Custom-Header: "value"
-        User-Agent: "S9S/1.0"
-      proxy: "http://proxy.example.com:8080"
-
-    # Rate limiting
-    rate_limit:
-      requests_per_second: 10
-      burst: 20
-
-    # Caching
-    cache:
-      enabled: true
-      ttl: 60s
-      max_size: 100MB
+defaultCluster: "production"
 ```
 
-## UI Preferences
+## UI Configuration
 
-### Basic UI Settings
 ```yaml
-preferences:
-  # Theme selection
-  theme: "dark"  # dark, light
-  # custom_theme: "/path/to/custom-theme.yaml"  # (planned)
+ui:
+  # Theme/skin selection
+  skin: "default"
 
-  # Default view
-  default_view: "jobs"  # jobs, nodes, dashboard, users, partitions
+  # Hide logo
+  logoless: false
 
-  # Refresh settings
-  refresh_interval: 5s  # 0 to disable auto-refresh
-  auto_refresh: true
+  # Hide breadcrumbs
+  crumbsless: false
 
-  # Display preferences
-  show_line_numbers: false
-  show_relative_time: true
-  use_24_hour_time: false
-  show_seconds: true
-  timezone: "Local"  # Local, UTC, or specific timezone
-  date_format: "2006-01-02 15:04:05"
+  # Hide status bar
+  statusless: false
 
-  # Behavior
-  confirm_actions: true
-  save_window_state: true
-  enable_animations: true
-  wrap_long_lines: false
+  # Hide header
+  headless: false
 
-  # Pagination
-  page_size: 50
-  max_results: 1000
+  # Disable icons
+  noIcons: false
 
-  # Performance
-  lazy_loading: true
-  virtual_scrolling: true
-  debounce_delay: 300ms
+  # Enable mouse support
+  enableMouse: true
 ```
 
-### Advanced UI Configuration (planned)
+## View Configuration
+
+### Jobs View
 ```yaml
-preferences:
-  # Color customization
-  colors:
-    accent: "#00ff00"
-    warning: "#ffaa00"
-    error: "#ff0000"
-    info: "#00aaff"
-
-  # Font settings
-  fonts:
-    family: "JetBrains Mono"
-    size: 14
-    line_height: 1.2
-
-  # Layout preferences
-  layout:
-    sidebar_width: 300
-    panel_heights:
-      main: 0.7
-      details: 0.3
-    compact_mode: false
-
-  # Notifications
-  notifications:
-    enabled: true
-    position: "top-right"  # top-left, top-right, bottom-left, bottom-right
-    duration: 5s
-    sound: true
-    desktop: true
-```
-
-### Column Configuration
-```yaml
-# Per-view column settings
-columns:
+views:
   jobs:
-    visible:
-      - "JobID"
-      - "Name"
-      - "User"
-      - "State"
-      - "Time"
-      - "Nodes"
-      - "Partition"
-    widths:
-      JobID: 100
-      Name: 200
-      User: 120
-    sort:
-      column: "SubmitTime"
-      direction: "desc"
+    # Visible columns
+    columns: ["id", "name", "user", "state", "time", "nodes", "priority"]
 
+    # Show only active jobs
+    showOnlyActive: true
+
+    # Default sort column
+    defaultSort: "time"
+
+    # Maximum number of jobs to display
+    maxJobs: 1000
+
+    # Job submission configuration
+    submission:
+      # Default values for job submission form
+      formDefaults:
+        partition: "compute"
+        nodes: 1
+      # Fields to hide from submission form
+      hiddenFields: ["comment"]
+      # Custom dropdown options for fields
+      fieldOptions:
+        partition: ["compute", "gpu", "highmem"]
+      # Show built-in templates (default: true)
+      showBuiltinTemplates: true
+      # Template sources to load: builtin, config, saved
+      templateSources: ["builtin", "config", "saved"]
+      # Custom job templates
+      templates:
+        - name: "GPU Training Job"
+          description: "PyTorch training on GPU partition"
+          defaults:
+            partition: "gpu"
+            gres: "gpu:1"
+          hiddenFields: []
+```
+
+### Nodes View
+```yaml
+views:
   nodes:
-    visible:
-      - "NodeName"
-      - "State"
-      - "CPULoad"
-      - "Memory"
-      - "Jobs"
-    auto_width: true
+    # Group nodes by field
+    groupBy: "partition"
 
-  # Custom columns
-  custom_columns:
-    efficiency:
-      title: "CPU Eff%"
-      formula: "(cpu_time / (runtime * cpu_count)) * 100"
-      format: "percentage"
-      width: 80
+    # Show utilization metrics
+    showUtilization: true
+
+    # Maximum number of nodes to display
+    maxNodes: 500
 ```
 
-## Authentication Configuration
-
-### Token Authentication
+### Partitions View
 ```yaml
-auth:
-  method: "token"
-  token: "${SLURM_TOKEN}"
-  # OR
-  token_file: "/path/to/token"
-  # OR
-  token_command: "vault kv get -field=token secret/slurm"
+views:
+  partitions:
+    # Show queue depth information
+    showQueueDepth: true
+
+    # Show estimated wait times
+    showWaitTime: true
 ```
 
-### Basic Authentication (planned)
-```yaml
-auth:
-  method: "basic"
-  username: "${SLURM_USER}"
-  password: "${SLURM_PASS}"
-  # OR
-  credentials_file: "/path/to/credentials"
-```
+## Feature Flags
 
-### OAuth 2.0 (planned)
 ```yaml
-auth:
-  method: "oauth2"
-  client_id: "${OAUTH_CLIENT_ID}"
-  client_secret: "${OAUTH_CLIENT_SECRET}"
-  token_url: "https://auth.example.com/oauth/token"
-  scopes: ["slurm.read", "slurm.write"]
+features:
+  # Enable job streaming
+  streaming: true
 
-  # Optional OAuth settings
-  auth_url: "https://auth.example.com/oauth/authorize"
-  redirect_url: "http://localhost:8080/callback"
-  state: "random-state-string"
-  pkce: true
-```
+  # Enable Pulseye integration
+  pulseye: true
 
-### Certificate Authentication (planned)
-```yaml
-auth:
-  method: "cert"
-  cert_file: "/path/to/client.crt"
-  key_file: "/path/to/client.key"
-  ca_file: "/path/to/ca.crt"
+  # Enable X-ray diagnostics
+  xray: false
+
+  # Enable app diagnostics
+  appDiagnostics: false
 ```
 
 ## Keyboard Shortcuts
 
-### Global Shortcuts
-```yaml
-keybindings:
-  global:
-    "q": "quit"
-    "?": "help"
-    "r": "refresh"
-    "ctrl+c": "interrupt"
-    "esc": "cancel"
-    "/": "filter"
-    ":": "command_mode"
-    "tab": "next_view"
-    "shift+tab": "prev_view"
+Custom keyboard shortcuts use the `shortcuts` array with `key`, `action`, and `description` fields:
 
-    # View switching
-    "1": "view jobs"
-    "2": "view nodes"
-    "3": "view users"
-    "4": "view partitions"
-    "0": "view dashboard"
+```yaml
+shortcuts:
+  - key: "ctrl+e"
+    action: "export csv"
+    description: "Export current view as CSV"
+
+  - key: "ctrl+s"
+    action: "submit job"
+    description: "Open job submission form"
 ```
 
-### View-Specific Shortcuts
+## Command Aliases
+
 ```yaml
-keybindings:
-  jobs:
-    "c": "cancel"
-    "h": "hold"
-    "r": "release"
-    "k": "kill"
-    "d": "details"
-    "s": "ssh"
-    "o": "output"
-    "l": "logs"
-    "p": "priority"
-
-  nodes:
-    "d": "drain"
-    "r": "resume"
-    "s": "ssh"
-    "m": "maintenance"
-    "i": "info"
-    "j": "jobs"
-    "ctrl+r": "reboot"
-
-  # Custom shortcuts
-  custom:
-    "ctrl+e": "export csv"
-    "ctrl+shift+e": "export json"
-    "alt+s": "save_filter"
+aliases:
+  ctx: "context"
+  kj: "kill job"
+  dj: "describe job"
+  dn: "describe node"
+  sub: "submit job"
 ```
 
-## Filtering Configuration
+## General Settings
 
-### Default Filters
 ```yaml
-filters:
-  # Predefined filters
-  presets:
-    my_jobs:
-      name: "My Jobs"
-      filter: "user:${USER}"
-      view: "jobs"
+# Auto-refresh interval (default: 2s)
+refreshRate: "2s"
 
-    running_gpu:
-      name: "Running GPU Jobs"
-      filter: "state:RUNNING partition:gpu"
-      view: "jobs"
+# Maximum API retries (default: 3)
+maxRetries: 3
 
-    idle_nodes:
-      name: "Idle Nodes"
-      filter: "state:IDLE"
-      view: "nodes"
+# Default cluster context
+defaultCluster: "default"
 
-  # Filter behavior
-  behavior:
-    case_sensitive: false
-    regex_enabled: true
-    auto_complete: true
-    save_history: true
-    max_history: 50
+# Use mock SLURM client (requires S9S_ENABLE_MOCK env var)
+useMockClient: false
 ```
 
-### Search Configuration (planned)
+## Auto-Discovery Configuration
+
 ```yaml
-search:
-  # Search providers
-  providers:
-    - name: "jobs"
-      fields: ["JobID", "JobName", "User", "Account"]
-      weight: 1.0
+discovery:
+  # Enable auto-discovery of slurmrestd endpoint and token
+  enabled: true
 
-    - name: "nodes"
-      fields: ["NodeName", "Features", "State"]
-      weight: 0.8
+  # Auto-discover endpoint
+  enableEndpoint: true
 
-  # Search behavior
-  fuzzy_matching: true
-  max_results: 100
-  highlight_matches: true
+  # Auto-discover/generate JWT token
+  enableToken: true
 
-  # Indexing
-  indexing:
-    enabled: true
-    update_interval: 60s
-    max_index_size: 10MB
-```
+  # Discovery timeout
+  timeout: "10s"
 
-## Export Configuration
+  # Default slurmrestd port
+  defaultPort: 6820
 
-### Default Export Settings
-```yaml
-export:
-  # Default format and location
-  default_format: "csv"
-  output_directory: "~/s9s-exports"
-
-  # File naming
-  filename_template: "{view}_{timestamp}.{ext}"
-  timestamp_format: "20060102_150405"
-
-  # Data options
-  include_headers: true
-  max_records: 1000000
-
-  # Format-specific settings
-  formats:
-    csv:
-      delimiter: ","
-      quote_char: '"'
-      encoding: "utf-8"
-      line_ending: "unix"
-
-    json:
-      indent: 2
-      sort_keys: true
-      ensure_ascii: false
-
-    excel:
-      sheet_name: "S9S Data"
-      auto_width: true
-      freeze_panes: true
-      include_charts: false
-```
-
-### Cloud Export Settings (planned)
-```yaml
-export:
-  # Cloud destinations
-  destinations:
-    s3:
-      enabled: true
-      bucket: "my-s9s-exports"
-      prefix: "exports/"
-      region: "us-west-2"
-      credentials:
-        access_key: "${AWS_ACCESS_KEY}"
-        secret_key: "${AWS_SECRET_KEY}"
-
-    gcs:
-      enabled: false
-      bucket: "my-gcs-bucket"
-      prefix: "s9s-exports/"
-      credentials_file: "/path/to/service-account.json"
-
-    azure:
-      enabled: false
-      account: "mystorageaccount"
-      container: "s9s-exports"
-      sas_token: "${AZURE_SAS_TOKEN}"
+  # Path to scontrol binary
+  scontrolPath: "scontrol"
 ```
 
 ## Plugin Configuration
 
-### Plugin Management
 ```yaml
+# Individual plugin entries
 plugins:
-  # Global plugin settings
-  enabled: true
-  directory: "~/.s9s/plugins"
-  auto_load: true
-
-  # Plugin repositories
-  repositories:
-    - url: "https://plugins.s9s.dev"
-      type: "official"
-
-    - url: "https://github.com/myorg/s9s-plugins"
-      type: "git"
-      auth:
-        username: "${GITHUB_USER}"
-        token: "${GITHUB_TOKEN}"
-
-  # Auto-load plugins
-  autoload:
-    - "efficiency-analyzer"
-    - "cost-tracker"
-    - "notification-manager"
-
-  # Plugin-specific configuration
-  config:
-    efficiency-analyzer:
-      threshold: 0.8
-      report_frequency: "daily"
-
-    cost-tracker:
-      currency: "USD"
-      rates:
-        cpu_hour: 0.05
-        gpu_hour: 2.50
-
-    notification-manager:
-      email:
-        smtp_server: "smtp.example.com"
-        port: 587
-        username: "${EMAIL_USER}"
-        password: "${EMAIL_PASS}"
-```
-
-## Performance Configuration
-
-### Caching Settings
-```yaml
-performance:
-  # Data caching
-  cache:
+  - name: "my-plugin"
     enabled: true
-    size: "500MB"
-    ttl:
-      jobs: 30s
-      nodes: 60s
-      users: 300s
-      partitions: 600s
+    path: "/path/to/plugin"
+    config:
+      customSetting: "value"
 
-    # Cache storage
-    storage:
-      type: "memory"  # memory, file, redis
-      # For file storage
-      directory: "~/.s9s/cache"
-      # For Redis
-      redis_url: "redis://localhost:6379"
-
-  # Connection pooling
-  connections:
-    max_idle: 10
-    max_open: 50
-    max_lifetime: 300s
-
-  # Request settings
-  requests:
-    timeout: 30s
-    retries: 3
-    backoff: "exponential"
-    max_backoff: 60s
-
-  # UI performance
-  ui:
-    virtual_scrolling: true
-    lazy_loading: true
-    debounce: 300ms
-    batch_size: 100
-```
-
-### Logging Configuration
-```yaml
-logging:
-  # Log level
-  level: "info"  # debug, info, warn, error
-
-  # Log destinations
-  outputs:
-    - type: "console"
-      format: "text"
-
-    - type: "file"
-      path: "~/.s9s/logs/s9s.log"
-      format: "json"
-      max_size: "100MB"
-      max_backups: 5
-      max_age: "30d"
-      compress: true
-
-    - type: "syslog"
-      network: "tcp"
-      address: "log.example.com:514"
-      tag: "s9s"
-
-  # Component-specific logging
-  components:
-    api: "debug"
-    ui: "info"
-    cache: "warn"
-    plugins: "info"
-
-  # Request logging
-  requests:
-    enabled: true
-    headers: false
-    body: false
-```
-
-## Security Configuration
-
-### TLS Settings
-```yaml
-security:
-  tls:
-    # Certificate verification
-    verify_certificates: true
-    ca_file: "/etc/ssl/certs/ca-bundle.crt"
-
-    # Client certificates
-    client_cert: "/path/to/client.crt"
-    client_key: "/path/to/client.key"
-
-    # TLS versions and ciphers
-    min_version: "1.2"
-    max_version: "1.3"
-    cipher_suites:
-      - "TLS_AES_256_GCM_SHA384"
-      - "TLS_CHACHA20_POLY1305_SHA256"
-
-  # Encryption
-  encryption:
-    # Data at rest
-    encrypt_cache: true
-    encryption_key_file: "/path/to/key"
-
-    # Data in transit
-    require_https: true
-```
-
-### Access Control
-```yaml
-security:
-  access_control:
-    # IP restrictions
-    allowed_ips:
-      - "10.0.0.0/8"
-      - "172.16.0.0/12"
-      - "192.168.0.0/16"
-
-    # Rate limiting
-    rate_limits:
-      requests_per_minute: 1000
-      requests_per_hour: 10000
-
-    # Session management
-    session:
-      timeout: "8h"
-      max_sessions: 5
-
-  # Audit logging
-  audit:
-    enabled: true
-    log_file: "/var/log/s9s/audit.log"
-    events:
-      - "authentication"
-      - "job_operations"
-      - "configuration_changes"
-```
-
-## Notification Configuration
-
-### Basic Notifications
-```yaml
-notifications:
-  enabled: true
-
-  # Desktop notifications
-  desktop:
-    enabled: true
-    duration: 5000  # milliseconds
-
-  # Sound notifications
-  sound:
-    enabled: true
-    file: "/path/to/notification.wav"
-
-  # Job completion notifications
-  job_completion:
-    enabled: true
-    only_long_jobs: true
-    min_runtime: "1h"
-```
-
-### Advanced Notifications (planned)
-```yaml
-notifications:
-  providers:
-    email:
-      enabled: true
-      smtp:
-        server: "smtp.gmail.com"
-        port: 587
-        username: "${EMAIL_USER}"
-        password: "${EMAIL_PASS}"
-        tls: true
-      from: "s9s@example.com"
-
-    slack:
-      enabled: true
-      webhook_url: "${SLACK_WEBHOOK}"
-      channel: "#hpc-notifications"
-      username: "S9S"
-      icon: ":computer:"
-
-    discord:
-      enabled: false
-      webhook_url: "${DISCORD_WEBHOOK}"
-
-    webhook:
-      enabled: false
-      url: "https://api.example.com/webhook"
-      headers:
-        Authorization: "Bearer ${WEBHOOK_TOKEN}"
-
-  # Event-based notifications
-  events:
-    job_completed:
-      providers: ["email", "slack"]
-      conditions:
-        - "runtime > 1h"
-        - "user == '${USER}'"
-
-    job_failed:
-      providers: ["email", "slack"]
-      urgent: true
-
-    node_down:
-      providers: ["email", "slack", "webhook"]
-      urgent: true
+# Global plugin settings
+pluginSettings:
+  enableAll: false
+  pluginDir: "$HOME/.s9s/plugins"
+  autoDiscover: true
+  safeMode: false          # Disable external plugins
+  maxMemoryMB: 100         # Memory limit per plugin
+  maxCPUPercent: 25.0      # CPU limit per plugin
 ```
 
 ## Environment Variables
 
-### Core Variables
+S9S recognizes the following environment variables:
+
 ```bash
-# Configuration
-export S9S_CONFIG="/path/to/config.yaml"
-export S9S_CLUSTER="production"
-export S9S_DEBUG=true
+# SLURM REST API endpoint (S9S-prefixed takes precedence)
+export SLURM_REST_URL="https://slurm.example.com:6820"
+export S9S_SLURM_REST_URL="https://slurm.example.com:6820"
 
-# Authentication
-export SLURM_TOKEN="your-token-here"
-export SLURM_USER="username"
-export SLURM_PASS="password"
+# SLURM JWT authentication token (S9S-prefixed takes precedence)
+export SLURM_JWT="your-token-here"
+export S9S_SLURM_JWT="your-token-here"
 
-# UI Preferences
-export S9S_THEME="dark"
-export S9S_REFRESH_INTERVAL="5s"
-export S9S_DEFAULT_VIEW="jobs"
+# SLURM API version (default: v0.0.43)
+export SLURM_API_VERSION="v0.0.43"
 
-# Performance
-export S9S_CACHE_SIZE="500MB"
-export S9S_MAX_RESULTS=1000
-export S9S_REQUEST_TIMEOUT="30s"
+# SLURM request timeout
+export SLURM_TIMEOUT="30s"
 
-# Logging
-export S9S_LOG_LEVEL="info"
-export S9S_LOG_FILE="/var/log/s9s.log"
+# Enable mock mode (any non-empty value)
+export S9S_ENABLE_MOCK=1
 ```
 
-### Integration Variables
-```bash
-# Cloud exports
-export AWS_ACCESS_KEY_ID="your-key"
-export AWS_SECRET_ACCESS_KEY="your-secret"
-export AWS_DEFAULT_REGION="us-west-2"
-
-# Notifications
-export SLACK_WEBHOOK="https://hooks.slack.com/..."
-export EMAIL_USER="user@example.com"
-export EMAIL_PASS="password"
-
-# OAuth
-export OAUTH_CLIENT_ID="client-id"
-export OAUTH_CLIENT_SECRET="client-secret"
-```
+Environment variables override configuration file settings. The `S9S_` prefixed versions take precedence over unprefixed versions.
 
 ## Configuration Examples
 
-### Complete Example
-```yaml
-# ~/.s9s/config.yaml
-version: 1
-
-# Cluster configuration
-clusters:
-  production:
-    url: "https://slurm-prod.example.com:6820"
-    auth:
-      method: "token"
-      token: "${SLURM_TOKEN}"
-    default: true
-    timeout: 30s
-
-  development:
-    url: "https://slurm-dev.example.com:6820"
-    auth:
-      method: "basic"
-      username: "${DEV_USER}"
-      password: "${DEV_PASS}"
-
-# UI preferences
-preferences:
-  theme: "dark"
-  default_view: "jobs"
-  refresh_interval: 5s
-  show_relative_time: true
-  confirm_actions: true
-
-# Keyboard shortcuts
-keybindings:
-  global:
-    "ctrl+q": "quit"
-    "f5": "refresh"
-  jobs:
-    "space": "toggle_selection"
-    "c": "cancel"
-    "d": "details"
-
-# Column configuration
-columns:
-  jobs:
-    visible: ["JobID", "Name", "User", "State", "Time", "Nodes"]
-    sort:
-      column: "SubmitTime"
-      direction: "desc"
-
-# Export settings
-export:
-  default_format: "csv"
-  output_directory: "~/exports"
-  include_headers: true
-
-# Plugin configuration
-plugins:
-  enabled: true
-  autoload: ["efficiency-analyzer"]
-  config:
-    efficiency-analyzer:
-      threshold: 0.8
-
-# Performance settings
-performance:
-  cache:
-    enabled: true
-    size: "200MB"
-    ttl:
-      jobs: 30s
-      nodes: 60s
-
-# Logging
-logging:
-  level: "info"
-  outputs:
-    - type: "file"
-      path: "~/.s9s/s9s.log"
-      max_size: "50MB"
-
-# Notifications
-notifications:
-  enabled: true
-  desktop:
-    enabled: true
-  providers:
-    slack:
-      enabled: true
-      webhook_url: "${SLACK_WEBHOOK}"
-      channel: "#hpc"
-```
-
 ### Minimal Configuration
 ```yaml
-version: 1
+clusters:
+  - name: "default"
+    cluster:
+      endpoint: "https://slurm.example.com:6820"
+      token: "${SLURM_JWT}"
+```
+
+### Complete Example
+```yaml
+refreshRate: "5s"
+maxRetries: 3
+defaultCluster: "production"
 
 clusters:
-  default:
-    url: "https://your-slurm-api.com"
-    auth:
-      method: "token"
-      token: "${SLURM_TOKEN}"
+  - name: "production"
+    cluster:
+      endpoint: "https://slurm-prod.example.com:6820"
+      token: "${SLURM_JWT}"
+      apiVersion: "v0.0.43"
+      timeout: "30s"
 
-preferences:
-  theme: "dark"
-  refresh_interval: 10s
+  - name: "development"
+    cluster:
+      endpoint: "https://slurm-dev.example.com:6820"
+      token: "${DEV_SLURM_JWT}"
+      insecure: true
+
+ui:
+  skin: "default"
+  enableMouse: true
+  noIcons: false
+
+views:
+  jobs:
+    columns: ["id", "name", "user", "state", "time", "nodes", "priority"]
+    showOnlyActive: true
+    defaultSort: "time"
+    maxJobs: 1000
+  nodes:
+    groupBy: "partition"
+    showUtilization: true
+    maxNodes: 500
+  partitions:
+    showQueueDepth: true
+    showWaitTime: true
+
+features:
+  streaming: true
+  pulseye: true
+  xray: false
+
+shortcuts:
+  - key: "ctrl+e"
+    action: "export csv"
+    description: "Export as CSV"
+
+aliases:
+  ctx: "context"
+  kj: "kill job"
+  dj: "describe job"
+  dn: "describe node"
+  sub: "submit job"
+
+plugins: []
+
+discovery:
+  enabled: true
+  enableEndpoint: true
+  enableToken: true
+  timeout: "10s"
+  defaultPort: 6820
+  scontrolPath: "scontrol"
 ```
 
 ## Configuration Validation
 
-### Validate Configuration
 ```bash
-# Check configuration syntax and values
+# Validate configuration syntax and values
 s9s config validate
-
-# Test cluster connections
-s9s config test-connections
 
 # Show effective configuration
 s9s config show
 
-# Check for deprecated settings
-s9s config check-deprecated
-```
-
-### Configuration Migration
-```bash
-# Upgrade configuration format
-s9s config migrate --from=0.9 --to=1.0
-
-# Export configuration
-s9s config export > backup.yaml
-
-# Import configuration
-s9s config import backup.yaml
+# Edit configuration file in your default editor
+s9s config edit
 ```
 
 ## Next Steps

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -8,9 +8,10 @@ S9S uses a hierarchical configuration system with the following precedence (high
 
 1. Command-line flags
 2. Environment variables
-3. User config: `~/.s9s/config.yaml`
-4. System config: `/etc/s9s/config.yaml`
-5. Default values
+3. Current directory: `./config.yaml`
+4. User config: `~/.s9s/config.yaml`
+5. System config: `/etc/s9s/config.yaml`
+6. Default values
 
 ## Basic Structure
 
@@ -414,5 +415,5 @@ s9s config edit
 
 - Review [command reference](./commands.md)
 - Explore [API integration](./api.md)
-- Start with a minimal configuration in [getting started guide](../guides/quickstart.md)
-- Configure [plugins](../guides/plugins.md)
+- Start with a minimal configuration in [getting started guide](../getting-started/quickstart.md)
+- Configure [plugins](../plugins/overview.md)

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -318,7 +318,7 @@ export SLURM_TIMEOUT="30s"
 export S9S_ENABLE_MOCK=1
 ```
 
-Environment variables override configuration file settings. The `S9S_` prefixed versions take precedence over unprefixed versions.
+Environment variables override configuration file settings. Only `SLURM_REST_URL` and `SLURM_JWT` have `S9S_` prefixed variants (`S9S_SLURM_REST_URL` and `S9S_SLURM_JWT`), and the prefixed versions take precedence over the unprefixed versions. The `SLURM_API_VERSION` and `SLURM_TIMEOUT` environment variables do not have `S9S_` prefixed variants.
 
 ## Configuration Examples
 

--- a/docs/user-guide/batch-operations.md
+++ b/docs/user-guide/batch-operations.md
@@ -78,12 +78,13 @@ Release held jobs:
 Requeue selected jobs:
 
 ```bash
-# Select jobs and press 'q' or choose "Requeue Jobs" from the menu
+# Choose "Requeue Jobs" from the batch operations menu
 # Jobs will be requeued for execution
 ```
 
 **Operation**: Calls `scontrol requeue` for each selected job
 **Use Case**: Restart failed jobs or re-run completed jobs
+**Note**: Use the batch operations menu (`b`) to access requeue, since the `q` key is reserved for the global quit shortcut.
 
 ### Delete Jobs
 
@@ -135,14 +136,14 @@ Export job output for all selected jobs:
 
 1. **Select Jobs**: Use visual selection (`Space` key) or filters to select multiple jobs
 2. **Open Batch Menu**: Press `b` (or configured batch key) to open the batch operations menu
-3. **Choose Operation**: Navigate the menu or use keyboard shortcuts:
-   - `c` - Cancel Jobs
-   - `H` - Hold Jobs
-   - `r` - Release Jobs
-   - `q` - Requeue Jobs
-   - `d` - Delete Jobs
-   - `p` - Set Priority
-   - `e` - Export Output
+3. **Choose Operation**: Navigate the menu and select an operation:
+   - Cancel Jobs
+   - Hold Jobs
+   - Release Jobs
+   - Requeue Jobs
+   - Delete Jobs
+   - Set Priority
+   - Export Output
 4. **Confirm**: Review the confirmation dialog showing affected jobs
 5. **Execute**: Confirm to execute the batch operation
 6. **Monitor Progress**: Watch the progress bar as operations are applied to each job
@@ -185,7 +186,7 @@ The batch operations interface shows:
 # Step 1: Filter failed jobs
 /FAILED
 
-# Step 2: Select jobs, open batch menu with 'b', press 'q' to requeue
+# Step 2: Select jobs, open batch menu with 'b', choose "Requeue Jobs"
 # Step 3: Jobs will be requeued and eligible to run again
 ```
 
@@ -225,20 +226,9 @@ If a batch operation fails on individual jobs:
 - Errors are counted and reported
 - Final summary shows successful vs. failed operations
 
-## Configuration
+## Export Defaults
 
-### Export Settings
-
-Configure default export behavior:
-
-```yaml
-# Default export path (defaults to ~/slurm_exports)
-export:
-  defaultPath: ~/my_job_exports
-
-# Default export format
-  defaultFormat: json
-```
+Export files are saved to `~/slurm_exports/` by default. The directory is created automatically on first export. Export path and format are selected interactively in the export dialog.
 
 ## Troubleshooting
 
@@ -267,7 +257,7 @@ export:
 | `c` | Cancel jobs | Cancel all selected jobs |
 | `H` | Hold jobs | Put selected jobs on hold |
 | `r` | Release jobs | Release held jobs |
-| `q` | Requeue jobs | Requeue selected jobs |
+| (menu) | Requeue jobs | Requeue selected jobs (via batch menu) |
 | `d` | Delete jobs | Delete all selected jobs |
 | `p` | Set priority | Set priority for selected jobs |
 | `e` | Export output | Export job output |

--- a/docs/user-guide/batch-operations.md
+++ b/docs/user-guide/batch-operations.md
@@ -84,7 +84,6 @@ Requeue selected jobs:
 
 **Operation**: Calls `scontrol requeue` for each selected job
 **Use Case**: Restart failed jobs or re-run completed jobs
-**Note**: Use the batch operations menu (`b`) to access requeue, since the `q` key is reserved for the global quit shortcut.
 
 ### Delete Jobs
 
@@ -257,7 +256,7 @@ Export files are saved to `~/slurm_exports/` by default. The directory is create
 | `c` | Cancel jobs | Cancel all selected jobs |
 | `H` | Hold jobs | Put selected jobs on hold |
 | `r` | Release jobs | Release held jobs |
-| (menu) | Requeue jobs | Requeue selected jobs (via batch menu) |
+| `q` | Requeue jobs | Requeue selected jobs |
 | `d` | Delete jobs | Delete all selected jobs |
 | `p` | Set priority | Set priority for selected jobs |
 | `e` | Export output | Export job output |

--- a/docs/user-guide/batch-operations.md
+++ b/docs/user-guide/batch-operations.md
@@ -19,8 +19,7 @@ Use visual selection mode to choose multiple items:
 | Key | Action | Description |
 |-----|--------|-------------|
 | `Space` | Toggle selection | Select/deselect current item |
-| `v` | Visual mode | Enter visual selection mode |
-| `V` | Visual line mode | Select entire rows |
+| `v`/`V` | Multi-select mode | Toggle multi-select mode |
 | `Ctrl+A` | Select all | Select all visible items |
 
 ### Filter-Based Selection
@@ -28,14 +27,9 @@ Use visual selection mode to choose multiple items:
 Select items using filters:
 
 ```bash
-# Select all failed jobs
-/state:FAILED
-
-# Select jobs by user
-/user:alice
-
-# Combine multiple filters
-/state:PENDING user:bob
+# Quick filter for text search
+/FAILED                # Jobs containing "FAILED"
+/alice                 # Jobs containing "alice"
 ```
 
 ## Available Batch Operations
@@ -91,6 +85,30 @@ Requeue selected jobs:
 **Operation**: Calls `scontrol requeue` for each selected job
 **Use Case**: Restart failed jobs or re-run completed jobs
 
+### Delete Jobs
+
+Delete selected jobs:
+
+```bash
+# Select jobs and press 'd' or choose "Delete Jobs" from the menu
+# Confirmation dialog will appear before execution
+```
+
+**Operation**: Cancels each selected job
+**Use Case**: Remove unwanted jobs from the queue
+
+### Set Priority
+
+Set priority for selected jobs:
+
+```bash
+# Select jobs and press 'p' or choose "Set Priority" from the menu
+# Enter the desired priority value
+```
+
+**Operation**: Sets priority for each selected job
+**Use Case**: Adjust scheduling priority for a group of jobs
+
 ### Export Job Output
 
 Export job output for all selected jobs:
@@ -106,6 +124,7 @@ Export job output for all selected jobs:
 - **JSON**: Structured JSON with metadata
 - **CSV**: CSV format (line-by-line for analysis)
 - **Markdown**: Markdown format with code blocks
+- **HTML**: HTML format for browser viewing
 
 **Operation**: Retrieves job output and saves to local files
 **Use Case**: Archive job results, analyze output across multiple jobs
@@ -121,6 +140,8 @@ Export job output for all selected jobs:
    - `H` - Hold Jobs
    - `r` - Release Jobs
    - `q` - Requeue Jobs
+   - `d` - Delete Jobs
+   - `p` - Set Priority
    - `e` - Export Output
 4. **Confirm**: Review the confirmation dialog showing affected jobs
 5. **Execute**: Confirm to execute the batch operation
@@ -139,32 +160,32 @@ The batch operations interface shows:
 ### Cleanup Failed Jobs
 
 ```bash
-# Step 1: Filter failed jobs
-/state:FAILED
+# Step 1: Filter failed jobs using quick filter
+/FAILED
 
 # Step 2: Review the filtered list
-# Step 3: Press 'c' to cancel all failed jobs
-# Step 4: Confirm the operation
+# Step 3: Select jobs with Space or V for multi-select, then b for batch menu
+# Step 4: Press 'c' to cancel, confirm the operation
 ```
 
 ### Hold User Jobs for Maintenance
 
 ```bash
 # Step 1: Filter user's pending jobs
-/user:alice state:PENDING
+/alice
 
-# Step 2: Press 'H' to hold all jobs
+# Step 2: Select jobs, open batch menu with 'b', press 'H' to hold all jobs
 # Step 3: Perform maintenance
-# Step 4: Filter held jobs and press 'r' to release them
+# Step 4: Filter held jobs and use batch menu 'r' to release them
 ```
 
 ### Requeue Failed Jobs
 
 ```bash
 # Step 1: Filter failed jobs
-/state:FAILED
+/FAILED
 
-# Step 2: Press 'q' to requeue
+# Step 2: Select jobs, open batch menu with 'b', press 'q' to requeue
 # Step 3: Jobs will be requeued and eligible to run again
 ```
 
@@ -172,10 +193,10 @@ The batch operations interface shows:
 
 ```bash
 # Step 1: Filter completed jobs
-/state:COMPLETED user:alice
+/COMPLETED
 
-# Step 2: Press 'e' to export
-# Step 3: Choose export format (Text, JSON, CSV, or Markdown)
+# Step 2: Select jobs, open batch menu with 'b', press 'e' to export
+# Step 3: Choose export format (Text, JSON, CSV, Markdown, or HTML)
 # Step 4: Files saved to ~/slurm_exports/
 ```
 
@@ -247,6 +268,8 @@ export:
 | `H` | Hold jobs | Put selected jobs on hold |
 | `r` | Release jobs | Release held jobs |
 | `q` | Requeue jobs | Requeue selected jobs |
+| `d` | Delete jobs | Delete all selected jobs |
+| `p` | Set priority | Set priority for selected jobs |
 | `e` | Export output | Export job output |
 | `Esc` | Close menu | Close batch operations menu |
 

--- a/docs/user-guide/export.md
+++ b/docs/user-guide/export.md
@@ -19,12 +19,12 @@ Export is available in all main data views:
 | View | Key | Exported Data |
 |------|-----|---------------|
 | Jobs | `e` | ID, Name, User, Account, State, Partition, Nodes, Time Used, Time Limit, Priority, Submit Time |
-| Nodes | `e` | Name, State, Partitions, CPU totals/allocated/idle/load, Memory totals, Features, Reason |
+| Nodes | `e` | Name, State, Partitions, CPUs Total, CPUs Alloc, CPUs Idle, CPU Load, Memory Total (MB), Memory Alloc (MB), Memory Free (MB), Features, Reason |
 | Partitions | `e` | Name, State, Total Nodes, Total CPUs, Default Time, Max Time, QoS, Nodes |
 | Reservations | `e` | Name, State, Start/End Time, Duration, Nodes, Node Count, Core Count, Users, Accounts |
 | QoS | `e` | Name, Priority, Preempt Mode, Flags, all per-user/account limits |
 | Accounts | `e` | Name, Description, Organization, Parent, QoS, Coordinators, resource limits |
-| Users | `e` | Name, UID, Default Account, Accounts, Admin Level, QoS, resource limits |
+| Users | `e` | Name, UID, Default Account, Accounts, Admin Level, Default QoS, QoS List, Max Jobs, Max Nodes, Max CPUs, Max Submit |
 
 ## Supported Formats
 

--- a/docs/user-guide/export.md
+++ b/docs/user-guide/export.md
@@ -23,7 +23,7 @@ Export is available in all main data views:
 | Partitions | `e` | Name, State, Total Nodes, Total CPUs, Default Time, Max Time, QoS, Nodes |
 | Reservations | `e` | Name, State, Start/End Time, Duration, Nodes, Node Count, Core Count, Users, Accounts |
 | QoS | `e` | Name, Priority, Preempt Mode, Flags, all per-user/account limits |
-| Accounts | `e` | Name, Description, Organization, Parent, QoS, Coordinators, resource limits |
+| Accounts | `e` | Name, Description, Organization, Parent, Default QoS, QoS List, Coordinators, Max Jobs, Max Nodes, Max CPUs, Max Submit, Max Wall, Children |
 | Users | `e` | Name, UID, Default Account, Accounts, Admin Level, Default QoS, QoS List, Max Jobs, Max Nodes, Max CPUs, Max Submit |
 
 ## Supported Formats

--- a/docs/user-guide/filtering.md
+++ b/docs/user-guide/filtering.md
@@ -31,7 +31,7 @@ The quick filter is a plain text search only. The only special prefix is `p:` fo
 
 ### Field-Specific Filters
 
-Press `Ctrl+F` to open the advanced filter (available in all data views). Use `field=value` syntax:
+Press `Ctrl+F` to open global search (available in all data views). The advanced filter bar uses `field=value` syntax:
 
 ```bash
 # Job filters (advanced filter, Ctrl+F)
@@ -221,7 +221,7 @@ user=~"^(alice|bob|charlie)"
 
 1. **Use state toggles**: Keyboard shortcuts like `p` (pending) are fastest
 2. **Quick filter first**: Use `/` for simple text searches
-3. **Advanced filter for precision**: Use `Ctrl+F` when you need field-specific matching (Jobs and Nodes views)
+3. **Global search for cross-resource matching**: Use `Ctrl+F` in any data view
 
 ## Filter Shortcuts
 
@@ -230,12 +230,12 @@ user=~"^(alice|bob|charlie)"
 | Key | Action | Description |
 |-----|--------|-------------|
 | `/` | Quick filter | Enter plain text filter mode |
-| `Ctrl+F` | Advanced filter | Open advanced field-specific filter (all data views) |
+| `Ctrl+F` | Global search | Open global search across all entity types (all data views) |
 | `Esc` | Clear | Clear current filter |
 
 ### Using Filters
 
-Use `/` in any view for plain text search across all columns. Use `Ctrl+F` to open the advanced filter for field-specific queries with operators (available in Jobs and Nodes views). Press `Esc` to clear the filter.
+Use `/` in any view for plain text search across all columns. Use `Ctrl+F` to open global search across all entity types (available in all data views). Press `Esc` to clear the filter.
 
 ## Troubleshooting Filters
 

--- a/docs/user-guide/filtering.md
+++ b/docs/user-guide/filtering.md
@@ -15,226 +15,145 @@ See filtering in action:
 Press `/` in any view to activate quick filter:
 
 ```bash
-# Simple text search
+# Simple text search (matches across all visible columns)
 /analysis      # Find items containing "analysis"
 /GPU          # Case-insensitive search for "GPU"
 /node001      # Find specific node
 ```
 
+The quick filter is a plain text search only. The only special prefix is `p:` for partition filtering (works in both Jobs and Nodes views).
+
 ### Clear Filters
 
 - `Esc` - Clear current filter and exit search mode
 
-## Filter Syntax
+## Advanced Filter
 
 ### Field-Specific Filters
 
-Target specific fields with the `field:value` syntax:
+Press `Ctrl+F` to open the advanced filter (available in Jobs and Nodes views). Use `field=value` syntax:
 
 ```bash
-# Job filters
-/user:alice              # Jobs by user alice
-/name:simulation        # Jobs with "simulation" in name
-/jobid:12345           # Specific job ID
-/state:RUNNING         # Jobs in RUNNING state
-/partition:gpu         # Jobs in GPU partition
+# Job filters (advanced filter, Ctrl+F)
+user=alice              # Jobs by user alice
+name~simulation        # Jobs containing "simulation" in name
+state=RUNNING          # Jobs in RUNNING state
+partition=gpu          # Jobs in GPU partition
 
-# Node filters
-/node:node001          # Specific node
-/state:idle           # Idle nodes
-/features:gpu         # Nodes with GPU feature
-/memory:>128GB       # Nodes with >128GB RAM
+# Node filters (advanced filter, Ctrl+F)
+state=idle             # Idle nodes
+name~compute           # Nodes containing "compute"
 ```
 
 ### Operators
 
-s9s supports various comparison operators:
+s9s supports the following comparison operators in the advanced filter:
 
 | Operator | Description | Example |
 |----------|-------------|---------|
-| `:` | Equals | `/state:RUNNING` |
-| `!` | Not equals | `/state:!FAILED` |
-| `>` | Greater than | `/nodes:>4` |
-| `<` | Less than | `/runtime:<1h` |
-| `>=` | Greater or equal | `/priority:>=1000` |
-| `<=` | Less or equal | `/memory:<=64GB` |
-| `~` | Regex match | `/name:~"test.*2023"` |
-| `*` | Wildcard | `/name:analysis*` |
-| `..` | Range | `/nodes:2..8` |
+| `=` | Equals | `state=RUNNING` |
+| `!=` | Not equals | `state!=FAILED` |
+| `>` | Greater than | `cpus>4` |
+| `<` | Less than | `priority<1000` |
+| `>=` | Greater or equal | `priority>=1000` |
+| `<=` | Less or equal | `cpus<=64` |
+| `~` | Contains | `name~analysis` |
+| `!~` | Not contains | `name!~test` |
+| `=~` | Regex match | `name=~"test.*2023"` |
+| `in` | In list | `state in (RUNNING,PENDING)` |
+| `not in` | Not in list | `state not in (COMPLETED,FAILED)` |
 
-## Advanced Filtering
+## Compound Filters
 
-### Compound Filters
+### AND Logic
 
-Combine multiple filters with spaces (AND logic):
+Combine multiple expressions with spaces (AND logic) in the advanced filter:
 
 ```bash
 # Jobs by alice in GPU partition
-/user:alice partition:gpu
+user=alice partition=gpu
 
-# Running jobs with more than 4 nodes
-/state:RUNNING nodes:>4
-
-# Failed jobs submitted today
-/state:FAILED submitted:today
+# Running jobs with more than 4 CPUs
+state=RUNNING cpus>4
 ```
 
-### OR Logic
+### OR Logic (in operator)
 
-Use comma-separated values for OR logic:
+Use the `in` operator for matching against multiple values:
 
 ```bash
 # Jobs in RUNNING or PENDING state
-/state:RUNNING,PENDING
+state in (RUNNING,PENDING)
 
 # Jobs in gpu or cpu partition
-/partition:gpu,cpu
-
-# Jobs by alice or bob
-/user:alice,bob
+partition in (gpu,cpu)
 ```
 
-### Complex Queries
+## Numeric and Time Filters
 
-Combine AND and OR logic:
-
-```bash
-# Alice or Bob's GPU jobs
-/user:alice,bob partition:gpu state:RUNNING
-
-# High priority pending jobs in specific partitions
-/state:PENDING priority:>1000 partition:gpu,highmem
-```
-
-## Time-Based Filters
-
-### Relative Time
-
-Use human-readable time expressions:
+The advanced filter supports numeric comparisons and automatic parsing of memory sizes (e.g., `4G`, `1024M`) and durations (e.g., `2:30:00`, `30m`):
 
 ```bash
-# Submitted time
-/submitted:<1h         # Less than 1 hour ago
-/submitted:>1d        # More than 1 day ago
-/submitted:today      # Submitted today
-/submitted:yesterday  # Submitted yesterday
-/submitted:thisweek   # This week
-/submitted:lastweek   # Last week
-
-# Runtime
-/runtime:>30m         # Running more than 30 minutes
-/runtime:<2h         # Running less than 2 hours
-/runtime:1h-3h      # Between 1 and 3 hours
-```
-
-### Absolute Time
-
-Use specific dates and times:
-
-```bash
-# ISO format
-/submitted:>2023-12-01
-/started:<2023-12-25T18:00:00
-
-# Date shortcuts
-/submitted:2023-12-01..2023-12-31
-/ended:yesterday..today
-```
-
-## Numeric Filters
-
-### Resource Filters
-
-Filter by resource usage:
-
-```bash
-# Node count
-/nodes:4              # Exactly 4 nodes
-/nodes:>8            # More than 8 nodes
-/nodes:2..16        # Between 2 and 16 nodes
-
-# Memory (supports units)
-/memory:>32GB        # More than 32GB
-/memory:64GB..128GB  # Between 64GB and 128GB
-/memory:<=1TB       # Up to 1TB
-
-# CPUs
-/cpus:>48           # More than 48 CPUs
-/cpus:24,48,96     # Specific CPU counts
-
-# GPUs
-/gpus:>0           # Has GPUs
-/gpus:8            # Exactly 8 GPUs
-```
-
-### Priority and QoS
-
-```bash
-# Priority
-/priority:>1000      # High priority jobs
-/priority:0..500    # Low to medium priority
+# Resource filters (advanced filter, Ctrl+F)
+cpus>48              # More than 48 CPUs
+cpus>=8              # 8 or more CPUs
+memory>4G            # More than 4GB memory
+priority>=1000       # High priority jobs
 
 # QoS
-/qos:normal         # Normal QoS
-/qos:high,critical  # High or critical QoS
+qos=normal           # Normal QoS
 ```
 
 ## Regular Expressions
 
-Use regex for complex pattern matching:
+Use regex for complex pattern matching with the `=~` operator in the advanced filter:
 
 ```bash
-# Enable regex with ~ operator
-/name:~"analysis_\d{4}"      # analysis_0001, analysis_0002, etc.
-/user:~"(alice|bob)_.*"      # alice_* or bob_* users
-/output:~"error|warning"      # Find errors or warnings
-/script:~"python.*\.py$"     # Python scripts
+# Enable regex with =~ operator (advanced filter, Ctrl+F)
+name=~"analysis_\d{4}"      # analysis_0001, analysis_0002, etc.
+user=~"(alice|bob)_.*"       # alice_* or bob_* users
+name=~"(?i)GPU"              # Case-insensitive match
 
-# Case-insensitive regex
-/name:~"(?i)GPU"             # Matches gpu, GPU, Gpu, etc.
-
-# Negative lookahead
-/name:~"^(?!test).*"         # Not starting with "test"
+# Note: ~ (without =) is the contains operator, not regex
+name~analysis                 # Matches if name contains "analysis"
 ```
 
 ## State Filters
 
-### Job States
+### Job States (Advanced Filter)
 
 ```bash
 # Single state
-/state:RUNNING
-/state:PENDING
-/state:COMPLETED
-/state:FAILED
+state=RUNNING
+state=PENDING
+state=COMPLETED
+state=FAILED
 
-# Multiple states
-/state:RUNNING,PENDING
-/state:!COMPLETED        # Not completed
-
-# State groups (s9s shortcuts)
-/state:active           # RUNNING,PENDING
-/state:ended           # COMPLETED,FAILED,CANCELLED
-/state:problem         # FAILED,TIMEOUT,NODE_FAIL
+# Multiple states using in operator
+state in (RUNNING,PENDING)
+state!=COMPLETED              # Not completed
 ```
 
-### Node States
+### Node States (Advanced Filter)
 
 ```bash
 # Basic states
-/state:idle
-/state:allocated
-/state:down
-/state:drain
-
-# Compound states
-/state:idle+drain      # Idle and draining
-/state:allocated+drain # Allocated but draining
-
-# State shortcuts
-/state:available       # idle,mixed
-/state:unusable       # down,drain,maint
+state=idle
+state=allocated
+state=down
+state=drain
 ```
+
+### State Toggle Shortcuts
+
+In the Jobs view, use keyboard shortcuts to toggle state filters quickly:
+- `p`/`P` -- toggle pending state filter
+- `a`/`A` -- show all states (clear filter)
+
+In the Nodes view:
+- `i`/`I` -- toggle idle state filter
+- `m`/`M` -- toggle mixed state filter
+- `a`/`A` -- show all states (clear filter)
 
 ## Saved Filters and Presets (Planned)
 
@@ -242,103 +161,67 @@ Use regex for complex pattern matching:
 >
 > In the meantime, you can re-enter filters manually using `/` in any view.
 
-## Dynamic Filters
+## Filter Behavior
 
-### Auto-Refresh Filters
+### Auto-Refresh
 
-Filters that update automatically:
+When auto-refresh is enabled (toggle with `m`/`M` in Jobs view), filters remain active as data refreshes. The filtered view updates automatically with each refresh cycle.
 
-```bash
-# Jobs submitted in last hour (updates)
-/submitted:<1h
+### Context-Aware Fields
 
-# Currently running jobs
-/state:RUNNING elapsed:>0
+The available filter fields depend on the current view. The advanced filter supports field aliases for convenience:
 
-# Recently completed
-/state:COMPLETED ended:<10m
-```
-
-### Context-Aware Filters
-
-Filters that adapt to current view:
-
-```bash
-# In Jobs view
-/state:RUNNING        # Running jobs
-
-# In Nodes view
-/state:idle           # Idle nodes
-
-# In Users view
-/user:alice           # Specific user
-```
-
-> **Note**: Advanced context-aware fields like `efficiency`, `load`, and `gpu_util` depend on those fields being available in the data returned by the SLURM REST API. Some advanced filter features are planned. See [#119](https://github.com/jontk/s9s/issues/119).
+| Alias | Canonical Field |
+|-------|----------------|
+| `name` | Name |
+| `user` | User |
+| `state` | State |
+| `partition` | Partition |
+| `node`/`nodes` | NodeList |
+| `cpu`/`cpus` | CPUs |
+| `mem`/`memory` | Memory |
+| `account` | Account |
+| `qos` | QoS |
+| `priority` | Priority |
+| `time` | TimeUsed |
+| `timelimit` | TimeLimit |
 
 ## Filter Examples
 
-### Common Use Cases
+### Common Use Cases (Advanced Filter, Ctrl+F)
 
-#### Find Stuck Jobs
+#### Find Pending Jobs
 ```bash
-/state:PENDING submitted:>1h reason:!Resources
+state=PENDING
 ```
 
 #### GPU Partition Jobs
 ```bash
-/partition:gpu state:RUNNING
+partition=gpu state=RUNNING
 ```
 
-#### Failed Jobs Today
+#### Jobs by User
 ```bash
-/state:FAILED ended:today user:${USER}
+user=alice state!=COMPLETED
 ```
 
-#### High Memory Jobs
+#### High CPU Jobs
 ```bash
-/memory:>500GB state:RUNNING,PENDING
-```
-
-#### Jobs Near Time Limit
-```bash
-/state:RUNNING time_left:<30m
-```
-
-### Power User Filters
-
-#### Complex Resource Query
-```bash
-/nodes:>16 cpus:>512 memory:>1TB partition:large state:PENDING
+cpus>64 state in (RUNNING,PENDING)
 ```
 
 #### Multi-User Team Filter
 ```bash
-/user:~"^(alice|bob|charlie)" project:ml_research state:!COMPLETED
-```
-
-#### Performance Analysis
-```bash
-/state:RUNNING runtime:>2h efficiency:<0.5 partition:!debug
+user=~"^(alice|bob|charlie)"
 ```
 
 ## Performance Tips
 
 ### Efficient Filtering
 
-1. **Use indexed fields**: Filter by indexed fields first (JobID, User, State)
-2. **Narrow scope**: Start with restrictive filters, then broaden
-3. **State first**: Filter by state for best performance
-
-### Filter Optimization
-
-```bash
-# Good: Indexed field first
-/state:RUNNING user:alice partition:gpu
-
-# Less efficient: Unindexed field first
-/name:analysis state:RUNNING user:alice
-```
+1. **Use state toggles**: Keyboard shortcuts like `p` (pending) are fastest
+2. **Quick filter first**: Use `/` for simple text searches
+3. **Advanced filter for precision**: Use `Ctrl+F` when you need field-specific matching (Jobs and Nodes views)
 
 ## Filter Shortcuts
 
@@ -346,14 +229,13 @@ Filters that adapt to current view:
 
 | Key | Action | Description |
 |-----|--------|-------------|
-| `/` | Start filter | Enter filter mode |
-| `Tab` | Autocomplete | Complete filter fields |
-| `↑/↓` | History | Browse filter history |
+| `/` | Quick filter | Enter plain text filter mode |
+| `Ctrl+F` | Advanced filter | Open advanced field-specific filter (Jobs and Nodes views) |
 | `Esc` | Clear | Clear current filter |
 
 ### Using Filters
 
-Use `/` in any view to enter filter mode and type your filter expression. Press `Esc` to clear the filter.
+Use `/` in any view for plain text search across all columns. Use `Ctrl+F` to open the advanced filter for field-specific queries with operators (available in Jobs and Nodes views). Press `Esc` to clear the filter.
 
 ## Troubleshooting Filters
 

--- a/docs/user-guide/filtering.md
+++ b/docs/user-guide/filtering.md
@@ -31,7 +31,7 @@ The quick filter is a plain text search only. The only special prefix is `p:` fo
 
 ### Field-Specific Filters
 
-Press `Ctrl+F` to open the advanced filter (available in Jobs and Nodes views). Use `field=value` syntax:
+Press `Ctrl+F` to open the advanced filter (available in all data views). Use `field=value` syntax:
 
 ```bash
 # Job filters (advanced filter, Ctrl+F)
@@ -230,7 +230,7 @@ user=~"^(alice|bob|charlie)"
 | Key | Action | Description |
 |-----|--------|-------------|
 | `/` | Quick filter | Enter plain text filter mode |
-| `Ctrl+F` | Advanced filter | Open advanced field-specific filter (Jobs and Nodes views) |
+| `Ctrl+F` | Advanced filter | Open advanced field-specific filter (all data views) |
 | `Esc` | Clear | Clear current filter |
 
 ### Using Filters
@@ -261,7 +261,7 @@ Use `/` in any view for plain text search across all columns. Use `Ctrl+F` to op
 
 ## Next Steps
 
-- Practice filters in [Mock Mode](../MOCK_MODE.md)
+- Practice filters in [Mock Mode](../guides/mock-mode.md)
 - Learn [Batch Operations](../user-guide/job-management.md) with filters
 - Explore filtering in specific views:
   - [Jobs View](../user-guide/views/jobs.md)

--- a/docs/user-guide/filtering.md
+++ b/docs/user-guide/filtering.md
@@ -27,11 +27,15 @@ The quick filter is a plain text search only. The only special prefix is `p:` fo
 
 - `Esc` - Clear current filter and exit search mode
 
+## Global Search
+
+Press `Ctrl+F` in any data view to open global search, which performs plain-text matching across all entity types (jobs, nodes, partitions, users, accounts, QoS, reservations).
+
 ## Advanced Filter
 
 ### Field-Specific Filters
 
-Press `Ctrl+F` to open global search (available in all data views). The advanced filter bar uses `field=value` syntax:
+The advanced filter bar supports `field=value` syntax for precise filtering:
 
 ```bash
 # Job filters (advanced filter, Ctrl+F)
@@ -230,7 +234,7 @@ user=~"^(alice|bob|charlie)"
 | Key | Action | Description |
 |-----|--------|-------------|
 | `/` | Quick filter | Enter plain text filter mode |
-| `Ctrl+F` | Global search | Open global search across all entity types (all data views) |
+| `Ctrl+F` | Global search | Plain-text search across all entity types (all data views) |
 | `Esc` | Clear | Clear current filter |
 
 ### Using Filters

--- a/docs/user-guide/job-management.md
+++ b/docs/user-guide/job-management.md
@@ -20,10 +20,8 @@ S9S provides a powerful interface for managing SLURM jobs with features that go 
 Press `s` in Jobs view to open the submission wizard:
 
 1. **Choose Method**:
-   - New job from scratch
-   - From template
-   - Copy existing job
-   - Import script file
+   - New job from scratch (Custom Job)
+   - From template (select a pre-configured template)
 
 2. **Configure Resources**:
    ```yaml
@@ -288,11 +286,11 @@ S9S color-codes job states for quick identification:
 |-------|-------|-------------|
 | PENDING | Yellow | Waiting for resources |
 | RUNNING | Green | Currently executing |
-| COMPLETED | Blue | Finished successfully |
+| COMPLETED | Cyan | Finished successfully |
 | FAILED | Red | Exited with error |
-| CANCELLED | Gray | Cancelled by user/admin |
-| TIMEOUT | Orange | Exceeded time limit |
-| SUSPENDED | Purple | Temporarily suspended |
+| CANCELLED | Gray | Cancelled by user/admin (SLURM uses British spelling) |
+| TIMEOUT | White | Exceeded time limit |
+| SUSPENDED | Orange | Temporarily suspended |
 
 ### Job Details
 
@@ -313,13 +311,11 @@ View job output in real-time:
 
 1. Select job and press `o`
 2. Choose output type:
-   - Standard output
-   - Error output
-   - Both (split view)
+   - Standard output (stdout)
+   - Standard error (stderr)
 3. Options:
    - `f` - Follow/tail output
-   - `/` - Search in output
-   - `s` - Save to file
+   - `s` - Switch between stdout/stderr
    - `Esc` - Exit viewer
 
 For more details, see the [Jobs View Guide](./views/jobs.md).
@@ -334,7 +330,7 @@ For more details, see the [Jobs View Guide](./views/jobs.md).
 | `H` | Hold | Prevent job from starting |
 | `r` | Release | Release held job |
 | `R` | Refresh | Refresh the jobs list |
-| `q`/`Q` | Requeue | Resubmit failed job |
+| `:requeue JOBID` | Requeue | Resubmit failed job (use command mode) |
 | `d`/`D` | Dependencies | View job dependencies |
 | `p`/`P` | Toggle Pending | Toggle pending state filter |
 | `e`/`E` | Export | Open export dialog |
@@ -377,10 +373,10 @@ S9S supports two filtering modes:
 
 **Quick Filter (`/`)** -- plain text search across all visible columns. Type `/gpu` to find items containing "gpu". The only special prefix is `p:` for partition filtering.
 
-**Advanced Filter (`Ctrl+F`)** -- field-specific filtering using `field=value` syntax with operators (available in Jobs and Nodes views):
+**Global Search (`Ctrl+F`)** -- opens cross-resource search (available in all data views). The advanced filter bar supports field-specific `field=value` syntax with operators:
 
 ```bash
-# Advanced filter examples (opened with Ctrl+F)
+# Advanced filter examples
 state=RUNNING                           # Running jobs
 user=alice                              # Alice's jobs
 state=PENDING user=bob                  # Bob's pending jobs (AND logic)
@@ -607,7 +603,7 @@ Export the current view by pressing `e` (depending on the view). This exports th
 /FAILED                # Quick filter for failed jobs
 Enter                  # View job details
 o                      # Check output/errors
-q                      # Requeue if needed
+:requeue JOBID         # Requeue if needed (command mode)
 ```
 
 #### Monitor GPU Jobs

--- a/docs/user-guide/job-management.md
+++ b/docs/user-guide/job-management.md
@@ -296,7 +296,7 @@ S9S color-codes job states for quick identification:
 
 ### Job Details
 
-Press `Enter` or `d` on any job to view details:
+Press `Enter` on any job to view details:
 
 - **Summary**: ID, name, user, submission time
 - **Resources**: Nodes, CPUs, memory, GPUs
@@ -304,6 +304,8 @@ Press `Enter` or `d` on any job to view details:
 - **Performance**: CPU/memory efficiency
 - **Output**: Stdout/stderr file paths
 - **Dependencies**: Parent/child jobs
+
+Press `d` to view job dependencies (not details).
 
 ### Live Output Monitoring
 
@@ -328,14 +330,15 @@ For more details, see the [Jobs View Guide](./views/jobs.md).
 
 | Key | Action | Description |
 |-----|--------|-------------|
-| `c` | Cancel | Cancel job (with confirmation) |
-| `C` | Force Cancel | Cancel without confirmation |
-| `h` | Hold | Prevent job from starting |
+| `c`/`C` | Cancel | Cancel job (with confirmation) |
+| `H` | Hold | Prevent job from starting |
 | `r` | Release | Release held job |
-| `R` | Requeue | Resubmit failed job |
-| `p` | Priority | Modify job priority |
-| `e` | Edit | Modify pending job |
-| `m` | Move | Move to different partition |
+| `R` | Refresh | Refresh the jobs list |
+| `q`/`Q` | Requeue | Resubmit failed job |
+| `d`/`D` | Dependencies | View job dependencies |
+| `p`/`P` | Toggle Pending | Toggle pending state filter |
+| `e`/`E` | Export | Open export dialog |
+| `m`/`M` | Auto-refresh | Toggle auto-refresh |
 
 ### Batch Operations
 
@@ -343,17 +346,16 @@ Select multiple jobs with `Space`, then press `b`:
 
 1. **Selection Methods**:
    - Manual: `Space` on each job
-   - All visible: `V`
-   - By filter: `/state:PENDING` then `V`
-   - By pattern: `:select pattern "analysis_*"`
+   - Toggle multi-select: `v` or `V`
+   - By filter: `/PENDING` then select visible jobs
 
 2. **Batch Actions**:
    - Cancel selected
    - Hold/Release selected
-   - Change priority
-   - Move partition
-   - Add dependency
-   - Export data
+   - Requeue selected
+   - Delete selected
+   - Set Priority
+   - Export output
 
 ### Advanced Operations
 
@@ -371,33 +373,22 @@ See [#115](https://github.com/jontk/s9s/issues/115) for planned command-mode enh
 
 ### Filter Syntax
 
-S9S supports powerful job filtering:
+S9S supports two filtering modes:
+
+**Quick Filter (`/`)** -- plain text search across all visible columns. Type `/gpu` to find items containing "gpu". The only special prefix is `p:` for partition filtering.
+
+**Advanced Filter (`Ctrl+F`)** -- field-specific filtering using `field=value` syntax with operators (available in Jobs and Nodes views):
 
 ```bash
-# Basic filters
-/RUNNING                    # Running jobs
-/gpu                       # Jobs with 'gpu' in name
-/user:alice               # Alice's jobs
-
-# State filters
-/state:PENDING            # Pending jobs
-/state:RUNNING,COMPLETED  # Multiple states
-/state:!FAILED           # Not failed
-
-# Resource filters
-/nodes:>4                # More than 4 nodes
-/memory:>=32GB          # 32GB or more memory
-/gpus:>0                # GPU jobs
-
-# Time filters
-/runtime:>1h            # Running over 1 hour
-/runtime:30m-2h        # Between 30min and 2h
-/submitted:<1d         # Submitted within 1 day
-/started:today         # Started today
-
-# Complex filters
-/user:bob state:RUNNING partition:gpu    # Bob's GPU jobs
-/name:~"analysis.*2023" nodes:>10       # Regex + resource
+# Advanced filter examples (opened with Ctrl+F)
+state=RUNNING                           # Running jobs
+user=alice                              # Alice's jobs
+state=PENDING user=bob                  # Bob's pending jobs (AND logic)
+name~analysis                           # Jobs containing "analysis"
+name=~"analysis.*2023"                  # Regex match
+memory>4G cpus>=8                       # Resource comparisons
+state!=FAILED                           # Not failed
+state in (RUNNING,PENDING)              # In list
 ```
 
 ### Saved Filters
@@ -415,28 +406,7 @@ S9S calculates job efficiency:
 - **GPU Utilization**: GPU usage percentage
 - **I/O Performance**: Read/write statistics
 
-View metrics:
-1. Select job and press `i`
-2. Navigate to "Performance" tab
-3. View graphs and statistics
-
-### Performance Alerts
-
-Set up alerts for inefficient jobs:
-
-```yaml
-# In config.yaml
-alerts:
-  lowEfficiency:
-    threshold: 0.5
-    metric: cpu
-    action: notify
-
-  highMemory:
-    threshold: 90%
-    metric: memory
-    action: email
-```
+View metrics by selecting a job and pressing `Enter` to see the job details view, which includes efficiency information when available.
 
 ## Job Templates
 
@@ -617,7 +587,7 @@ Job chains and recurring job scheduling via command mode are not yet available. 
 
 ### Export Job Data
 
-Export the current view by pressing `Ctrl+E` or `e` (depending on the view). This exports the visible data to a file. Command-mode export and report generation are not yet available. See [#115](https://github.com/jontk/s9s/issues/115) for planned reporting enhancements.
+Export the current view by pressing `e` (depending on the view). This exports the visible data to a file. Command-mode export and report generation are not yet available. See [#115](https://github.com/jontk/s9s/issues/115) for planned reporting enhancements.
 
 ## Tips & Best Practices
 
@@ -633,23 +603,24 @@ Export the current view by pressing `Ctrl+E` or `e` (depending on the view). Thi
 
 #### Debug Failed Jobs
 ```bash
-/state:FAILED          # Filter failed jobs
+# Use p/P to toggle pending filter, or / for text search
+/FAILED                # Quick filter for failed jobs
 Enter                  # View job details
 o                      # Check output/errors
-R                      # Requeue if needed
+q                      # Requeue if needed
 ```
 
-#### Monitor GPU Usage
+#### Monitor GPU Jobs
 ```bash
-/partition:gpu state:RUNNING    # Filter GPU jobs
-i                              # View job info
-Tab → Performance             # Check GPU utilization
+/gpu                           # Quick filter for GPU-related jobs
+Enter                          # View job details
 ```
 
 #### Bulk Cancel User Jobs
 ```bash
-/user:username                # Filter by user
-V                            # Select all visible
+/username                     # Filter by user text
+V                            # Toggle multi-select mode
+Space                        # Select individual jobs
 b                           # Batch operations
 c                          # Cancel selected
 ```

--- a/docs/user-guide/keyboard-shortcuts.md
+++ b/docs/user-guide/keyboard-shortcuts.md
@@ -15,15 +15,30 @@ These shortcuts work from any view:
 | `Shift+Tab` | Previous view | Cycle backwards through views |
 | `h` | Previous view | Move to previous view |
 | `l` | Next view | Move to next view |
+| `F1` | Help | Show help modal |
+| `F2` | Alerts | Show system alerts (passes through to Jobs view for templates) |
+| `F3` | Preferences | Show preferences dialog |
+| `F4` | Layout | Show layout switcher |
 | `F5` | Force refresh | Refresh current view data |
-| `R` | Manual refresh | Refresh view (most views) |
+| `F10` | Configuration | Show configuration |
 | `Ctrl+K` | Switch cluster | Switch between configured clusters |
-| `Ctrl+C` | Cancel | Cancel current operation or close modal |
+| `Ctrl+C` | Exit application | Exit s9s entirely |
 | `ESC` | Exit/Close | Exit filter mode, close modal, cancel operation |
 
 ## View Switching
 
-Use number keys `1`-`9` and `0` to switch directly to a view by its position in the tab bar.
+| Key | View |
+|-----|------|
+| `1` | Jobs |
+| `2` | Nodes |
+| `3` | Partitions |
+| `4` | Reservations |
+| `5` | QoS |
+| `6` | Accounts |
+| `7` | Users |
+| `8` | Dashboard |
+| `9` | Health |
+| `0` | Performance |
 
 ## Dashboard View
 
@@ -51,12 +66,11 @@ Use number keys `1`-`9` and `0` to switch directly to a view by its position in 
 | Key | Action | Description |
 |-----|--------|-------------|
 | `Enter` | View details | Show detailed job information |
-| `s/S` | Submit job | Open job submission wizard |
+| `s` | Submit job | Open job submission wizard |
 | `F2` | Job templates | Open job templates/submission form |
 | `c/C` | Cancel job | Cancel selected job |
 | `H` | Hold job | Place job on hold |
 | `r` | Release job | Release held job |
-| `q/Q` | Requeue job | Requeue completed/failed job |
 | `o/O` | View output | View job output/logs |
 | `d/D` | View dependencies | Show job dependency graph |
 
@@ -72,7 +86,7 @@ Use number keys `1`-`9` and `0` to switch directly to a view by its position in 
 | Key | Action | Description |
 |-----|--------|-------------|
 | `/` | Simple filter | Activate filter input |
-| `F3` | Advanced filter | Open advanced filter bar |
+| `Ctrl+F` | Global search | Search across resources (view-specific) |
 | `a/A` | Filter all states | Show all job states |
 | `p/P` | Filter pending | Show pending jobs only |
 | `u/U` | Filter by user | Filter jobs by username |
@@ -83,7 +97,6 @@ Use number keys `1`-`9` and `0` to switch directly to a view by its position in 
 |-----|--------|-------------|
 | `R` | Manual refresh | Refresh jobs data |
 | `m/M` | Toggle auto-refresh | Enable/disable auto-refresh (30s) |
-| `F1` | Action menu | Show context-sensitive actions |
 | `S` | Sort modal | Open interactive sorting dialog |
 | `e/E` | Export | Export job list to CSV/JSON/Text/Markdown/HTML |
 
@@ -95,13 +108,13 @@ Use number keys `1`-`9` and `0` to switch directly to a view by its position in 
 | `Enter` | View details | Show node details and metrics |
 | `d/D` | Drain node | Drain selected node |
 | `r` | Resume node | Resume drained node |
-| `s/S` | SSH to node | Open SSH options menu |
+| `s` | SSH to node | Open SSH connection to node |
 
 ### Filtering & Search
 | Key | Action | Description |
 |-----|--------|-------------|
 | `/` | Simple filter | Activate filter input |
-| `F3` | Advanced filter | Open advanced filter bar |
+| `Ctrl+F` | Global search | Search across resources (view-specific) |
 | `p/P` | Partition filter | Filter by partition |
 | `a/A` | Toggle all states | Toggle "all states" filter |
 | `i/I` | Toggle idle | Toggle idle state filter |
@@ -136,7 +149,6 @@ Use number keys `1`-`9` and `0` to switch directly to a view by its position in 
 | Key | Action | Description |
 |-----|--------|-------------|
 | `/` | Simple filter | Activate filter input |
-| `F3` | Advanced filter | Open advanced filter bar |
 | `ESC` | Exit filter | Clear filter and exit filter mode |
 
 ### Data Management
@@ -157,7 +169,6 @@ Use number keys `1`-`9` and `0` to switch directly to a view by its position in 
 | Key | Action | Description |
 |-----|--------|-------------|
 | `/` | Simple filter | Activate filter input |
-| `F3` | Advanced filter | Open advanced filter bar |
 | `a/A` | Toggle admin filter | Show admins/operators only or all users |
 | `ESC` | Exit filter | Clear filter and exit filter mode |
 
@@ -180,7 +191,6 @@ Use number keys `1`-`9` and `0` to switch directly to a view by its position in 
 | Key | Action | Description |
 |-----|--------|-------------|
 | `/` | Simple filter | Activate filter input |
-| `F3` | Advanced filter | Open advanced filter bar |
 | `ESC` | Exit filter | Clear filter and exit filter mode |
 
 ### Data Management
@@ -201,7 +211,6 @@ Use number keys `1`-`9` and `0` to switch directly to a view by its position in 
 | Key | Action | Description |
 |-----|--------|-------------|
 | `/` | Simple filter | Activate filter input |
-| `F3` | Advanced filter | Open advanced filter bar |
 | `ESC` | Exit filter | Clear filter and exit filter mode |
 
 ### Data Management
@@ -222,7 +231,6 @@ Use number keys `1`-`9` and `0` to switch directly to a view by its position in 
 | Key | Action | Description |
 |-----|--------|-------------|
 | `/` | Simple filter | Activate filter input |
-| `F3` | Advanced filter | Open advanced filter bar |
 | `a/A` | Toggle active | Show active reservations only |
 | `f/F` | Toggle future | Show future reservations only |
 | `ESC` | Exit filter | Clear filter and exit filter mode |
@@ -258,65 +266,65 @@ Use number keys `1`-`9` and `0` to switch directly to a view by its position in 
 
 ## Advanced Filter Syntax
 
-When using `F3` for advanced filtering, use these expression patterns:
+When using the advanced filter, use these expression patterns:
 
-### Field Matching
+### Operators
 ```
-field:value          - Contains match
 field=value          - Exact match
-field:>value         - Greater than (numeric)
-field:<value         - Less than (numeric)
-field:>=value        - Greater or equal (numeric)
-field:<=value        - Less or equal (numeric)
+field!=value         - Not equals
+field~value          - Contains match
+field!~value         - Not contains
+field>value          - Greater than (numeric)
+field<value          - Less than (numeric)
+field>=value         - Greater or equal (numeric)
+field<=value         - Less or equal (numeric)
+field=~pattern       - Regex match
+field in (a,b,c)     - In list
+field not in (a,b)   - Not in list
 ```
 
 ### Examples
 
 **Jobs:**
 ```
-state:RUNNING partition:gpu
-user:alice priority:>500
-nodes:>=8 state:PENDING
+state=RUNNING partition=gpu
+user=alice priority>500
+cpus>=8 state=PENDING
+name~test memory>4G
 ```
 
 **Nodes:**
 ```
-state:IDLE partition:gpu
-features:nvlink cpus:>64
-memory:>256GB
+state=idle partition=gpu
+features~nvlink cpus>64
+memory>256G
 ```
 
 **Partitions:**
 ```
-state:UP nodes:>100
-efficiency:>80 qos:high
+state=up nodes>100
+qos~normal
 ```
 
 **Users:**
 ```
-admin:Administrator
-account:research qos:high
-maxjobs:>50
+account=research qos~high
 ```
 
 **Accounts:**
 ```
-organization:research
-parent:root qos:high
-maxcpus:>1000
+name~research
+qos~high
 ```
 
 **QoS:**
 ```
-priority:>1000
-preempt:Suspend
-maxjobs:>100
+priority>1000
 ```
 
 **Reservations:**
 ```
-state:ACTIVE nodes:>16
-users:alice accounts:ml-team
+state=ACTIVE nodes>16
 ```
 
 ## Special Filter Syntax
@@ -339,9 +347,9 @@ Works in Jobs and Nodes views.
 
 ### Efficient Filtering
 - Use `/` for quick keyword search
-- Use `F3` when you need complex multi-field filtering
+- Use `Ctrl+F` in Jobs/Nodes views for cross-resource search
 - Press `ESC` to quickly clear filters
-- Special syntax like `p:gpu` saves time
+- Special syntax like `p:gpu` saves time in simple filter mode
 
 ### Batch Operations (Jobs)
 1. Press `v/V` to enter multi-select mode
@@ -361,7 +369,7 @@ Works in Jobs and Nodes views.
 
 ### Help When Stuck
 - Press `?` for context-sensitive help
-- Press `F1` for action menu (shows available operations)
+- Press `F1` for help modal
 - Press `ESC` to cancel most operations
 
 ## Customizing Shortcuts

--- a/docs/user-guide/keyboard-shortcuts.md
+++ b/docs/user-guide/keyboard-shortcuts.md
@@ -152,6 +152,7 @@ These shortcuts work from any view:
 | Key | Action | Description |
 |-----|--------|-------------|
 | `/` | Simple filter | Activate filter input |
+| `Ctrl+F` | Global search | Search across all entity types (all data views) |
 | `ESC` | Exit filter | Clear filter and exit filter mode |
 
 ### Data Management
@@ -172,6 +173,7 @@ These shortcuts work from any view:
 | Key | Action | Description |
 |-----|--------|-------------|
 | `/` | Simple filter | Activate filter input |
+| `Ctrl+F` | Global search | Search across all entity types (all data views) |
 | `a/A` | Toggle admin filter | Show admins/operators only or all users |
 | `ESC` | Exit filter | Clear filter and exit filter mode |
 
@@ -194,6 +196,7 @@ These shortcuts work from any view:
 | Key | Action | Description |
 |-----|--------|-------------|
 | `/` | Simple filter | Activate filter input |
+| `Ctrl+F` | Global search | Search across all entity types (all data views) |
 | `ESC` | Exit filter | Clear filter and exit filter mode |
 
 ### Data Management
@@ -214,6 +217,7 @@ These shortcuts work from any view:
 | Key | Action | Description |
 |-----|--------|-------------|
 | `/` | Simple filter | Activate filter input |
+| `Ctrl+F` | Global search | Search across all entity types (all data views) |
 | `ESC` | Exit filter | Clear filter and exit filter mode |
 
 ### Data Management
@@ -234,6 +238,7 @@ These shortcuts work from any view:
 | Key | Action | Description |
 |-----|--------|-------------|
 | `/` | Simple filter | Activate filter input |
+| `Ctrl+F` | Global search | Search across all entity types (all data views) |
 | `a/A` | Toggle active | Show active reservations only |
 | `f/F` | Toggle future | Show future reservations only |
 | `ESC` | Exit filter | Clear filter and exit filter mode |

--- a/docs/user-guide/keyboard-shortcuts.md
+++ b/docs/user-guide/keyboard-shortcuts.md
@@ -363,7 +363,7 @@ Works in Jobs and Nodes views.
 3. Makes large node lists easier to navigate
 
 ### Refresh Strategies
-- Most views auto-refresh every 10-30 seconds
+- Three views auto-refresh: Jobs (30s), Health (10s), Performance (5s)
 - Use `R` for immediate manual refresh
 - Jobs view: `m/M` toggles auto-refresh on/off
 

--- a/docs/user-guide/keyboard-shortcuts.md
+++ b/docs/user-guide/keyboard-shortcuts.md
@@ -44,6 +44,9 @@ These shortcuts work from any view:
 
 | Key | Action | Description |
 |-----|--------|-------------|
+| `J` | Jobs view | Switch to Jobs view |
+| `N` | Nodes view | Switch to Nodes view |
+| `P` | Partitions view | Switch to Partitions view |
 | `A` | Advanced analytics | Open analytics modal |
 | `H` | Health check | Open health check modal |
 | `R` | Refresh dashboard | Manual refresh all panels |
@@ -86,7 +89,7 @@ These shortcuts work from any view:
 | Key | Action | Description |
 |-----|--------|-------------|
 | `/` | Simple filter | Activate filter input |
-| `Ctrl+F` | Global search | Search across resources (view-specific) |
+| `Ctrl+F` | Global search | Search across all entity types (all data views) |
 | `a/A` | Filter all states | Show all job states |
 | `p/P` | Filter pending | Show pending jobs only |
 | `u/U` | Filter by user | Filter jobs by username |
@@ -114,7 +117,7 @@ These shortcuts work from any view:
 | Key | Action | Description |
 |-----|--------|-------------|
 | `/` | Simple filter | Activate filter input |
-| `Ctrl+F` | Global search | Search across resources (view-specific) |
+| `Ctrl+F` | Global search | Search across all entity types (all data views) |
 | `p/P` | Partition filter | Filter by partition |
 | `a/A` | Toggle all states | Toggle "all states" filter |
 | `i/I` | Toggle idle | Toggle idle state filter |
@@ -347,7 +350,7 @@ Works in Jobs and Nodes views.
 
 ### Efficient Filtering
 - Use `/` for quick keyword search
-- Use `Ctrl+F` in Jobs/Nodes views for cross-resource search
+- Use `Ctrl+F` in any data view for cross-resource search
 - Press `ESC` to quickly clear filters
 - Special syntax like `p:gpu` saves time in simple filter mode
 
@@ -363,7 +366,7 @@ Works in Jobs and Nodes views.
 3. Makes large node lists easier to navigate
 
 ### Refresh Strategies
-- Three views auto-refresh: Jobs (30s), Health (10s), Performance (5s)
+- Four views auto-refresh: Jobs (30s), Dashboard (10s), Health (10s), Performance (5s)
 - Use `R` for immediate manual refresh
 - Jobs view: `m/M` toggles auto-refresh on/off
 
@@ -413,4 +416,4 @@ Press `:` to enter vim-style command mode with tab completion support:
 
 **How it works:** Completions are context-aware and use data from the currently loaded views, so you'll see real job IDs and node names from your cluster.
 
-See [Commands Reference](../../reference/commands.md) for full command list.
+See [Commands Reference](../reference/commands.md) for full command list.

--- a/docs/user-guide/keyboard-shortcuts.md
+++ b/docs/user-guide/keyboard-shortcuts.md
@@ -366,7 +366,7 @@ Works in Jobs and Nodes views.
 3. Makes large node lists easier to navigate
 
 ### Refresh Strategies
-- Four views auto-refresh: Jobs (30s), Dashboard (10s), Health (10s), Performance (5s)
+- Three views auto-refresh: Jobs (30s), Health (10s), Performance (5s)
 - Use `R` for immediate manual refresh
 - Jobs view: `m/M` toggles auto-refresh on/off
 

--- a/docs/user-guide/navigation.md
+++ b/docs/user-guide/navigation.md
@@ -49,8 +49,9 @@ These shortcuts work across all views:
 
 | Key | Action | Description |
 |-----|--------|-------------|
-| `j` or `↓` | Down | Move cursor down |
-| `k` or `↑` | Up | Move cursor up |
+| `↓` | Down | Move cursor down |
+| `↑` | Up | Move cursor up |
+| `j`/`k` | Down/Up | Vim-style navigation (Jobs view multi-select table only) |
 | `Home` | Top | Go to first item |
 | `End` | Bottom | Go to last item |
 
@@ -71,7 +72,7 @@ These shortcuts work across all views:
 | `v` | Multi-Select | Toggle multi-select mode |
 | `m` | Auto Refresh | Toggle auto-refresh |
 | `/` | Filter | Filter jobs |
-| `Ctrl+F` | Search | Global search (view-specific) |
+| `Ctrl+F` | Search | Global search across all entity types |
 | `F2` | Templates | Show job templates |
 | `S` | Sort | Open sort modal |
 | `R` | Refresh | Force refresh view |
@@ -86,7 +87,7 @@ These shortcuts work across all views:
 | `r` | Resume | Resume drained node |
 | `R` | Refresh | Force refresh view |
 | `/` | Filter | Filter nodes |
-| `Ctrl+F` | Search | Global search (view-specific) |
+| `Ctrl+F` | Search | Global search across all entity types |
 | `S` | Sort | Open sort modal |
 | `p` | Partition | Filter by partition |
 | `a` | All States | Show all node states |
@@ -178,23 +179,17 @@ Enter filter mode with `/` in any view:
 
 ### Advanced Filter
 
-The advanced filter bar is available via view-specific key handlers (e.g., `Ctrl+F` in Jobs and Nodes views). Note that the global `F3` key opens Preferences, which takes priority over view-level advanced filter bindings.
-
-The advanced filter supports:
-- Field-specific filtering
-- Operator support (equals, contains, greater than, less than)
-- Multiple filter conditions
-- Save and load filter presets
+The advanced filter bar supports field-specific filtering with operators (equals, contains, greater than, less than) and multiple filter conditions. Note that the global `F3` key opens Preferences, which takes priority over view-level filter bindings.
 
 ### Global Search
 
-Press `Ctrl+F` in supported views (Jobs, Nodes) to search across resources.
+Press `Ctrl+F` in any data view (Jobs, Nodes, Partitions, QoS, Accounts, Users, Reservations) to search across all entity types.
 
 ## Tips & Tricks
 
 ### Efficiency Tips
 
-1. **Use vim keys**: `j`/`k` for up/down, `gg`/`G` for top/bottom
+1. **Use arrow keys**: `↑`/`↓` for up/down, `Home`/`End` for top/bottom
 2. **Quick view switching**: Number keys `1-9` switch directly to views
 3. **Quick filters**: `/` for instant filtering in any view
 4. **Multi-select**: Use `v` in jobs view for batch operations
@@ -244,7 +239,7 @@ See [Commands Reference](../reference/commands.md) for complete command document
 - **Real-time updates** - Data refreshes automatically
 - **Command mode with autocomplete** - Vim-style `:` commands with Tab completion
 - **ASCII visualizations** - Resource usage shown with colored progress bars
-- **Advanced filtering** - Use `/` to filter data in any view, or `Ctrl+F` in Jobs/Nodes for advanced search
+- **Advanced filtering** - Use `/` to filter data in any view, or `Ctrl+F` in data views for global search
 - **Sortable columns** - Press `S` to open the sort modal
 - **Detailed analytics** - Press `A` or `W` in partitions for insights
 - **Node grouping** - Group nodes by partition, state, or features
@@ -277,7 +272,7 @@ Bar colors:
 
 ## Next Steps
 
-- Practice navigation in mock mode: `s9s --mock`
+- Practice navigation in mock mode: `S9S_ENABLE_MOCK=1 s9s --mock`
 - Learn advanced filtering techniques
 - Explore individual view guides:
   - [Jobs View](views/jobs.md)

--- a/docs/user-guide/navigation.md
+++ b/docs/user-guide/navigation.md
@@ -104,7 +104,10 @@ These shortcuts work across all views:
 | `A` | Analytics | Show partition analytics |
 | `W` | Wait Times | Show wait time analytics |
 | `/` | Filter | Filter partitions |
+| `Ctrl+F` | Search | Global search across all entity types |
 | `S` | Sort | Open sort modal |
+| `R` | Refresh | Force refresh view |
+| `e` | Export | Export partition data |
 
 ### QoS View
 
@@ -112,7 +115,10 @@ These shortcuts work across all views:
 |-----|--------|-------------|
 | `Enter` | Details | Show QoS details |
 | `/` | Filter | Filter QoS policies |
+| `Ctrl+F` | Search | Global search across all entity types |
 | `S` | Sort | Open sort modal |
+| `R` | Refresh | Force refresh view |
+| `e` | Export | Export QoS data |
 
 ### Accounts View
 
@@ -121,7 +127,10 @@ These shortcuts work across all views:
 | `Enter` | Details | Show account details |
 | `H` | Hierarchy | Show account hierarchy |
 | `/` | Filter | Filter accounts |
+| `Ctrl+F` | Search | Global search across all entity types |
 | `S` | Sort | Open sort modal |
+| `R` | Refresh | Force refresh view |
+| `e` | Export | Export account data |
 
 ### Users View
 
@@ -130,7 +139,10 @@ These shortcuts work across all views:
 | `Enter` | Details | Show user details |
 | `a` | Toggle Filter | Show admin users / all users |
 | `/` | Filter | Filter users |
+| `Ctrl+F` | Search | Global search across all entity types |
 | `S` | Sort | Open sort modal |
+| `R` | Refresh | Force refresh view |
+| `e` | Export | Export user data |
 
 ### Reservations View
 
@@ -140,7 +152,10 @@ These shortcuts work across all views:
 | `a` | Active Only | Filter active reservations |
 | `f` | Future Only | Filter future reservations |
 | `/` | Filter | Filter reservations |
+| `Ctrl+F` | Search | Global search across all entity types |
 | `S` | Sort | Open sort modal |
+| `R` | Refresh | Force refresh view |
+| `e` | Export | Export reservation data |
 
 ### Dashboard View
 

--- a/docs/user-guide/navigation.md
+++ b/docs/user-guide/navigation.md
@@ -51,8 +51,8 @@ These shortcuts work across all views:
 |-----|--------|-------------|
 | `j` or `↓` | Down | Move cursor down |
 | `k` or `↑` | Up | Move cursor up |
-| `gg` | Top | Go to first item (vim double-g motion) |
-| `G` | Bottom | Go to last item |
+| `Home` | Top | Go to first item |
+| `End` | Bottom | Go to last item |
 
 ## View-Specific Shortcuts
 

--- a/docs/user-guide/navigation.md
+++ b/docs/user-guide/navigation.md
@@ -22,15 +22,13 @@ These shortcuts work across all views:
 | `Shift+Tab` | Previous View | Cycle to previous view |
 | `h` | Previous View | Move to previous view |
 | `l` | Next View | Move to next view |
-| `F1` | Help | Show context-sensitive help |
-| `F2` | Alerts | Show system alerts |
+| `F1` | Help | Show help modal |
+| `F2` | Alerts | Show system alerts (passes through to Jobs view for templates) |
 | `F3` | Preferences | Show preferences dialog |
 | `F4` | Layout | Show layout switcher |
 | `F5` | Refresh | Refresh current view |
 | `F10` | Configuration | Show configuration |
-| `Ctrl+F` | Global Search | Search across all resources |
 | `Ctrl+K` | Switch Cluster | Switch between configured clusters |
-| `R` | Manual Refresh | Force refresh current view |
 
 ### View Navigation
 
@@ -53,7 +51,7 @@ These shortcuts work across all views:
 |-----|--------|-------------|
 | `j` or `↓` | Down | Move cursor down |
 | `k` or `↑` | Up | Move cursor up |
-| `g` | Top | Go to first item |
+| `gg` | Top | Go to first item (vim double-g motion) |
 | `G` | Bottom | Go to last item |
 
 ## View-Specific Shortcuts
@@ -69,14 +67,11 @@ These shortcuts work across all views:
 | `r` | Release | Release held job |
 | `o` | Output | View job output |
 | `d` | Dependencies | Show job dependencies |
-| `q` | Requeue | Requeue failed job |
 | `b` | Batch Ops | Enter batch operations mode |
 | `v` | Multi-Select | Toggle multi-select mode |
 | `m` | Auto Refresh | Toggle auto-refresh |
 | `/` | Filter | Filter jobs |
-| `F3` | Adv Filter | Advanced filter mode |
-| `Ctrl+F` | Search | Global search |
-| `F1` | Actions Menu | Show actions menu |
+| `Ctrl+F` | Search | Global search (view-specific) |
 | `F2` | Templates | Show job templates |
 | `S` | Sort | Open sort modal |
 | `R` | Refresh | Force refresh view |
@@ -89,11 +84,10 @@ These shortcuts work across all views:
 | `s` | SSH | SSH to selected node |
 | `d` | Drain | Drain node |
 | `r` | Resume | Resume drained node |
-| `/` | Filter | Filter nodes |
-| `F3` | Adv Filter | Advanced filter mode |
-| `Ctrl+F` | Search | Global search |
-| `S` | Sort | Open sort modal |
 | `R` | Refresh | Force refresh view |
+| `/` | Filter | Filter nodes |
+| `Ctrl+F` | Search | Global search (view-specific) |
+| `S` | Sort | Open sort modal |
 | `p` | Partition | Filter by partition |
 | `a` | All States | Show all node states |
 | `g` | Group By | Group nodes by attribute |
@@ -109,10 +103,7 @@ These shortcuts work across all views:
 | `A` | Analytics | Show partition analytics |
 | `W` | Wait Times | Show wait time analytics |
 | `/` | Filter | Filter partitions |
-| `F3` | Adv Filter | Advanced filter mode |
-| `Ctrl+F` | Search | Global search |
 | `S` | Sort | Open sort modal |
-| `R` | Refresh | Force refresh view |
 
 ### QoS View
 
@@ -120,10 +111,7 @@ These shortcuts work across all views:
 |-----|--------|-------------|
 | `Enter` | Details | Show QoS details |
 | `/` | Filter | Filter QoS policies |
-| `F3` | Adv Filter | Advanced filter mode |
-| `Ctrl+F` | Search | Global search |
 | `S` | Sort | Open sort modal |
-| `R` | Refresh | Force refresh view |
 
 ### Accounts View
 
@@ -132,10 +120,7 @@ These shortcuts work across all views:
 | `Enter` | Details | Show account details |
 | `H` | Hierarchy | Show account hierarchy |
 | `/` | Filter | Filter accounts |
-| `F3` | Adv Filter | Advanced filter mode |
-| `Ctrl+F` | Search | Global search |
 | `S` | Sort | Open sort modal |
-| `R` | Refresh | Force refresh view |
 
 ### Users View
 
@@ -144,10 +129,7 @@ These shortcuts work across all views:
 | `Enter` | Details | Show user details |
 | `a` | Toggle Filter | Show admin users / all users |
 | `/` | Filter | Filter users |
-| `F3` | Adv Filter | Advanced filter mode |
-| `Ctrl+F` | Search | Global search |
 | `S` | Sort | Open sort modal |
-| `R` | Refresh | Force refresh view |
 
 ### Reservations View
 
@@ -157,10 +139,7 @@ These shortcuts work across all views:
 | `a` | Active Only | Filter active reservations |
 | `f` | Future Only | Filter future reservations |
 | `/` | Filter | Filter reservations |
-| `F3` | Adv Filter | Advanced filter mode |
-| `Ctrl+F` | Search | Global search |
 | `S` | Sort | Open sort modal |
-| `R` | Refresh | Force refresh view |
 
 ### Dashboard View
 
@@ -187,7 +166,7 @@ These shortcuts work across all views:
 
 ## Search and Filter Mode
 
-Enter filter mode with `/` or advanced filter with `F3`:
+Enter filter mode with `/` in any view:
 
 ### Basic Filter
 
@@ -199,7 +178,9 @@ Enter filter mode with `/` or advanced filter with `F3`:
 
 ### Advanced Filter
 
-Press `F3` to access the advanced filter builder with:
+The advanced filter bar is available via view-specific key handlers (e.g., `Ctrl+F` in Jobs and Nodes views). Note that the global `F3` key opens Preferences, which takes priority over view-level advanced filter bindings.
+
+The advanced filter supports:
 - Field-specific filtering
 - Operator support (equals, contains, greater than, less than)
 - Multiple filter conditions
@@ -207,13 +188,13 @@ Press `F3` to access the advanced filter builder with:
 
 ### Global Search
 
-Press `Ctrl+F` to search across all views simultaneously and jump to results.
+Press `Ctrl+F` in supported views (Jobs, Nodes) to search across resources.
 
 ## Tips & Tricks
 
 ### Efficiency Tips
 
-1. **Use vim keys**: `j`/`k` for up/down, `g`/`G` for top/bottom
+1. **Use vim keys**: `j`/`k` for up/down, `gg`/`G` for top/bottom
 2. **Quick view switching**: Number keys `1-9` switch directly to views
 3. **Quick filters**: `/` for instant filtering in any view
 4. **Multi-select**: Use `v` in jobs view for batch operations
@@ -263,7 +244,7 @@ See [Commands Reference](../reference/commands.md) for complete command document
 - **Real-time updates** - Data refreshes automatically
 - **Command mode with autocomplete** - Vim-style `:` commands with Tab completion
 - **ASCII visualizations** - Resource usage shown with colored progress bars
-- **Advanced filtering** - Use `/` to filter data in any view or `F3` for advanced filters
+- **Advanced filtering** - Use `/` to filter data in any view, or `Ctrl+F` in Jobs/Nodes for advanced search
 - **Sortable columns** - Press `S` to open the sort modal
 - **Detailed analytics** - Press `A` or `W` in partitions for insights
 - **Node grouping** - Group nodes by partition, state, or features

--- a/docs/user-guide/node-operations.md
+++ b/docs/user-guide/node-operations.md
@@ -189,14 +189,14 @@ The `/` quick filter performs plain text search across all visible columns:
 /node001              # Specific node
 ```
 
-For field-specific filtering, use the advanced filter (`Ctrl+F`):
+Press `Ctrl+F` for global search across all entity types, or use keyboard shortcuts for specific state filters:
 
 ```bash
-# Advanced filter examples (Ctrl+F)
-state=idle                              # Idle nodes
-state=mixed                             # Mixed-state nodes
-name~compute                            # Nodes containing "compute"
-memory>64000                            # Nodes with >64GB RAM (in MB)
+# State filter shortcuts
+i/I                                     # Toggle idle filter
+m/M                                     # Toggle mixed filter
+a/A                                     # Show all states
+p/P                                     # Filter by partition
 ```
 
 ## Troubleshooting Node Issues

--- a/docs/user-guide/node-operations.md
+++ b/docs/user-guide/node-operations.md
@@ -4,7 +4,7 @@ Master node management in S9S with powerful operations for monitoring, maintenan
 
 ## Node View Overview
 
-Press `2` or `:view nodes` to access the nodes view, where you can:
+Press `2` or `:nodes` to access the nodes view, where you can:
 
 - Monitor all cluster nodes in real-time
 - View detailed node specifications and utilization
@@ -31,7 +31,7 @@ S9S displays nodes in various states:
 
 ### Node Details
 
-View detailed information with `Enter` or `d`:
+View detailed information with `Enter`:
 
 ```bash
 Node: node001.cluster.edu
@@ -54,28 +54,22 @@ Last Seen: 2023-12-15 14:23:42 (5s ago)
 
 | Key | Action | Description |
 |-----|--------|-------------|
-| `d` | Show details | View comprehensive node information |
-| `l` | View logs | Show node logs and messages |
-| `j` | View jobs | List all jobs on this node |
+| `Enter` | Show details | View comprehensive node information |
+| `d`/`D` | Drain | Prepare node for maintenance |
+| `r` | Resume | Return node to service |
+| `R` | Refresh | Update node information |
 | `s` | SSH to node | Direct SSH access |
-| `r` | Refresh | Update node information |
 
-### Maintenance Operations
-
-| Key | Action | Description |
-|-----|--------|-------------|
-| `D` | Drain node | Prepare node for maintenance |
-| `R` | Resume node | Return node to service |
-| `U` | Update state | Force state update |
-| `M` | Maintenance mode | Put node in maintenance |
-
-### Advanced Operations
+### State Filter Shortcuts
 
 | Key | Action | Description |
 |-----|--------|-------------|
-| `Ctrl+R` | Reboot node | Restart node (admin only) |
-| `Ctrl+P` | Power cycle | Hard power cycle |
-| `Ctrl+D` | Force drain | Immediate drain with job termination |
+| `a`/`A` | All states | Clear state filter |
+| `i`/`I` | Idle filter | Toggle idle state filter |
+| `m`/`M` | Mixed filter | Toggle mixed state filter |
+| `p`/`P` | Partition filter | Prompt for partition filter |
+| `g`/`G` | Group by | Group nodes by partition, state, or features |
+| `e`/`E` | Export | Open export dialog |
 
 ## Maintenance Workflows
 
@@ -85,7 +79,7 @@ Last Seen: 2023-12-15 14:23:42 (5s ago)
    ```bash
    # In nodes view, select node and press D
    # Or use command mode
-   :drain node001 --reason="Planned maintenance" --timeout=1h
+   :drain node001 Planned maintenance
    ```
 
 2. **Wait for jobs to complete**:
@@ -107,28 +101,32 @@ Last Seen: 2023-12-15 14:23:42 (5s ago)
 
 ### Emergency Maintenance
 
-1. **Force drain immediately**:
+1. **Drain the node with a reason**:
    ```bash
-   :drain node001 --force --reason="Emergency maintenance"
+   :drain node001 Emergency maintenance
    ```
 
-2. **Jobs are immediately terminated**
-3. **Node is ready for maintenance**
+2. **Monitor draining progress** -- jobs will finish naturally
+3. **Perform maintenance once drained**
 
 ### Batch Maintenance
 
-Maintain multiple nodes efficiently:
+Drain individual nodes using the command mode:
 
 ```bash
-# Drain multiple nodes
-:drain node[001-010] --reason="OS update" --timeout=2h
+# Drain nodes one at a time
+:drain node001 OS update
+:drain node002 OS update
 
-# Resume multiple nodes
-:resume node[001-010]
+# Resume nodes after maintenance
+:resume node001
+:resume node002
 
-# Check status of node range
-/node:node[001-010]
+# Filter to see specific nodes
+/node001
 ```
+
+> **Note:** The `:drain` command accepts a single node name and an optional reason string. Node ranges and `--reason`/`--timeout` flags are planned. See [#119](https://github.com/jontk/s9s/issues/119).
 
 ## SSH Integration
 
@@ -141,42 +139,13 @@ Press `s` on any node to SSH directly:
 ssh user@node001.cluster.edu
 ```
 
-### SSH Configuration
-
-Configure SSH in `~/.s9s/config.yaml`:
-
-```yaml
-ssh:
-  defaultUser: ${USER}
-  keyFile: ~/.ssh/id_rsa
-  knownHostsFile: ~/.ssh/known_hosts
-  compression: true
-  forwardAgent: true
-  extraArgs: "-o StrictHostKeyChecking=ask"
-```
-
 ### SSH Operations
 
 | Key | Action | Description |
 |-----|--------|-------------|
-| `s` | SSH to node | Interactive SSH session |
-| `Ctrl+S` | SSH with options | Choose user, key, options |
-| `Alt+S` | Background SSH | SSH in new terminal |
+| `s` | SSH to node | Interactive SSH session to selected node |
 
-### Bulk SSH Operations
-
-Execute commands across multiple nodes:
-
-```bash
-# Run command on all idle nodes
-:ssh --filter="state:idle" "uptime"
-
-# Update all nodes in maintenance
-:ssh --nodes="node[001-010]" "sudo apt update"
-
-# Check disk space on GPU nodes
-:ssh --filter="features:gpu" "df -h"
-```
+Press `s` on a selected node in the Nodes view to open an SSH session. See [SSH Integration Guide](../guides/ssh-integration.md) for configuration.
 
 ## Node Monitoring
 
@@ -196,71 +165,38 @@ GPU 0: ████████████████ 100% (job_12345)
 GPU 1: ░░░░░░░░░░░░░░░░ 0% (idle)
 ```
 
-### Health Monitoring
+### Resource Display
 
-S9S monitors node health indicators:
+S9S displays the following node resource information:
 
-- **Load Average**: System load over 1, 5, 15 minutes
-- **Memory Pressure**: Available vs allocated memory
-- **Disk Space**: Available disk space on filesystems
-- **Network**: Network connectivity and bandwidth
-- **Temperature**: Hardware temperature sensors
-- **Jobs**: Running and pending job counts
-
-### Alerts and Notifications
-
-Configure alerts for node issues:
-
-```yaml
-# In config.yaml
-notifications:
-  nodeAlerts:
-    - condition: "load > 32"
-      severity: warning
-      message: "High load on {node}"
-    - condition: "memory < 10%"
-      severity: critical
-      message: "Low memory on {node}"
-    - condition: "state == DOWN"
-      severity: critical
-      message: "Node {node} is down"
-```
+- **CPU Usage**: Allocated vs total CPUs, CPU load
+- **Memory Usage**: Allocated vs total memory
+- **State**: Current node state with color coding
+- **Partitions**: Which partitions the node belongs to
+- **Features**: Node feature tags
+- **Reason**: Drain/down reason if applicable
 
 ## Node Filtering and Search
 
 ### Find Specific Nodes
 
+The `/` quick filter performs plain text search across all visible columns:
+
 ```bash
-# Find nodes by name pattern
-/node:compute*
-
-# Find nodes by state
-/state:idle
-
-# Find GPU nodes
-/features:gpu
-
-# Find nodes with high memory
-/memory:>64GB
-
-# Find nodes with specific job count
-/jobs:>4
+# Find nodes by name
+/compute              # Nodes containing "compute"
+/gpu                  # Nodes with "gpu" in any column
+/node001              # Specific node
 ```
 
-### Complex Node Queries
+For field-specific filtering, use the advanced filter (`Ctrl+F`):
 
 ```bash
-# Idle GPU nodes with >100GB RAM
-/state:idle features:gpu memory:>100GB
-
-# Nodes that haven't been seen recently
-/lastseen:>1h state:!DOWN
-
-# Overutilized nodes
-/load:>16 cpus:<=16
-
-# Nodes ready for maintenance
-/jobs:0 state:idle
+# Advanced filter examples (Ctrl+F)
+state=idle                              # Idle nodes
+state=mixed                             # Mixed-state nodes
+name~compute                            # Nodes containing "compute"
+memory>64000                            # Nodes with >64GB RAM (in MB)
 ```
 
 ## Troubleshooting Node Issues
@@ -287,19 +223,9 @@ notifications:
 
 ### Node Diagnostics
 
-```bash
-# View detailed node diagnostics
-:diag node001
+View node details by selecting a node and pressing `Enter` in the Nodes view. For deeper diagnostics, SSH to the node with `s`.
 
-# Check node connectivity
-:ping node001
-
-# View system logs
-:logs node001 --system --lines=100
-
-# Check SLURM daemon status
-:slurm-status node001
-```
+> **Note:** Command-mode diagnostic commands (`:diag`, `:ping`, `:logs`, `:slurm-status`) are planned. See [#119](https://github.com/jontk/s9s/issues/119).
 
 ## Best Practices
 

--- a/docs/user-guide/node-operations.md
+++ b/docs/user-guide/node-operations.md
@@ -21,13 +21,13 @@ S9S displays nodes in various states:
 | State | Description | Color |
 |-------|-------------|-------|
 | **IDLE** | Available for new jobs | Green |
-| **MIXED** | Some CPUs allocated, some free | Yellow |
+| **MIXED** | Some CPUs allocated, some free | Blue |
 | **ALLOCATED** | Fully utilized by jobs | Blue |
 | **DOWN** | Node is offline | Red |
-| **DRAIN** | Being drained for maintenance | Orange |
-| **DRAINING** | Actively draining jobs | Orange |
-| **FAIL** | Node has failed | Red |
-| **MAINT** | In maintenance mode | Gray |
+| **DRAIN** | Being drained for maintenance | Red |
+| **DRAINING** | Actively draining jobs | Red |
+| **RESERVED** | Reserved for specific use | Yellow |
+| **MAINTENANCE** | In maintenance mode | Orange |
 
 ### Node Details
 
@@ -231,7 +231,7 @@ View node details by selecting a node and pressing `Enter` in the Nodes view. Fo
 
 ### Node Management
 
-1. **Plan maintenance windows** - Use drain with timeout
+1. **Plan maintenance windows** - Use drain with descriptive reasons
 2. **Monitor during drainage** - Ensure jobs complete cleanly
 3. **Verify after maintenance** - Test functionality before resuming
 4. **Document changes** - Use descriptive drain reasons

--- a/docs/user-guide/views/accounts.md
+++ b/docs/user-guide/views/accounts.md
@@ -172,6 +172,7 @@ Press `S` to open the interactive sort modal.
 | Key | Action |
 |-----|--------|
 | `R` | Manual refresh |
+| `e/E` | Export view data |
 | `S` | Sort modal |
 
 ## Account Details Example

--- a/docs/user-guide/views/accounts.md
+++ b/docs/user-guide/views/accounts.md
@@ -12,9 +12,11 @@ The Accounts view shows all SLURM accounts used for billing, resource allocation
 
 ## Table Columns
 
+The accounts table displays 9 columns:
+
 | Column | Description |
 |--------|-------------|
-| **Account** | Account name |
+| **Name** | Account name |
 | **Description** | Account purpose or description |
 | **Organization** | Organizational unit |
 | **Parent** | Parent account in hierarchy |
@@ -22,7 +24,6 @@ The Accounts view shows all SLURM accounts used for billing, resource allocation
 | **Max Jobs** | Maximum concurrent jobs |
 | **Max Nodes** | Maximum nodes per account |
 | **Max CPUs** | Maximum CPUs per account |
-| **Max Wall Time** | Maximum job duration |
 | **Coordinators** | Account administrators |
 
 ## Account Hierarchy
@@ -135,29 +136,6 @@ Filter accounts by:
 - Parent account
 - Coordinator name
 
-#### Advanced Filter
-**Shortcut**: `F3`
-
-Expression-based filtering:
-
-```
-organization:research
-parent:root
-qos:high
-maxcpus:>1000
-```
-
-**Supported fields:**
-- `account` - Account name
-- `description` - Description text
-- `organization` - Organization name
-- `parent` - Parent account name
-- `qos` - Default QoS
-- `maxjobs` - Max jobs (supports >, <, >=, <=)
-- `maxnodes` - Max nodes (supports comparison)
-- `maxcpus` - Max CPUs (supports comparison)
-- `coordinator` - Coordinator name
-
 ### Global Search
 **Shortcut**: `Ctrl+F`
 
@@ -187,7 +165,6 @@ Press `S` to open the interactive sort modal.
 | Key | Action |
 |-----|--------|
 | `/` | Simple filter |
-| `F3` | Advanced filter |
 | `Ctrl+F` | Global search |
 | `ESC` | Exit filter mode |
 
@@ -376,7 +353,7 @@ root
 - **Coordinate access**: Contact coordinators to request account access
 - **Billing attribution**: Jobs bill to the specified account
 - **Default account**: Users have a default, but can submit to any associated account
-- **Filter by organization**: Use `F3` with `organization:name` to group by dept
+- **Filter by organization**: Use `/` with the organization name to filter by dept
 - **Wall time inheritance**: Child accounts often inherit parent wall time limits
 - **QoS interaction**: Account limits stack with QoS limits (most restrictive wins)
 

--- a/docs/user-guide/views/dashboard.md
+++ b/docs/user-guide/views/dashboard.md
@@ -8,7 +8,7 @@ The Dashboard provides a real-time overview of your SLURM cluster with comprehen
 
 ## Overview
 
-The Dashboard is the default view in s9s, displaying six information panels organized in a responsive layout:
+The Dashboard provides a cluster overview accessible via key `8`, displaying six information panels organized in a responsive layout:
 
 - **Cluster Overview** - System information and health status
 - **Jobs Summary** - Job queue and state distribution
@@ -80,12 +80,12 @@ Shows "No issues detected" with green checkmark when system is healthy.
 
 ### Performance Trends (Bottom)
 
-Displays demo visualizations:
+Displays cluster performance visualizations:
 - Job throughput sparklines
 - Resource efficiency percentages
 - System health score with visual bar
 
-> **Note:** This panel shows demo data only, not actual cluster metrics.
+These values are computed from real cluster metrics collected during the session.
 
 ## Actions & Shortcuts
 
@@ -126,8 +126,8 @@ Press `A` to open the Advanced Analytics modal with comprehensive cluster analys
 - Node utilization metrics
 - Resource availability trends
 
-### AI-Generated Recommendations
-The system analyzes current metrics and provides:
+### Recommendations
+The system applies rule-based heuristics to current metrics and provides:
 - Performance optimization suggestions
 - Resource allocation recommendations
 - Potential issue warnings
@@ -178,7 +178,7 @@ Each component shows:
 
 ## Auto-Refresh
 
-The Dashboard automatically refreshes every **10 seconds** (more frequent than other views) to provide real-time cluster monitoring.
+The Dashboard loads data on initial display but does not automatically refresh afterward. Press `R` for a manual refresh to update the dashboard data.
 
 ## Visual Design
 
@@ -212,7 +212,7 @@ The Dashboard uses flexible layout proportions to adapt to different terminal si
 ## Tips
 
 - Use the Dashboard as your cluster monitoring hub
-- Press `A` regularly to review AI recommendations
+- Press `A` regularly to review recommendations
 - Check `H` for detailed health diagnostics
 - Navigate directly to specific views using `J`, `N`, or `P`
-- The Dashboard refreshes automatically—no need to manually refresh unless you want immediate updates
+- Press `R` to manually refresh the dashboard data when you want the latest metrics

--- a/docs/user-guide/views/dashboard.md
+++ b/docs/user-guide/views/dashboard.md
@@ -81,8 +81,7 @@ Shows "No issues detected" with green checkmark when system is healthy.
 ### Performance Trends (Bottom)
 
 Displays cluster performance visualizations:
-- Job throughput sparklines
-- Resource efficiency percentages
+- Resource efficiency bar (average of CPU and Memory utilization)
 - System health score with visual bar
 
 These values are computed from real cluster metrics collected during the session.

--- a/docs/user-guide/views/health.md
+++ b/docs/user-guide/views/health.md
@@ -21,11 +21,11 @@ The Health view monitors cluster status and identifies issues requiring attentio
 
 The top of the Health view shows cluster-wide health:
 
-| Status | Color | Score Range | Description |
-|--------|-------|-------------|-------------|
-| **Healthy** | Green | 90-100 | No issues, optimal performance |
-| **Warning** | Yellow | 60-89 | Minor issues, attention recommended |
-| **Critical** | Red | 0-59 | Serious issues, immediate action needed |
+| Status | Color | Description |
+|--------|-------|-------------|
+| **Healthy** | Green | No issues, optimal performance |
+| **Warning** | Yellow | Minor issues, attention recommended |
+| **Critical** | Red | Serious issues, immediate action needed |
 
 ### Health Score Calculation
 
@@ -237,37 +237,29 @@ Each component shows:
 ### Show Health Statistics
 **Shortcut**: `s/S`
 
-Opens health statistics dashboard:
+Opens health statistics summary:
 
-**Alert Statistics:**
-- Total alerts (all time)
-- Active alerts by severity
-- Average resolution time
-- Alert frequency trends
+**Alert Counts:**
+- Total alerts
+- Critical alerts
+- Warning alerts
+- Info alerts
+- Active alerts
+- Resolved alerts
+- Acknowledged alerts
+- Unacknowledged alerts
 
-**System Uptime:**
-- Cluster uptime
-- Node availability percentage
-- Service disruptions
-
-**Performance Metrics:**
-- Job success rate
-- Average queue wait time
-- Resource utilization trends
-- System throughput
-
-**Historical Trends:**
-- Health score over time (24h, 7d, 30d)
-- Alert frequency patterns
-- Recurring issues
-- Improvement/degradation trends
+**Check Summary:**
+- Total Checks
+- Overall Status
+- Last Updated
 
 ### Refresh Health Data
 **Shortcut**: `R`
 
 Manually refreshes all health checks and alerts.
 
-Auto-refresh occurs every 10-30 seconds.
+Auto-refresh occurs every 10 seconds.
 
 ## Filtering
 
@@ -312,9 +304,7 @@ Auto-refresh occurs every 10-30 seconds.
 
 ## Auto-Refresh
 
-Health view auto-refreshes every **10-30 seconds** to provide real-time monitoring.
-
-More frequent during active incidents.
+Health view auto-refreshes every **10 seconds** to provide real-time monitoring.
 
 ## Alert Example
 
@@ -390,34 +380,20 @@ When viewing statistics (`s/S`):
 ```
 Health Statistics
 
-Alert Summary (Last 7 Days):
+Alert Summary:
   Total Alerts: 47
   Critical: 2
   Warning: 28
   Info: 17
-  Average Resolution Time: 2h 15m
+  Active: 3
+  Resolved: 36
+  Acknowledged: 8
+  Unacknowledged: 3
 
-Current Status:
-  Active Alerts: 3
-  Acknowledged: 1
-  Resolved (24h): 8
-
-System Uptime:
-  Cluster: 99.8%
-  Average Node Availability: 98.5%
-  Last Outage: 3 days ago (15 minutes)
-
-Performance Metrics:
-  Job Success Rate: 94.2%
-  Average Wait Time: 1h 45m
-  Resource Utilization: 78%
-  Throughput: 245 jobs/hour
-
-Health Trend (7 days):
-  Average Score: 87/100
-  Trend: Improving (+3 points)
-  Best Day: Monday (95/100)
-  Worst Day: Wednesday (78/100)
+Check Summary:
+  Total Checks: 5
+  Overall Status: Warning
+  Last Updated: 2024-01-15 14:35:00
 ```
 
 ## Tips

--- a/docs/user-guide/views/index.md
+++ b/docs/user-guide/views/index.md
@@ -8,45 +8,54 @@ s9s provides specialized views for different aspects of your SLURM cluster. Each
 
 | View | Description | Key Shortcut |
 |------|-------------|--------------|
-| [Dashboard](dashboard.md) | Real-time cluster overview with health metrics | Default view |
-| [Jobs](jobs.md) | Job management, submission, and monitoring | `Tab` or `J` |
-| [Nodes](nodes.md) | Node status, resource usage, and operations | `N` |
-| [Partitions](partitions.md) | Partition information and queue analysis | `P` |
+| [Jobs](jobs.md) | Job management, submission, and monitoring | `1` |
+| [Nodes](nodes.md) | Node status, resource usage, and operations | `2` |
+| [Partitions](partitions.md) | Partition information and queue analysis | `3` |
+| [Dashboard](dashboard.md) | Real-time cluster overview with health metrics | `8` |
 
 ### Resource Management
 
-| View | Description | Access |
+| View | Description | Key Shortcut |
 |------|-------------|--------|
-| [Users](users.md) | User accounts and resource limits | Via navigation |
-| [Accounts](accounts.md) | Account hierarchy and associations | Via navigation |
-| [QoS](qos.md) | Quality of Service policies and priorities | Via navigation |
-| [Reservations](reservations.md) | Reservation scheduling and management | Via navigation |
+| [Reservations](reservations.md) | Reservation scheduling and management | `4` |
+| [QoS](qos.md) | Quality of Service policies and priorities | `5` |
+| [Accounts](accounts.md) | Account hierarchy and associations | `6` |
+| [Users](users.md) | User accounts and resource limits | `7` |
 
 ### Monitoring
 
-| View | Description | Access |
+| View | Description | Key Shortcut |
 |------|-------------|--------|
-| [Performance](performance.md) | Cluster-wide metrics and resource utilization | `9` or via navigation |
-| [Health](health.md) | Cluster health checks and alerts | `H` from Dashboard |
+| [Health](health.md) | Cluster health checks and alerts | `9` |
+| [Performance](performance.md) | Cluster-wide metrics and resource utilization | `0` |
 
 ## Switching Between Views
 
 ### Using Tab Navigation
-Press `Tab` to cycle through the main views:
-- Dashboard → Jobs → Nodes → Partitions → Users → Accounts → QoS → Reservations
+Press `Tab` to cycle through views in this order:
+- Jobs → Nodes → Partitions → Reservations → QoS → Accounts → Users → Dashboard → Health → Performance
 
-### Direct Navigation
-Press the corresponding key to jump directly to a view:
-- `J` - Jobs view
-- `N` - Nodes view
-- `P` - Partitions view
+### Using Number Keys
+Press a number key to jump directly to a view (works globally):
+- `1` - Jobs
+- `2` - Nodes
+- `3` - Partitions
+- `4` - Reservations
+- `5` - QoS
+- `6` - Accounts
+- `7` - Users
+- `8` - Dashboard
+- `9` - Health
+- `0` - Performance
 
 ### From Dashboard
-The Dashboard provides quick navigation shortcuts:
+The Dashboard provides additional letter shortcuts:
 - `J` - Switch to Jobs
 - `N` - Switch to Nodes
 - `P` - Switch to Partitions
 - `H` - Open Health Check modal
+
+Note: The `J`, `N`, and `P` letter shortcuts only work from the Dashboard view, not globally.
 
 ## Common Features
 
@@ -54,7 +63,7 @@ All views share these standard capabilities:
 
 ### Filtering
 - **`/`** - Simple text filter (searches all columns)
-- **`F3`** - Advanced filter with expression syntax
+- **`Ctrl+F`** - Advanced filter with expression syntax (Jobs and Nodes views)
 - **`ESC`** - Exit filter mode
 
 ### Search
@@ -62,17 +71,18 @@ All views share these standard capabilities:
 - Search by resource type (jobs, nodes, partitions, etc.)
 
 ### Sorting
-- **`1-9`** - Sort by column number
+- **`S`** - Open sort modal
 - Click column headers to toggle sort direction
 
 ### Refresh
 - **`R`** - Manual refresh
+- **`F5`** - Manual refresh (global)
 - **`m/M`** - Toggle auto-refresh (Jobs view)
-- Views auto-refresh every 10-30 seconds
+- Auto-refresh varies by view: Jobs (30s), Health (10s), Performance (5s). Other views (Dashboard, Users, Accounts, QoS, Reservations) do not auto-refresh.
 
 ### Help
 - **`?`** - Show help and keyboard shortcuts
-- **`F1`** - Action menu (context-specific)
+- **`F1`** - Help modal (global)
 
 ## View-Specific Features
 

--- a/docs/user-guide/views/index.md
+++ b/docs/user-guide/views/index.md
@@ -73,7 +73,7 @@ The following capabilities are available in all table-based data views (Jobs, No
 - **`R`** - Manual refresh
 - **`F5`** - Manual refresh (global)
 - **`m/M`** - Toggle auto-refresh (Jobs view)
-- Auto-refresh varies by view: Jobs (30s), Dashboard (10s), Health (10s), Performance (5s). Other views do not auto-refresh.
+- Auto-refresh varies by view: Jobs (30s), Health (10s), Performance (5s). Other views (including Dashboard) use manual refresh with `R`.
 
 ### Help
 - **`?`** - Show help and keyboard shortcuts

--- a/docs/user-guide/views/index.md
+++ b/docs/user-guide/views/index.md
@@ -59,26 +59,21 @@ Note: The `J`, `N`, and `P` letter shortcuts only work from the Dashboard view, 
 
 ## Common Features
 
-All views share these standard capabilities:
+The following capabilities are available in all table-based data views (Jobs, Nodes, Partitions, Reservations, QoS, Accounts, Users). Dashboard, Health, and Performance views have their own specialized controls.
 
-### Filtering
+### Filtering & Search
 - **`/`** - Simple text filter (searches all columns)
-- **`Ctrl+F`** - Advanced filter with expression syntax (Jobs and Nodes views)
+- **`Ctrl+F`** - Global search across all entity types
 - **`ESC`** - Exit filter mode
-
-### Search
-- **`Ctrl+F`** - Global search across all views
-- Search by resource type (jobs, nodes, partitions, etc.)
 
 ### Sorting
 - **`S`** - Open sort modal
-- Click column headers to toggle sort direction
 
 ### Refresh
 - **`R`** - Manual refresh
 - **`F5`** - Manual refresh (global)
 - **`m/M`** - Toggle auto-refresh (Jobs view)
-- Auto-refresh varies by view: Jobs (30s), Health (10s), Performance (5s). Other views (Nodes, Partitions, Dashboard, Users, Accounts, QoS, Reservations) do not auto-refresh.
+- Auto-refresh varies by view: Jobs (30s), Dashboard (10s), Health (10s), Performance (5s). Other views do not auto-refresh.
 
 ### Help
 - **`?`** - Show help and keyboard shortcuts

--- a/docs/user-guide/views/index.md
+++ b/docs/user-guide/views/index.md
@@ -78,7 +78,7 @@ All views share these standard capabilities:
 - **`R`** - Manual refresh
 - **`F5`** - Manual refresh (global)
 - **`m/M`** - Toggle auto-refresh (Jobs view)
-- Auto-refresh varies by view: Jobs (30s), Health (10s), Performance (5s). Other views (Dashboard, Users, Accounts, QoS, Reservations) do not auto-refresh.
+- Auto-refresh varies by view: Jobs (30s), Health (10s), Performance (5s). Other views (Nodes, Partitions, Dashboard, Users, Accounts, QoS, Reservations) do not auto-refresh.
 
 ### Help
 - **`?`** - Show help and keyboard shortcuts

--- a/docs/user-guide/views/jobs.md
+++ b/docs/user-guide/views/jobs.md
@@ -280,6 +280,7 @@ When disabled, use `R` for manual refresh.
 |-----|--------|
 | `R` | Manual refresh |
 | `m/M` | Toggle auto-refresh |
+| `e/E` | Export view data |
 | `F1` | Help (global) |
 | `S` | Sort modal |
 

--- a/docs/user-guide/views/jobs.md
+++ b/docs/user-guide/views/jobs.md
@@ -32,11 +32,11 @@ The jobs table displays 11 columns:
 - **State column**: Color varies by job state
   - Green: RUNNING
   - Cyan: COMPLETED
-  - Yellow: PENDING, CONFIGURING
-  - Red: FAILED, TIMEOUT
-  - Gray: CANCELED
-  - Orange: SUSPENDED, PREEMPTED
-  - Blue: COMPLETING
+  - Yellow: PENDING
+  - Red: FAILED
+  - Gray: CANCELLED
+  - Orange: SUSPENDED
+  - White: TIMEOUT, PREEMPTED, COMPLETING, CONFIGURING (default)
 - **Table header**: Teal
 - **Selected rows**: Yellow highlight
 
@@ -89,11 +89,9 @@ Available for:
 - PENDING jobs (that were held)
 
 ### Requeue Job
-**Shortcut**: `q/Q`
+**Command**: `:requeue JOBID`
 
-Requeues a completed, failed, or cancelled job for re-execution.
-
-Note: Since `q/Q` is also the global quit shortcut, the requeue action is intercepted by the global quit handler before reaching the Jobs view, making requeue via `q/Q` unreachable.
+Requeues a completed, failed, or cancelled job for re-execution. Use command mode (`:requeue`) since the `q` key is reserved for the global quit shortcut.
 
 ### View Job Output
 **Shortcut**: `o/O`
@@ -164,10 +162,14 @@ Activates the filter input box. Filters jobs by:
 
 **Example**: `/` then type "gpu" to find all jobs with "gpu" in any field.
 
-### Advanced Filter
+### Global Search
 **Shortcut**: `Ctrl+F`
 
-Opens the advanced filter bar with expression-based filtering.
+Opens global search across all entity types (jobs, nodes, partitions, users, accounts, QoS, reservations).
+
+### Advanced Filter
+
+The advanced filter bar supports expression-based filtering.
 
 **Filter expressions:**
 ```
@@ -221,11 +223,6 @@ Press `ESC` to exit advanced filter mode.
 
 Opens dialog to filter jobs by specific username.
 
-### Global Search
-**Shortcut**: `Ctrl+F`
-
-Opens global search across all views (jobs, nodes, partitions, users, accounts, QoS, reservations).
-
 ## Sorting
 
 Sort jobs by clicking column headers or using keyboard shortcuts.
@@ -245,12 +242,6 @@ Jobs view auto-refreshes every **30 seconds** by default.
 
 When disabled, use `R` for manual refresh.
 
-## Action Menu
-
-**Shortcut**: `F1`
-
-Shows context-sensitive action menu with all available actions for the selected job.
-
 ## Keyboard Shortcuts Reference
 
 ### Job Operations
@@ -262,7 +253,7 @@ Shows context-sensitive action menu with all available actions for the selected 
 | `c/C` | Cancel job |
 | `H` | Hold job |
 | `r` | Release job |
-| `q/Q` | Requeue job |
+| `:requeue JOBID` | Requeue job (command mode) |
 | `o/O` | View output |
 | `d/D` | View dependencies |
 
@@ -278,7 +269,7 @@ Shows context-sensitive action menu with all available actions for the selected 
 | Key | Action |
 |-----|--------|
 | `/` | Simple filter |
-| `Ctrl+F` | Advanced filter / Global search |
+| `Ctrl+F` | Global search |
 | `a/A` | Filter all states |
 | `p/P` | Filter pending |
 | `u/U` | Filter by user |
@@ -289,7 +280,7 @@ Shows context-sensitive action menu with all available actions for the selected 
 |-----|--------|
 | `R` | Manual refresh |
 | `m/M` | Toggle auto-refresh |
-| `F1` | Action menu |
+| `F1` | Help (global) |
 | `S` | Sort modal |
 
 ## Job Submission
@@ -328,9 +319,9 @@ See [Job Management](../job-management.md) for detailed submission guide.
 
 - Use `v/V` for multi-select when you need to operate on specific jobs
 - Use batch operations by state when you want to affect all jobs in a state
-- Press `Ctrl+F` for powerful filtering with expressions
+- Press `Ctrl+F` for global search across all entity types
 - Use `p:name` syntax in simple filter for quick partition filtering
 - Check job output with `o/O` to debug issues
 - Use `d/D` to understand job dependencies before canceling
 - Enable auto-refresh (`m/M`) for monitoring active jobs
-- Press `F1` when unsure what actions are available for a job
+- Press `?` when unsure what actions are available for a job

--- a/docs/user-guide/views/jobs.md
+++ b/docs/user-guide/views/jobs.md
@@ -30,10 +30,13 @@ The jobs table displays 11 columns:
 
 ### Color Coding
 - **State column**: Color varies by job state
-  - Green: RUNNING, COMPLETED
+  - Green: RUNNING
+  - Cyan: COMPLETED
   - Yellow: PENDING, CONFIGURING
-  - Red: FAILED, CANCELLED, TIMEOUT
-  - Cyan: SUSPENDED
+  - Red: FAILED, TIMEOUT
+  - Gray: CANCELED
+  - Orange: SUSPENDED, PREEMPTED
+  - Blue: COMPLETING
 - **Table header**: Teal
 - **Selected rows**: Yellow highlight
 
@@ -53,10 +56,10 @@ Shows detailed information about the selected job:
 - Standard output/error paths
 
 ### Submit New Job
-**Shortcuts**: `s/S` (wizard), `F2` (templates)
+**Shortcuts**: `s` (wizard), `F2` (templates)
 
 Two submission methods:
-1. **Job Submission Wizard** (`s/S`): Step-by-step guided submission
+1. **Job Submission Wizard** (`s`): Step-by-step guided submission
 2. **Job Templates** (`F2`): Pre-configured job templates
 
 See [Job Management](../job-management.md) for detailed submission guide.
@@ -89,6 +92,8 @@ Available for:
 **Shortcut**: `q/Q`
 
 Requeues a completed, failed, or cancelled job for re-execution.
+
+Note: Since `q/Q` is also the global quit shortcut, the requeue action is intercepted by the global quit handler before reaching the Jobs view, making requeue via `q/Q` unreachable.
 
 ### View Job Output
 **Shortcut**: `o/O`
@@ -160,17 +165,17 @@ Activates the filter input box. Filters jobs by:
 **Example**: `/` then type "gpu" to find all jobs with "gpu" in any field.
 
 ### Advanced Filter
-**Shortcut**: `F3`
+**Shortcut**: `Ctrl+F`
 
 Opens the advanced filter bar with expression-based filtering.
 
 **Filter expressions:**
 ```
-state:RUNNING
-user:alice
-partition:gpu
-nodes:>4
-priority:>=1000
+state=RUNNING
+user=alice
+partition=gpu
+nodes>4
+priority>=1000
 ```
 
 **Supported fields:**
@@ -193,14 +198,14 @@ priority:>=1000
 
 **Operators:**
 - `=` - Exact match
-- `:` - Contains
+- `~` - Contains
 - `>`, `<`, `>=`, `<=` - Numeric comparison
 
 **Example filters:**
 ```
-state:RUNNING partition:gpu
-user:alice priority:>500
-nodes:>=8 state:PENDING
+state=RUNNING partition=gpu
+user=alice priority>500
+nodes>=8 state=PENDING
 ```
 
 Press `ESC` to exit advanced filter mode.
@@ -252,7 +257,7 @@ Shows context-sensitive action menu with all available actions for the selected 
 | Key | Action |
 |-----|--------|
 | `Enter` | View job details |
-| `s/S` | Submit job (wizard) |
+| `s` | Submit job (wizard) |
 | `F2` | Job templates |
 | `c/C` | Cancel job |
 | `H` | Hold job |
@@ -273,8 +278,7 @@ Shows context-sensitive action menu with all available actions for the selected 
 | Key | Action |
 |-----|--------|
 | `/` | Simple filter |
-| `F3` | Advanced filter |
-| `Ctrl+F` | Global search |
+| `Ctrl+F` | Advanced filter / Global search |
 | `a/A` | Filter all states |
 | `p/P` | Filter pending |
 | `u/U` | Filter by user |
@@ -294,7 +298,7 @@ Shows context-sensitive action menu with all available actions for the selected 
 
 *Job submission wizard with step-by-step configuration*
 
-The job submission wizard (`s/S`) guides you through:
+The job submission wizard (`s`) guides you through:
 
 1. **Basic Information**
    - Job name
@@ -324,8 +328,8 @@ See [Job Management](../job-management.md) for detailed submission guide.
 
 - Use `v/V` for multi-select when you need to operate on specific jobs
 - Use batch operations by state when you want to affect all jobs in a state
-- Press `F3` for powerful filtering with expressions
-- Use `partition:name` syntax in simple filter for quick partition filtering
+- Press `Ctrl+F` for powerful filtering with expressions
+- Use `p:name` syntax in simple filter for quick partition filtering
 - Check job output with `o/O` to debug issues
 - Use `d/D` to understand job dependencies before canceling
 - Enable auto-refresh (`m/M`) for monitoring active jobs

--- a/docs/user-guide/views/nodes.md
+++ b/docs/user-guide/views/nodes.md
@@ -181,7 +181,6 @@ Filters nodes by any column value:
 - `p:partition` or `partition:name` - Filter by partition
 
 ### Advanced Filter
-**Shortcut**: `Ctrl+F`
 
 Expression-based filtering with field matching:
 
@@ -268,7 +267,7 @@ Press `S` to open the interactive sort modal.
 | Key | Action |
 |-----|--------|
 | `/` | Simple filter |
-| `Ctrl+F` | Advanced filter / Global search |
+| `Ctrl+F` | Global search |
 | `p/P` | Filter by partition |
 | `a/A` | Toggle all states |
 | `i/I` | Toggle idle filter |

--- a/docs/user-guide/views/nodes.md
+++ b/docs/user-guide/views/nodes.md
@@ -14,7 +14,7 @@ The Nodes view displays all compute nodes in your cluster with real-time resourc
 
 | Column | Description |
 |--------|-------------|
-| **Node Name** | Node identifier |
+| **Name** | Node identifier |
 | **State** | Color-coded node status |
 | **Partitions** | Associated partition names |
 | **CPU Usage** | Dual visual bar with allocated vs. actual usage |
@@ -31,13 +31,13 @@ Node states are color-coded for quick identification:
 | State | Color | Description |
 |-------|-------|-------------|
 | **IDLE** | Green | Available for work |
-| **ALLOCATED** | Cyan | Fully assigned to jobs |
-| **MIXED** | Yellow | Partially allocated |
+| **ALLOCATED** | Blue | Fully assigned to jobs |
+| **MIXED** | Blue | Partially allocated |
 | **DOWN** | Red | Unavailable/offline |
-| **DRAIN** | Orange | Being drained |
-| **IDLE+DRAIN** | Orange | Idle but draining |
-| **COMPLETING** | Blue | Jobs completing |
-| **RESERVED** | Magenta | Reserved |
+| **DRAIN** | Red | Being drained |
+| **DRAINING** | Red | Draining in progress |
+| **RESERVED** | Yellow | Reserved |
+| **MAINTENANCE** | Orange | Under maintenance |
 
 ## Resource Usage Visualization
 
@@ -130,7 +130,7 @@ Resumes a drained node, making it available for new jobs.
 - State changes from DRAIN to IDLE (or appropriate state)
 
 ### SSH Access
-**Shortcut**: `s/S`
+**Shortcut**: `s`
 
 Opens SSH options menu with four choices:
 
@@ -181,16 +181,16 @@ Filters nodes by any column value:
 - `p:partition` or `partition:name` - Filter by partition
 
 ### Advanced Filter
-**Shortcut**: `F3`
+**Shortcut**: `Ctrl+F`
 
 Expression-based filtering with field matching:
 
 ```
-state:IDLE
-partition:gpu
-features:nvlink
-cpus:>64
-memory:>256GB
+state=IDLE
+partition=gpu
+features~nvlink
+cpus>64
+memory>256GB
 ```
 
 Press `ESC` to exit advanced filter.
@@ -261,14 +261,14 @@ Press `S` to open the interactive sort modal.
 | `Enter` | View node details |
 | `d/D` | Drain node |
 | `r` | Resume node |
-| `s/S` | SSH to node |
+| `s` | SSH to node |
+| `S` | Sort modal |
 
 ### Filtering & Search
 | Key | Action |
 |-----|--------|
 | `/` | Simple filter |
-| `F3` | Advanced filter |
-| `Ctrl+F` | Global search |
+| `Ctrl+F` | Advanced filter / Global search |
 | `p/P` | Filter by partition |
 | `a/A` | Toggle all states |
 | `i/I` | Toggle idle filter |

--- a/docs/user-guide/views/nodes.md
+++ b/docs/user-guide/views/nodes.md
@@ -284,6 +284,7 @@ Press `S` to open the interactive sort modal.
 | Key | Action |
 |-----|--------|
 | `R` | Manual refresh |
+| `e/E` | Export view data |
 | `S` | Sort modal |
 
 ## Node Details Example

--- a/docs/user-guide/views/partitions.md
+++ b/docs/user-guide/views/partitions.md
@@ -12,17 +12,21 @@ The Partitions view displays all SLURM partitions with real-time queue informati
 
 ## Table Columns
 
+The partitions table displays 11 columns:
+
 | Column | Description |
 |--------|-------------|
 | **Name** | Partition name |
 | **State** | Partition status (UP/DOWN/DRAIN/INACTIVE) |
-| **Total Nodes** | Number of nodes in partition |
+| **Nodes** | Number of nodes in partition |
 | **CPUs** | Total CPU count |
 | **Queue Depth** | Visual representation of pending vs. running jobs |
-| **Jobs (Run/Pend)** | Running and pending job counts |
-| **Avg Wait / Max Wait** | Average and maximum wait times |
+| **Running** | Running job count |
+| **Pending** | Pending job count |
+| **Avg Wait** | Average wait time for pending jobs |
+| **Max Wait** | Maximum wait time for pending jobs |
 | **Efficiency** | Cluster efficiency percentage |
-| **QoS** | Associated Quality of Service policies |
+| **QOS** | Associated Quality of Service policies |
 
 ## Queue Depth Visualization
 
@@ -184,30 +188,6 @@ Filters partitions by:
 - QoS policies
 - Any displayed column
 
-### Advanced Filter
-**Shortcut**: `F3`
-
-Expression-based filtering:
-
-```
-state:UP
-nodes:>100
-efficiency:>80
-qos:high
-```
-
-**Supported fields:**
-- `name` - Partition name
-- `state` - Partition state
-- `nodes` - Node count (supports >, <, >=, <=)
-- `cpus` - CPU count (supports comparison)
-- `efficiency` - Efficiency percentage (supports comparison)
-- `jobs` - Running job count
-- `pending` - Pending job count
-- `qos` - QoS name
-
-Press `ESC` to exit advanced filter.
-
 ### Global Search
 **Shortcut**: `Ctrl+F`
 
@@ -240,7 +220,6 @@ Press `S` to open the interactive sort modal.
 | Key | Action |
 |-----|--------|
 | `/` | Simple filter |
-| `F3` | Advanced filter |
 | `Ctrl+F` | Global search |
 | `ESC` | Exit filter mode |
 
@@ -351,7 +330,7 @@ The longest current wait for any pending job.
 - **Navigate to nodes**: Press `N` to check partition node health
 - **Compare partitions**: Sort by efficiency to compare partition utilization
 - **Queue depth visualization**: Use visual bars to quickly spot bottlenecks
-- **Filter by state**: Use `F3` with `state:UP` to focus on active partitions
+- **Filter by state**: Use `/` with `UP` to focus on active partitions
 - **Capacity planning**: Review analytics regularly for growth trends
 
 ## Capacity Planning

--- a/docs/user-guide/views/partitions.md
+++ b/docs/user-guide/views/partitions.md
@@ -227,6 +227,7 @@ Press `S` to open the interactive sort modal.
 | Key | Action |
 |-----|--------|
 | `R` | Manual refresh |
+| `e/E` | Export view data |
 | `S` | Sort modal |
 
 ## Partition Details Example

--- a/docs/user-guide/views/performance.md
+++ b/docs/user-guide/views/performance.md
@@ -18,7 +18,7 @@ This view is designed for quick cluster health assessment and capacity planning.
 
 ## Access
 
-Press **`9`** or navigate to "Performance" from the view switcher.
+Press **`0`** or navigate to "Performance" from the view switcher.
 
 ## Display Sections
 
@@ -71,8 +71,6 @@ Shows aggregate cluster utilization:
 |-----|--------|
 | `R` | Toggle auto-refresh on/off |
 | `F5` | Manual refresh |
-| `?` | Show help |
-| `q` | Exit view |
 
 ## Auto-Refresh
 
@@ -145,10 +143,10 @@ Pending: 3      Idle: 0
 
 The Performance view provides a high-level overview. Drill down for details:
 
-- **Jobs view** (`J`): See specific job details and queue analysis
-- **Nodes view** (`N`): Investigate individual node status and down nodes
-- **Partitions view** (`P`): Check partition-specific utilization
-- **Dashboard view** (`D`): See health checks and detailed metrics
+- **Jobs view** (`1`): See specific job details and queue analysis
+- **Nodes view** (`2`): Investigate individual node status and down nodes
+- **Partitions view** (`3`): Check partition-specific utilization
+- **Dashboard view** (`8`): See health checks and detailed metrics
 
 ## Tips
 
@@ -175,7 +173,7 @@ All metrics are pulled from the SLURM cluster via `sinfo`, `squeue`, and cluster
 For s9s developers, there's an **App Diagnostics** view that monitors the s9s CLI application itself (memory, goroutines, internal operations). This is hidden by default and can be enabled with:
 
 ```yaml
-# ~/.config/s9s/config.yaml
+# ~/.s9s/config.yaml
 features:
   appDiagnostics: true
 ```

--- a/docs/user-guide/views/qos.md
+++ b/docs/user-guide/views/qos.md
@@ -12,18 +12,21 @@ Quality of Service (QoS) policies define service tiers with different priorities
 
 ## Table Columns
 
+The QoS table displays 9 columns:
+
 | Column | Description |
 |--------|-------------|
 | **Name** | QoS policy name |
 | **Priority** | Scheduling priority (color-coded) |
 | **Preempt Mode** | Preemption behavior |
-| **Max Jobs (User)** | Max jobs per user |
-| **Max Submit (User)** | Max submitted jobs per user |
-| **Max CPUs (User)** | Max CPUs per user |
-| **Max Nodes (User)** | Max nodes per user |
+| **Max Jobs/User** | Max jobs per user |
+| **Max Submit/User** | Max submitted jobs per user |
+| **Max CPUs/User** | Max CPUs per user |
+| **Max Nodes/User** | Max nodes per user |
 | **Max Wall Time** | Maximum job duration |
 | **Grace Time** | Time before preemption |
-| **Flags** | Special QoS flags |
+
+Note: The **Flags** column is not shown in the table but is available in the QoS details modal (`Enter`).
 
 ## QoS Priority
 
@@ -34,8 +37,8 @@ Priority determines scheduling order when resources are limited.
 | Range | Color | Description | Typical Use |
 |-------|-------|-------------|-------------|
 | **>1000** | Green | High priority | Production, urgent work |
-| **100-1000** | Yellow | Normal priority | Regular research |
-| **<100** | White | Low priority | Background tasks |
+| **>100** | Yellow | Normal priority | Regular research |
+| **<=100** | White | Low priority | Background tasks |
 
 **How priority works:**
 - Higher priority jobs schedule before lower priority
@@ -47,7 +50,7 @@ Priority determines scheduling order when resources are limited.
 ```
 urgent:    10000  (Green)  - Critical production
 high:       5000  (Green)  - Important deadlines
-normal:      100  (Yellow) - Standard work
+normal:      100  (White)  - Standard work
 low:          10  (White)  - Best-effort
 preemptible:   1  (White)  - Scavenger jobs
 ```
@@ -168,27 +171,6 @@ Filter by:
 - Preempt mode
 - Flags
 
-#### Advanced Filter
-**Shortcut**: `F3`
-
-Expression-based filtering:
-
-```
-priority:>1000
-preempt:Suspend
-maxjobs:>100
-walltime:>7-00:00:00
-```
-
-**Supported fields:**
-- `name` - QoS name
-- `priority` - Priority value (supports >, <, >=, <=)
-- `preempt` - Preemption mode
-- `maxjobs` - Max jobs per user (supports comparison)
-- `maxcpus` - Max CPUs per user (supports comparison)
-- `walltime` - Max wall time (supports comparison)
-- `flags` - Flag names
-
 ### Global Search
 **Shortcut**: `Ctrl+F`
 
@@ -216,7 +198,6 @@ Press `S` to open the interactive sort modal.
 | Key | Action |
 |-----|--------|
 | `/` | Simple filter |
-| `F3` | Advanced filter |
 | `Ctrl+F` | Global search |
 | `ESC` | Exit filter mode |
 

--- a/docs/user-guide/views/qos.md
+++ b/docs/user-guide/views/qos.md
@@ -205,6 +205,7 @@ Press `S` to open the interactive sort modal.
 | Key | Action |
 |-----|--------|
 | `R` | Manual refresh |
+| `e/E` | Export view data |
 | `S` | Sort modal |
 
 ## QoS Details Example

--- a/docs/user-guide/views/reservations.md
+++ b/docs/user-guide/views/reservations.md
@@ -137,13 +137,6 @@ Shows comprehensive reservation information:
 - Full list of authorized accounts
 - Access restrictions
 
-**Flags:**
-- IGNORE_JOBS - Override running jobs
-- DAILY - Repeating daily reservation
-- WEEKLY - Repeating weekly reservation
-- REPLACE - Replace existing allocation
-- STATIC_ALLOC - Fixed node allocation
-
 **Current Usage** (for active):
 - Jobs running in reservation
 - Resources in use vs. reserved
@@ -159,28 +152,6 @@ Filter by:
 - State
 - Authorized users
 - Authorized accounts
-
-#### Advanced Filter
-**Shortcut**: `F3`
-
-Expression-based filtering:
-
-```
-state:ACTIVE
-nodes:>16
-users:alice
-accounts:ml-team
-```
-
-**Supported fields:**
-- `name` - Reservation name
-- `state` - State (ACTIVE/INACTIVE/future)
-- `nodes` - Node count (supports >, <, >=, <=)
-- `cores` - Core count (supports comparison)
-- `users` - Username in authorized list
-- `accounts` - Account in authorized list
-- `start` - Start time (supports comparison)
-- `end` - End time (supports comparison)
 
 ### Global Search
 **Shortcut**: `Ctrl+F`
@@ -210,7 +181,6 @@ Press `S` to open the interactive sort modal.
 | Key | Action |
 |-----|--------|
 | `/` | Simple filter |
-| `F3` | Advanced filter |
 | `Ctrl+F` | Global search |
 | `a` | Toggle active filter (show active reservations only) |
 | `f` | Toggle future filter (show future reservations only) |

--- a/docs/user-guide/views/reservations.md
+++ b/docs/user-guide/views/reservations.md
@@ -182,14 +182,15 @@ Press `S` to open the interactive sort modal.
 |-----|--------|
 | `/` | Simple filter |
 | `Ctrl+F` | Global search |
-| `a` | Toggle active filter (show active reservations only) |
-| `f` | Toggle future filter (show future reservations only) |
+| `a/A` | Toggle active filter (show active reservations only) |
+| `f/F` | Toggle future filter (show future reservations only) |
 | `ESC` | Exit filter mode |
 
 ### Data Management
 | Key | Action |
 |-----|--------|
 | `R` | Manual refresh |
+| `e/E` | Export view data |
 | `S` | Sort modal |
 
 ## Reservation Details Example

--- a/docs/user-guide/views/users.md
+++ b/docs/user-guide/views/users.md
@@ -181,6 +181,7 @@ Press `S` to open the interactive sort modal.
 | Key | Action |
 |-----|--------|
 | `R` | Manual refresh |
+| `e/E` | Export view data |
 | `S` | Sort modal |
 
 ## User Details Example

--- a/docs/user-guide/views/users.md
+++ b/docs/user-guide/views/users.md
@@ -14,7 +14,7 @@ The Users view provides a comprehensive list of all SLURM users with their permi
 
 | Column | Description |
 |--------|-------------|
-| **User** | Username |
+| **Name** | Username |
 | **UID** | User ID number |
 | **Default Account** | Primary billing account |
 | **Admin Level** | User privilege level (color-coded) |
@@ -111,14 +111,13 @@ Shows comprehensive user information:
 - Maximum jobs (running + pending)
 - Maximum nodes per job
 - Maximum CPUs total
-- Maximum wall time
-- Maximum memory
 
 **Current Usage:**
 - Active jobs count
 - Current CPU usage
 - Current node usage
-- Current memory usage
+
+Note: Current Usage values display "N/A" placeholders and do not show actual usage data.
 
 **Account Associations:**
 - List of accounts user can submit to
@@ -136,28 +135,6 @@ Filter by:
 - Admin level
 - QoS
 - Any displayed field
-
-#### Advanced Filter
-**Shortcut**: `F3`
-
-Expression-based filtering:
-
-```
-admin:Administrator
-account:research
-qos:high
-maxjobs:>50
-```
-
-**Supported fields:**
-- `user` - Username
-- `uid` - User ID
-- `account` - Default account name
-- `admin` - Admin level (Administrator/Operator/Regular)
-- `qos` - Default QoS
-- `maxjobs` - Max jobs limit (supports >, <, >=, <=)
-- `maxnodes` - Max nodes limit (supports comparison)
-- `maxcpus` - Max CPUs limit (supports comparison)
 
 ### Admin Filter Toggle
 **Shortcut**: `a/A`
@@ -196,7 +173,6 @@ Press `S` to open the interactive sort modal.
 | Key | Action |
 |-----|--------|
 | `/` | Simple filter |
-| `F3` | Advanced filter |
 | `Ctrl+F` | Global search |
 | `a/A` | Toggle admin-only filter |
 | `ESC` | Exit filter mode |
@@ -223,13 +199,11 @@ Resource Limits:
   Max Jobs: 50
   Max Nodes: 16 per job
   Max CPUs: 1000 total
-  Max Wall Time: 7-00:00:00 (7 days)
-  Max Memory: 2TB
 
 Current Usage:
-  Active Jobs: 8
-  CPUs Used: 384/1000 (38%)
-  Nodes Used: 12/16 (75%)
+  Active Jobs: N/A
+  CPUs Used: N/A
+  Nodes Used: N/A
 
 Associated Accounts:
   ml-team (Default, Priority: 100)
@@ -317,7 +291,7 @@ Press `a/A` to toggle admin-only filtering:
 - **Review account associations**: Users might not realize they have access to other accounts
 - **Monitor admin users**: Regularly review who has elevated access
 - **Compare QoS**: Different QoS levels provide different priorities and limits
-- **Filter by account**: Use `F3` with `account:name` to see all users in a research group
+- **Filter by account**: Use `/` with the account name to see all users in a research group
 - **Sort by usage limits**: Identify power users with high CPU/node limits
 - **Default account matters**: Billing and priority often depend on the default account
 - **Unlimited ≠ infinite**: Still subject to partition and cluster limits


### PR DESCRIPTION
## Summary

Final comprehensive sweep of all 42 doc files. Fixes 6 files with remaining inaccuracies found after PRs #116, #118, #120, #121.

### Changes

- **commands.md**: Fix global shortcuts (Ctrl+K, F1, F5), view number mappings (3=Partitions not Users), selection shortcuts, clear filter key
- **quickstart.md**: Fix view numbers, R→F5 for refresh
- **node-operations.md**: Fix :view→:nodes, remove fake drain flags/ssh/diag commands
- **job-management.md**: Remove :select pattern, fix Ctrl+E→e
- **development/setup.md**: Remove --mock-jobs/--mock-nodes flags

### Verification

Confirmed these ARE correctly documented (per-view, not global):
- `Ctrl+F` — implemented in jobs, nodes, partitions, accounts, qos, reservations, users views
- `R` — implemented as view-specific refresh in all views
- `Ctrl+A` — implemented in jobs view for select all

### Final sweep results

Zero matches for: `:view`, `:submit`, `:ssh`, `:diag`, `:chain`, `:schedule`, `:select`, `:cache`, `:export`, `:set`, `--url`, `--theme`, `--mock-jobs`, `--mock-nodes`, `Ctrl+E`

## Test plan

- [ ] All documented shortcuts exist in code
- [ ] All documented commands exist in command registry
- [ ] All documented CLI flags exist in root.go
- [ ] No references to unimplemented features remain