### PR TITLE
chore: prepare v0.7.1 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to release (e.g. v0.7.0)'
+        description: 'Tag to release (e.g. v0.7.1)'
         required: true
 
 env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [0.7.1] - 2026-03-21
+
+### Added
+
+- **Configurable SLURM username per cluster** — new `user` field in cluster config overrides the `X-SLURM-USER-NAME` header, fixing job submission and node operations when s9s runs on a different machine than the SLURM cluster (#143, #145)
+- **`SLURM_USER_NAME` environment variable** — overrides all other username resolution methods (#144)
+- **`config.ResolveSlurmUser()`** — shared helper for consistent username resolution across auth and wizard
+
+### Changed
+
+- **Username resolution chain** — `SLURM_USER_NAME` env > config `cluster.user` > `USER` env > OS current user. No silent `root` fallback; fails explicitly if no username can be determined
+- **Dev clusters script** — writes `user: root` directly in config instead of requiring env var wrappers
+
+### Fixed
+
+- **Job submission fails on remote clusters** — `X-SLURM-USER-NAME` header sent local OS username instead of the SLURM user the JWT token was generated for (#143)
+- **Node drain/resume fails on remote clusters** — same username mismatch caused permission errors
+- **Account dropdown empty on remote clusters** — wizard looked up local username in SLURM user database instead of the configured user
+
 ## [0.7.0] - 2026-03-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Configurable SLURM username per cluster** — new `user` field in cluster config overrides the `X-SLURM-USER-NAME` header, fixing job submission and node operations when s9s runs on a different machine than the SLURM cluster (#143, #145)
+- **Configurable SLURM username per cluster** — new `user` field in cluster config overrides the `X-SLURM-USER-NAME` header, for environments where the local OS user doesn't match a SLURM user (e.g., laptops, CI runners, containers, or any host outside the cluster's shared user directory) (#143, #145)
 - **`SLURM_USER_NAME` environment variable** — overrides all other username resolution methods (#144)
 - **`config.ResolveSlurmUser()`** — shared helper for consistent username resolution across auth and wizard
 
@@ -30,9 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Job submission fails on remote clusters** — `X-SLURM-USER-NAME` header sent local OS username instead of the SLURM user the JWT token was generated for (#143)
-- **Node drain/resume fails on remote clusters** — same username mismatch caused permission errors
-- **Account dropdown empty on remote clusters** — wizard looked up local username in SLURM user database instead of the configured user
+- **Job submission fails when local user differs from SLURM user** — `X-SLURM-USER-NAME` header sent the local OS username instead of the SLURM user the JWT token was generated for, causing `slurm_submit_batch_job()` failures (#143)
+- **Node drain/resume fails when local user lacks SLURM admin** — same username mismatch caused `_update_node` permission errors
+- **Account dropdown empty when local user not in SLURM** — wizard looked up the local OS username in SLURM's user database instead of the configured user
 
 ## [0.7.0] - 2026-03-16
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Recent Changes
 
+### Version 0.7.1 (2026-03-21)
+
+Bug fix release for remote cluster connectivity:
+
+- **Configurable SLURM Username**: New `user` field in cluster config (`cluster.user: root`) overrides the `X-SLURM-USER-NAME` header — fixes job submission and node drain/resume when s9s runs on a different machine than the SLURM cluster
+- **`SLURM_USER_NAME` Environment Variable**: Overrides all other username resolution for CI/scripting use cases
+- **No Silent Root Fallback**: Username resolution fails explicitly if no user can be determined, preventing unintended privilege escalation
+
 ### Version 0.7.0 (2026-03-16)
 
 Configurable job submission templates and full SLURM field support:

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Bug fix release for remote cluster connectivity:
 
-- **Configurable SLURM Username**: New `user` field in cluster config (`cluster.user: root`) overrides the `X-SLURM-USER-NAME` header — fixes job submission and node drain/resume when s9s runs on a different machine than the SLURM cluster
+- **Configurable SLURM Username**: New `user` field in cluster config (`cluster.user: root`) overrides the `X-SLURM-USER-NAME` header — for environments where the local OS user doesn't match a SLURM user (laptops, CI runners, containers, or any host outside the cluster's shared user directory)
 - **`SLURM_USER_NAME` Environment Variable**: Overrides all other username resolution for CI/scripting use cases
 - **No Silent Root Fallback**: Username resolution fails explicitly if no user can be determined, preventing unintended privilege escalation
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -67,11 +67,13 @@ clusters:
     cluster:
       endpoint: https://slurm.example.com:6820
       token: ${SLURM_JWT}  # or discovered via scontrol token / SLURM_JWT env var
+      # user: admin  # Override SLURM username (default: OS user)
 
   - name: development
     cluster:
       endpoint: https://slurm-dev.example.com:6820
       token: ${DEV_SLURM_JWT}
+      user: root  # Use root for dev clusters where tokens are generated for root
 
 # UI preferences
 ui:
@@ -89,6 +91,7 @@ S9s uses the `S9S_` prefix for its own environment variables and also supports u
 | `SLURM_REST_URL` or `S9S_SLURM_REST_URL` | SLURM REST API URL | - | `https://slurm.example.com:6820` |
 | `SLURM_JWT` or `S9S_SLURM_JWT` | Authentication token (auto-discovered via `scontrol token` if not set) | - | `eyJhbGci...` |
 | `SLURM_API_VERSION` | API version | `v0.0.43` | `v0.0.40` |
+| `SLURM_USER_NAME` | Override SLURM username for `X-SLURM-USER-NAME` header (takes precedence over config `cluster.user` and OS user) | OS user | `root` |
 
 ### Mock Mode Variable
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -31,31 +31,31 @@ Download pre-built binaries from our [releases page](https://github.com/jontk/s9
 
 ```bash
 # Linux (x86_64)
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.7.0_Linux_x86_64.tar.gz
-tar -xzf s9s_0.7.0_Linux_x86_64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.7.1_Linux_x86_64.tar.gz
+tar -xzf s9s_0.7.1_Linux_x86_64.tar.gz
 mkdir -p ~/.local/bin
 mv s9s ~/.local/bin/
 
 # Linux (ARM64)
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.7.0_Linux_arm64.tar.gz
-tar -xzf s9s_0.7.0_Linux_arm64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.7.1_Linux_arm64.tar.gz
+tar -xzf s9s_0.7.1_Linux_arm64.tar.gz
 mkdir -p ~/.local/bin
 mv s9s ~/.local/bin/
 
 # macOS (Apple Silicon)
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.7.0_Darwin_arm64.tar.gz
-tar -xzf s9s_0.7.0_Darwin_arm64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.7.1_Darwin_arm64.tar.gz
+tar -xzf s9s_0.7.1_Darwin_arm64.tar.gz
 mkdir -p ~/.local/bin
 mv s9s ~/.local/bin/
 
 # macOS (Intel)
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.7.0_Darwin_x86_64.tar.gz
-tar -xzf s9s_0.7.0_Darwin_x86_64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.7.1_Darwin_x86_64.tar.gz
+tar -xzf s9s_0.7.1_Darwin_x86_64.tar.gz
 mkdir -p ~/.local/bin
 mv s9s ~/.local/bin/
 ```
 
-> **Note:** Replace `0.7.0` with the latest version from the [releases page](https://github.com/jontk/s9s/releases).
+> **Note:** Replace `0.7.1` with the latest version from the [releases page](https://github.com/jontk/s9s/releases).
 
 ### 3. Using Go Install
 
@@ -102,7 +102,7 @@ s9s --version
 
 You should see output like:
 ```
-S9S - SLURM Terminal UI version 0.7.0
+S9S - SLURM Terminal UI version 0.7.1
 ```
 
 ### 2. Initial Configuration
@@ -262,10 +262,10 @@ On Linux, if you get "cannot execute binary file":
 uname -m
 
 # For x86_64/AMD64
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.7.0_Linux_x86_64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.7.1_Linux_x86_64.tar.gz
 
 # For ARM64/aarch64
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.7.0_Linux_arm64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.7.1_Linux_arm64.tar.gz
 ```
 
 ## Upgrading
@@ -277,8 +277,8 @@ To upgrade to the latest version:
 curl -sSL https://get.s9s.dev | bash
 
 # If installed via binary download (replace version and arch as needed)
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.7.0_Linux_x86_64.tar.gz
-tar -xzf s9s_0.7.0_Linux_x86_64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.7.1_Linux_x86_64.tar.gz
+tar -xzf s9s_0.7.1_Linux_x86_64.tar.gz
 mkdir -p ~/.local/bin
 mv s9s ~/.local/bin/
 


### PR DESCRIPTION
## Summary

Prepare v0.7.1 patch release for remote cluster connectivity fixes.

- Changelogs updated (root + docs)
- Installation docs version bumped (0.7.0 → 0.7.1)
- Configuration docs: `cluster.user` field and `SLURM_USER_NAME` env var documented
- Release workflow tag updated

## Changes since v0.7.0

- **feat**: Configurable SLURM username per cluster (`cluster.user`) (#145)
- **feat**: `SLURM_USER_NAME` environment variable override (#144)
- **fix**: Job submission and node drain/resume on remote clusters (#143)
- **fix**: Account dropdown empty on remote clusters

## Test plan

- [ ] Changelog dates and versions correct
- [ ] Installation docs reference 0.7.1
- [ ] Configuration docs show `user` field and `SLURM_USER_NAME`
- [ ] After merge, tag `v0.7.1` and push