### PR TITLE
fix: command line focus and layout docs update

### DIFF
--- a/docs/user-guide/keyboard-shortcuts.md
+++ b/docs/user-guide/keyboard-shortcuts.md
@@ -18,7 +18,6 @@ These shortcuts work from any view:
 | `F1` | Help | Show help modal |
 | `F2` | Alerts | Show system alerts (passes through to Jobs view for templates) |
 | `F3` | Preferences | Show preferences dialog |
-| `F4` | Layout | Show layout switcher |
 | `F5` | Force refresh | Refresh current view data |
 | `F10` | Configuration | Show configuration |
 | `Ctrl+K` | Switch cluster | Switch between configured clusters |
@@ -44,9 +43,7 @@ These shortcuts work from any view:
 
 | Key | Action | Description |
 |-----|--------|-------------|
-| `J` | Jobs view | Switch to Jobs view |
-| `N` | Nodes view | Switch to Nodes view |
-| `P` | Partitions view | Switch to Partitions view |
+| `L` | Switch layout | Toggle between default dashboard and monitoring layout |
 | `A` | Advanced analytics | Open analytics modal |
 | `H` | Health check | Open health check modal |
 | `R` | Refresh dashboard | Manual refresh all panels |

--- a/docs/user-guide/navigation.md
+++ b/docs/user-guide/navigation.md
@@ -25,7 +25,6 @@ These shortcuts work across all views:
 | `F1` | Help | Show help modal |
 | `F2` | Alerts | Show system alerts (passes through to Jobs view for templates) |
 | `F3` | Preferences | Show preferences dialog |
-| `F4` | Layout | Show layout switcher |
 | `F5` | Refresh | Refresh current view |
 | `F10` | Configuration | Show configuration |
 | `Ctrl+K` | Switch Cluster | Switch between configured clusters |
@@ -161,9 +160,7 @@ These shortcuts work across all views:
 
 | Key | Action | Description |
 |-----|--------|-------------|
-| `J` | Jobs View | Jump to jobs view |
-| `N` | Nodes View | Jump to nodes view |
-| `P` | Partitions View | Jump to partitions view |
+| `L` | Switch Layout | Toggle between default dashboard and monitoring layout |
 | `A` | Analytics | Show advanced analytics |
 | `H` | Health Check | Show health check |
 | `R` | Refresh | Refresh all panels |

--- a/docs/user-guide/views/dashboard.md
+++ b/docs/user-guide/views/dashboard.md
@@ -88,12 +88,10 @@ These values are computed from real cluster metrics collected during the session
 
 ## Actions & Shortcuts
 
-### Navigation
+### Layout
 | Key | Action |
 |-----|--------|
-| `J` | Switch to Jobs View |
-| `N` | Switch to Nodes View |
-| `P` | Switch to Partitions View |
+| `L` | Switch layout (Default / Monitoring) |
 
 ### Analytics
 | Key | Action |
@@ -213,5 +211,5 @@ The Dashboard uses flexible layout proportions to adapt to different terminal si
 - Use the Dashboard as your cluster monitoring hub
 - Press `A` regularly to review recommendations
 - Check `H` for detailed health diagnostics
-- Navigate directly to specific views using `J`, `N`, or `P`
+- Press `L` to switch between the default dashboard and the monitoring layout
 - Press `R` to manually refresh the dashboard data when you want the latest metrics

--- a/internal/app/app_commands.go
+++ b/internal/app/app_commands.go
@@ -25,9 +25,12 @@ func (s *S9s) hideCommandLine() {
 	s.cmdVisible = false
 	s.mainLayout.ResizeItem(s.cmdLine, 0, 0)
 
-	// Return focus to current view
-	if currentView, err := s.viewMgr.GetCurrentView(); err == nil {
-		s.app.SetFocus(currentView.Render())
+	// Only restore focus to the current view if no modal is open.
+	// Commands like :layout open modals that set their own focus.
+	if !s.IsModalOpen() {
+		if currentView, err := s.viewMgr.GetCurrentView(); err == nil {
+			s.app.SetFocus(currentView.Render())
+		}
 	}
 }
 

--- a/internal/layouts/layout_manager.go
+++ b/internal/layouts/layout_manager.go
@@ -27,7 +27,7 @@ type Layout struct {
 	ID          string            `json:"id"`
 	Name        string            `json:"name"`
 	Description string            `json:"description"`
-	Template    string            `json:"template"` // "standard", "compact", "monitoring", "admin"
+	Template    string            `json:"template"` // "monitoring" (or custom)
 	Grid        GridConfig        `json:"grid"`
 	Widgets     []WidgetPlacement `json:"widgets"`
 	Responsive  bool              `json:"responsive"`

--- a/internal/preferences/preferences.go
+++ b/internal/preferences/preferences.go
@@ -283,7 +283,7 @@ func (up *UserPreferences) setDefaults() {
 		"mark":            "m",
 		"mark_all":        "Ctrl+a",
 		"clear_marks":     "Ctrl+u",
-		"layout_switcher": "F4",
+		"layout_switcher": "L",
 		"layout_edit":     "Ctrl+l",
 	}
 }

--- a/test/tui/operations_test.go
+++ b/test/tui/operations_test.go
@@ -251,7 +251,7 @@ func TestOperationWithoutSelection(t *testing.T) {
 	}
 }
 
-// TestLayoutSwitcher verifies that F4 opens layout switcher
+// TestLayoutSwitcher verifies that L opens layout switcher in dashboard view
 func TestLayoutSwitcher(t *testing.T) {
 	h := NewTUITestHarness(t)
 	defer h.Cleanup()
@@ -259,13 +259,15 @@ func TestLayoutSwitcher(t *testing.T) {
 	h.Start()
 	time.Sleep(100 * time.Millisecond)
 
-	// Press F4 to open layout switcher
-	h.SendKey(tcell.KeyF4, 0, tcell.ModNone)
+	// Switch to dashboard view (key 8)
+	h.SendRune('8')
+	time.Sleep(100 * time.Millisecond)
+
+	// Press L to open layout switcher
+	h.SendRune('L')
 	time.Sleep(100 * time.Millisecond)
 
 	// Modal should be open
-	// Note: F4 may not always open a modal depending on implementation
-	// Just verify the app is still functional
 	if h.IsModalOpen() {
 		// If modal opened, close it
 		h.SendEsc()
@@ -274,7 +276,7 @@ func TestLayoutSwitcher(t *testing.T) {
 	}
 
 	// App should still be functional
-	h.AssertCurrentView("jobs")
+	h.AssertCurrentView("dashboard")
 }
 
 // TestSequentialOperations verifies that multiple operations can be performed in sequence


### PR DESCRIPTION
## Summary

- Fix command line stealing focus from modals opened by commands like `:layout`
- Update docs and code references for layout system changes (F4 removed, L key added, J/N/P removed from dashboard)

## Test plan

- [ ] `:layout` command opens layout switcher and responds to keyboard input
- [ ] `:prefs` and other modal commands still work correctly
- [ ] Docs accurately reflect current keyboard shortcuts
- [ ] `go test ./internal/...` passes