### PR TITLE
fix: use SLURM_USER_NAME env var for auth and user defaults

### DIFF
--- a/internal/dao/slurm_adapter.go
+++ b/internal/dao/slurm_adapter.go
@@ -53,8 +53,11 @@ func NewSlurmAdapter(ctx context.Context, cfg *config.ClusterConfig) (*SlurmAdap
 	// Add authentication if token is provided
 	if cfg.Token != "" {
 		// Resolve username for X-SLURM-USER-NAME header.
-		// Priority: SLURM_USER_NAME env var > OS current user
+		// Priority: SLURM_USER_NAME env > USER env > OS current user
 		username := os.Getenv("SLURM_USER_NAME")
+		if username == "" {
+			username = os.Getenv("USER")
+		}
 		if username == "" {
 			if currentUser, err := osuser.Current(); err == nil && currentUser.Username != "" {
 				username = currentUser.Username

--- a/internal/dao/slurm_adapter.go
+++ b/internal/dao/slurm_adapter.go
@@ -52,10 +52,16 @@ func NewSlurmAdapter(ctx context.Context, cfg *config.ClusterConfig) (*SlurmAdap
 
 	// Add authentication if token is provided
 	if cfg.Token != "" {
-		// Get current username for X-SLURM-USER-NAME header
-		username := "root" // default
-		if currentUser, err := osuser.Current(); err == nil && currentUser.Username != "" {
-			username = currentUser.Username
+		// Resolve username for X-SLURM-USER-NAME header.
+		// Priority: SLURM_USER_NAME env var > OS current user
+		username := os.Getenv("SLURM_USER_NAME")
+		if username == "" {
+			if currentUser, err := osuser.Current(); err == nil && currentUser.Username != "" {
+				username = currentUser.Username
+			}
+		}
+		if username == "" {
+			return nil, fmt.Errorf("cannot determine SLURM username: set SLURM_USER_NAME environment variable")
 		}
 
 		// Use WithUserToken to set both X-SLURM-USER-NAME and X-SLURM-USER-TOKEN headers

--- a/internal/views/job_submission_wizard.go
+++ b/internal/views/job_submission_wizard.go
@@ -2308,7 +2308,11 @@ func (w *JobSubmissionWizard) getAvailableQoS() []string {
 
 // getCurrentUser fetches the current OS user's SLURM user record
 func (w *JobSubmissionWizard) getCurrentUser() *dao.User {
-	username := os.Getenv("USER")
+	// Use the same resolution as the auth layer: SLURM_USER_NAME > OS user
+	username := os.Getenv("SLURM_USER_NAME")
+	if username == "" {
+		username = os.Getenv("USER")
+	}
 	if username == "" {
 		if u, err := osuser.Current(); err == nil {
 			username = u.Username

--- a/internal/views/job_submission_wizard.go
+++ b/internal/views/job_submission_wizard.go
@@ -2308,7 +2308,7 @@ func (w *JobSubmissionWizard) getAvailableQoS() []string {
 
 // getCurrentUser fetches the current OS user's SLURM user record
 func (w *JobSubmissionWizard) getCurrentUser() *dao.User {
-	// Use the same resolution as the auth layer: SLURM_USER_NAME > OS user
+	// Same resolution as the auth layer: SLURM_USER_NAME env > USER env > OS user
 	username := os.Getenv("SLURM_USER_NAME")
 	if username == "" {
 		username = os.Getenv("USER")

--- a/scripts/dev-clusters.sh
+++ b/scripts/dev-clusters.sh
@@ -193,19 +193,38 @@ discovery:
   enabled: false
 EOF
 
+# Write env file for SLURM_USER_NAME (tokens are generated for root)
+ENV_FILE="$CONFIG_DIR/env.sh"
+cat > "$ENV_FILE" <<EOF
+# Source this file or use the s9s-dev wrapper below
+export SLURM_USER_NAME=root
+EOF
+
+# Write convenience wrapper script
+WRAPPER="$CONFIG_DIR/s9s-dev"
+cat > "$WRAPPER" <<WRAPPER_EOF
+#!/usr/bin/env bash
+# Dev cluster wrapper — sets SLURM_USER_NAME and passes all args to s9s
+export SLURM_USER_NAME=root
+exec s9s --config "$CONFIG_FILE" --no-discovery "\$@"
+WRAPPER_EOF
+chmod +x "$WRAPPER"
+
 echo ""
 echo -e "${BOLD}=== Dev Clusters Config Ready ===${NC}"
 echo ""
-echo -e "  Config: ${GREEN}$CONFIG_FILE${NC}"
+echo -e "  Config:   ${GREEN}$CONFIG_FILE${NC}"
+echo -e "  Wrapper:  ${GREEN}$WRAPPER${NC}"
 echo -e "  Clusters: ${AVAILABLE_NAMESPACES[*]}"
 echo -e "  Default:  ${BOLD}$DEFAULT_CLUSTER${NC}"
 echo ""
-echo -e "  ${BOLD}Usage:${NC}"
-echo -e "    s9s --config $CONFIG_FILE --no-discovery"
+echo -e "  ${BOLD}Usage (easiest):${NC}"
+echo -e "    $WRAPPER"
+echo -e "    $WRAPPER --cluster slurm-2511"
 echo ""
-echo -e "  ${BOLD}Switch cluster:${NC}"
-echo -e "    s9s --config $CONFIG_FILE --cluster slurm-2511 --no-discovery"
-echo -e "    or edit defaultCluster in $CONFIG_FILE"
+echo -e "  ${BOLD}Or manually:${NC}"
+echo -e "    source $ENV_FILE"
+echo -e "    s9s --config $CONFIG_FILE --no-discovery"
 echo ""
 echo -e "  ${BOLD}Re-seed clusters:${NC}"
 echo -e "    $0 --seed-only"


### PR DESCRIPTION
## Summary

Fix job submission and node drain failures when s9s runs on a different machine than the SLURM cluster (e.g., local dev connecting to Kubernetes clusters).

## Problem

The `X-SLURM-USER-NAME` header and wizard user lookup both resolved the username from the local OS (`os/user.Current()`). When the local username (e.g., `jontk`) doesn't exist in SLURM:
- **Job submission fails**: `slurm_submit_batch_job()` — SLURM can't resolve the account
- **Node drain fails**: `_update_node` — user lacks admin privileges
- **Account dropdown empty**: wizard looks up `jontk` in SLURM users, gets nothing

## Fix

- **Auth**: `SLURM_USER_NAME` env var > OS username. No silent `root` fallback — fails explicitly if neither available.
- **Wizard**: `getCurrentUser()` now checks `SLURM_USER_NAME` first, so account/QoS defaults resolve correctly.
- **Dev script**: Generates `s9s-dev` wrapper and `env.sh` that set `SLURM_USER_NAME=root`.

Proper fix (configurable `user` field per cluster in config) tracked in #143.

## Test plan

- [ ] `SLURM_USER_NAME=root s9s` — job submission works on dev clusters
- [ ] `SLURM_USER_NAME=root s9s` — node drain/resume works
- [ ] Account dropdown defaults to root's default account
- [ ] Without `SLURM_USER_NAME`, uses OS username (existing behavior on SLURM nodes)
- [ ] Without either, fails with clear error message