### PR TITLE
feat: configurable SLURM username per cluster

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -19,6 +19,7 @@ clusters:
       apiVersion: v0.0.40
       insecure: false
       timeout: 30s
+      # user: root  # Override SLURM username (default: OS user)
     namespace: default
     readOnly: false
     

--- a/internal/app/app_views.go
+++ b/internal/app/app_views.go
@@ -49,6 +49,7 @@ func (s *S9s) registerJobsView() error {
 	view.SetStatusBar(s.statusBar)
 	view.SetPages(s.pages)
 	view.SetSubmissionConfig(&s.config.Views.Jobs.Submission)
+	view.SetSlurmUser(s.config.ResolveSlurmUser())
 	return s.addViewToApp("jobs", view)
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	osuser "os/user"
 	"path/filepath"
 	"strings"
 
@@ -457,14 +458,23 @@ func (c *Config) GetCluster(name string) (*ClusterContext, error) {
 // Priority: SLURM_USER_NAME env > cluster config user > USER env > OS current user.
 // Returns empty string if no username can be determined.
 func (c *Config) ResolveSlurmUser() string {
+	return ResolveSlurmUserForCluster(&c.Cluster)
+}
+
+// ResolveSlurmUserForCluster resolves the SLURM username from a cluster config.
+// Priority: SLURM_USER_NAME env > cluster config user > USER env > OS current user.
+func ResolveSlurmUserForCluster(cfg *ClusterConfig) string {
 	if u := os.Getenv("SLURM_USER_NAME"); u != "" {
 		return u
 	}
-	if c.Cluster.User != "" {
-		return c.Cluster.User
+	if cfg != nil && cfg.User != "" {
+		return cfg.User
 	}
 	if u := os.Getenv("USER"); u != "" {
 		return u
+	}
+	if u, err := osuser.Current(); err == nil && u.Username != "" {
+		return u.Username
 	}
 	return ""
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,6 +57,7 @@ type ClusterConfig struct {
 	APIVersion string `mapstructure:"apiVersion"`
 	Insecure   bool   `mapstructure:"insecure"`
 	Timeout    string `mapstructure:"timeout"`
+	User       string `mapstructure:"user"` // Override X-SLURM-USER-NAME header
 }
 
 // UIConfig holds UI-related settings
@@ -450,6 +451,22 @@ func (c *Config) GetCluster(name string) (*ClusterContext, error) {
 		}
 	}
 	return nil, fmt.Errorf("cluster %q not found", name)
+}
+
+// ResolveSlurmUser returns the effective SLURM username for API requests.
+// Priority: SLURM_USER_NAME env > cluster config user > USER env > OS current user.
+// Returns empty string if no username can be determined.
+func (c *Config) ResolveSlurmUser() string {
+	if u := os.Getenv("SLURM_USER_NAME"); u != "" {
+		return u
+	}
+	if c.Cluster.User != "" {
+		return c.Cluster.User
+	}
+	if u := os.Getenv("USER"); u != "" {
+		return u
+	}
+	return ""
 }
 
 // SaveToFile saves the configuration to a file

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -197,12 +197,12 @@ func (v *Validator) validateContexts() {
 // validateClusters validates cluster configurations
 func (v *Validator) validateClusters() {
 	for i, entry := range v.config.Clusters {
-		v.validateCluster(entry.Cluster, fmt.Sprintf("clusters[%d].cluster", i))
+		v.validateCluster(&entry.Cluster, fmt.Sprintf("clusters[%d].cluster", i))
 	}
 }
 
 // validateCluster validates a single cluster configuration
-func (v *Validator) validateCluster(cluster ClusterConfig, basePath string) {
+func (v *Validator) validateCluster(cluster *ClusterConfig, basePath string) {
 	// Endpoint validation (main connection method)
 	if cluster.Endpoint == "" {
 		v.addError(fmt.Sprintf("%s.endpoint", basePath),
@@ -234,7 +234,7 @@ func (v *Validator) validateCluster(cluster ClusterConfig, basePath string) {
 
 // validateClusterInContext validates cluster within a cluster entry
 func (v *Validator) validateClusterInContext(entry *ClusterContext, entryPath string) {
-	v.validateCluster(entry.Cluster, fmt.Sprintf("%s.cluster", entryPath))
+	v.validateCluster(&entry.Cluster, fmt.Sprintf("%s.cluster", entryPath))
 }
 
 // validateAuthentication validates authentication settings

--- a/internal/dao/slurm_adapter.go
+++ b/internal/dao/slurm_adapter.go
@@ -53,8 +53,11 @@ func NewSlurmAdapter(ctx context.Context, cfg *config.ClusterConfig) (*SlurmAdap
 	// Add authentication if token is provided
 	if cfg.Token != "" {
 		// Resolve username for X-SLURM-USER-NAME header.
-		// Priority: SLURM_USER_NAME env > USER env > OS current user
+		// Priority: SLURM_USER_NAME env > config user > USER env > OS current user
 		username := os.Getenv("SLURM_USER_NAME")
+		if username == "" {
+			username = cfg.User
+		}
 		if username == "" {
 			username = os.Getenv("USER")
 		}
@@ -64,8 +67,9 @@ func NewSlurmAdapter(ctx context.Context, cfg *config.ClusterConfig) (*SlurmAdap
 			}
 		}
 		if username == "" {
-			return nil, fmt.Errorf("cannot determine SLURM username: set SLURM_USER_NAME environment variable")
+			return nil, fmt.Errorf("cannot determine SLURM username: set 'user' in cluster config or SLURM_USER_NAME env var")
 		}
+		debug.Logger.Printf("Using SLURM username: %s", username)
 
 		// Use WithUserToken to set both X-SLURM-USER-NAME and X-SLURM-USER-TOKEN headers
 		// This is required for slurmrestd authentication

--- a/internal/dao/slurm_adapter.go
+++ b/internal/dao/slurm_adapter.go
@@ -52,20 +52,7 @@ func NewSlurmAdapter(ctx context.Context, cfg *config.ClusterConfig) (*SlurmAdap
 
 	// Add authentication if token is provided
 	if cfg.Token != "" {
-		// Resolve username for X-SLURM-USER-NAME header.
-		// Priority: SLURM_USER_NAME env > config user > USER env > OS current user
-		username := os.Getenv("SLURM_USER_NAME")
-		if username == "" {
-			username = cfg.User
-		}
-		if username == "" {
-			username = os.Getenv("USER")
-		}
-		if username == "" {
-			if currentUser, err := osuser.Current(); err == nil && currentUser.Username != "" {
-				username = currentUser.Username
-			}
-		}
+		username := config.ResolveSlurmUserForCluster(cfg)
 		if username == "" {
 			return nil, fmt.Errorf("cannot determine SLURM username: set 'user' in cluster config or SLURM_USER_NAME env var")
 		}

--- a/internal/views/job_submission_wizard.go
+++ b/internal/views/job_submission_wizard.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
-	osuser "os/user"
 	"regexp"
 	"strconv"
 	"strings"
@@ -27,13 +26,14 @@ type JobSubmissionWizard struct {
 	onSubmit         func(jobID string)
 	onCancel         func()
 	workingDir       string // Current working directory at application start
+	slurmUser        string // Resolved SLURM username for user lookups
 	submissionConfig *config.JobSubmissionConfig
 	selectedTemplate *dao.JobTemplate   // Track currently selected template for hidden fields
 	currentJob       *dao.JobSubmission // Track current job for field visibility
 }
 
 // NewJobSubmissionWizard creates a new job submission wizard
-func NewJobSubmissionWizard(client dao.SlurmClient, app *tview.Application, cfg *config.JobSubmissionConfig) *JobSubmissionWizard {
+func NewJobSubmissionWizard(client dao.SlurmClient, app *tview.Application, cfg *config.JobSubmissionConfig, slurmUser string) *JobSubmissionWizard {
 	// Get current working directory at application start
 	workingDir, err := os.Getwd()
 	if err != nil {
@@ -44,6 +44,7 @@ func NewJobSubmissionWizard(client dao.SlurmClient, app *tview.Application, cfg 
 		client:           client,
 		app:              app,
 		workingDir:       workingDir,
+		slurmUser:        slurmUser,
 		submissionConfig: cfg,
 	}
 	w.templates = w.mergeTemplates()
@@ -2308,19 +2309,9 @@ func (w *JobSubmissionWizard) getAvailableQoS() []string {
 
 // getCurrentUser fetches the current OS user's SLURM user record
 func (w *JobSubmissionWizard) getCurrentUser() *dao.User {
-	// Same resolution as the auth layer: SLURM_USER_NAME env > USER env > OS user
-	username := os.Getenv("SLURM_USER_NAME")
-	if username == "" {
-		username = os.Getenv("USER")
-	}
-	if username == "" {
-		if u, err := osuser.Current(); err == nil {
-			username = u.Username
-		}
-	}
-	if username == "" {
+	if w.slurmUser == "" {
 		return nil
 	}
-	user, _ := w.client.Users().Get(username)
+	user, _ := w.client.Users().Get(w.slurmUser)
 	return user
 }

--- a/internal/views/jobs.go
+++ b/internal/views/jobs.go
@@ -49,11 +49,17 @@ type JobsView struct {
 	selectionStatusText *tview.TextView
 	mainStatusBar       *components.StatusBar // Reference to main app status bar
 	submissionConfig    *config.JobSubmissionConfig
+	slurmUser           string
 }
 
 // SetSubmissionConfig sets the job submission configuration
 func (v *JobsView) SetSubmissionConfig(cfg *config.JobSubmissionConfig) {
 	v.submissionConfig = cfg
+}
+
+// SetSlurmUser sets the resolved SLURM username for the job submission wizard
+func (v *JobsView) SetSlurmUser(user string) {
+	v.slurmUser = user
 }
 
 // SetPages sets the pages reference for modal handling
@@ -1147,7 +1153,7 @@ func (v *JobsView) performRequeueJob(jobID string) {
 
 // showJobSubmissionForm shows job submission form using the wizard
 func (v *JobsView) showJobSubmissionForm() {
-	wizard := NewJobSubmissionWizard(v.client, v.app, v.submissionConfig)
+	wizard := NewJobSubmissionWizard(v.client, v.app, v.submissionConfig, v.slurmUser)
 	wizard.Show(v.pages, func(_ string) {
 		go func() { _ = v.Refresh() }()
 	}, func() {

--- a/scripts/dev-clusters.sh
+++ b/scripts/dev-clusters.sh
@@ -181,6 +181,7 @@ for ns in "${AVAILABLE_NAMESPACES[@]}"; do
       apiVersion: $api_ver
       insecure: true
       timeout: 30s
+      user: root
 
 EOF
 done
@@ -193,38 +194,18 @@ discovery:
   enabled: false
 EOF
 
-# Write env file for SLURM_USER_NAME (tokens are generated for root)
-ENV_FILE="$CONFIG_DIR/env.sh"
-cat > "$ENV_FILE" <<EOF
-# Source this file or use the s9s-dev wrapper below
-export SLURM_USER_NAME=root
-EOF
-
-# Write convenience wrapper script
-WRAPPER="$CONFIG_DIR/s9s-dev"
-cat > "$WRAPPER" <<WRAPPER_EOF
-#!/usr/bin/env bash
-# Dev cluster wrapper — sets SLURM_USER_NAME and passes all args to s9s
-export SLURM_USER_NAME=root
-exec s9s --config "$CONFIG_FILE" --no-discovery "\$@"
-WRAPPER_EOF
-chmod +x "$WRAPPER"
-
 echo ""
 echo -e "${BOLD}=== Dev Clusters Config Ready ===${NC}"
 echo ""
 echo -e "  Config:   ${GREEN}$CONFIG_FILE${NC}"
-echo -e "  Wrapper:  ${GREEN}$WRAPPER${NC}"
 echo -e "  Clusters: ${AVAILABLE_NAMESPACES[*]}"
 echo -e "  Default:  ${BOLD}$DEFAULT_CLUSTER${NC}"
 echo ""
-echo -e "  ${BOLD}Usage (easiest):${NC}"
-echo -e "    $WRAPPER"
-echo -e "    $WRAPPER --cluster slurm-2511"
-echo ""
-echo -e "  ${BOLD}Or manually:${NC}"
-echo -e "    source $ENV_FILE"
+echo -e "  ${BOLD}Usage:${NC}"
 echo -e "    s9s --config $CONFIG_FILE --no-discovery"
+echo ""
+echo -e "  ${BOLD}Switch cluster:${NC}"
+echo -e "    s9s --config $CONFIG_FILE --cluster slurm-2511 --no-discovery"
 echo ""
 echo -e "  ${BOLD}Re-seed clusters:${NC}"
 echo -e "    $0 --seed-only"


### PR DESCRIPTION
## Summary

Add `user` field to cluster config for overriding the X-SLURM-USER-NAME header. Closes #143.

```yaml
clusters:
  - name: slurm-2511
    cluster:
      endpoint: http://10.43.1.1:6820
      token: "jwt-token"
      user: root  # new — override SLURM username
```

## Resolution priority

`SLURM_USER_NAME` env > config `cluster.user` > `USER` env > OS user > explicit error

## Changes

- `config.ClusterConfig.User` field
- `config.ResolveSlurmUser()` shared helper
- Auth layer and wizard both use the resolved username
- Dev clusters script writes `user: root` in config directly (removes env wrapper/sourcefile)
- `config.example.yaml` updated

## Test plan

- [ ] `s9s --config` with `user: root` — job submission and drain work on dev clusters
- [ ] `SLURM_USER_NAME=root s9s` — env var still overrides config
- [ ] On a real SLURM node without `user` config — defaults to OS user (existing behavior)
- [ ] No user resolvable — clear error message