### PR TITLE
feat: wire uniform key bindings for advanced filter and actions menu

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -135,6 +135,8 @@ S9S provides interactive keyboard shortcuts for common operations within each vi
 | `r` | Release selected job |
 | `d` | Show job dependencies |
 | `o` | Show job output |
+| `f` | Advanced filter |
+| `x` | Actions menu |
 | `Enter` | Show job details |
 | `Space` | Toggle selection |
 | `v` | Visual selection mode |
@@ -211,6 +213,8 @@ Export functionality is available through the interactive UI:
 | `r` | Release job |
 | `d` | Show dependencies |
 | `o` | Show output |
+| `f` | Advanced filter |
+| `x` | Actions menu |
 | `Enter` | Show details |
 
 **Nodes View:**

--- a/docs/user-guide/keyboard-shortcuts.md
+++ b/docs/user-guide/keyboard-shortcuts.md
@@ -85,10 +85,12 @@ These shortcuts work from any view:
 | Key | Action | Description |
 |-----|--------|-------------|
 | `/` | Simple filter | Activate filter input |
+| `f` | Advanced filter | Open advanced filter bar |
 | `Ctrl+F` | Global search | Search across all entity types (all data views) |
 | `a/A` | Filter all states | Show all job states |
 | `p/P` | Filter pending | Show pending jobs only |
 | `u/U` | Filter by user | Filter jobs by username |
+| `x` | Actions menu | Open actions menu for selected job |
 | `ESC` | Exit filter | Clear filter and exit filter mode |
 
 ### Data Management
@@ -113,6 +115,7 @@ These shortcuts work from any view:
 | Key | Action | Description |
 |-----|--------|-------------|
 | `/` | Simple filter | Activate filter input |
+| `f` | Advanced filter | Open advanced filter bar |
 | `Ctrl+F` | Global search | Search across all entity types (all data views) |
 | `p/P` | Partition filter | Filter by partition |
 | `a/A` | Toggle all states | Toggle "all states" filter |
@@ -148,6 +151,7 @@ These shortcuts work from any view:
 | Key | Action | Description |
 |-----|--------|-------------|
 | `/` | Simple filter | Activate filter input |
+| `f` | Advanced filter | Open advanced filter bar |
 | `Ctrl+F` | Global search | Search across all entity types (all data views) |
 | `ESC` | Exit filter | Clear filter and exit filter mode |
 
@@ -169,6 +173,7 @@ These shortcuts work from any view:
 | Key | Action | Description |
 |-----|--------|-------------|
 | `/` | Simple filter | Activate filter input |
+| `f` | Advanced filter | Open advanced filter bar |
 | `Ctrl+F` | Global search | Search across all entity types (all data views) |
 | `a/A` | Toggle admin filter | Show admins/operators only or all users |
 | `ESC` | Exit filter | Clear filter and exit filter mode |
@@ -192,6 +197,7 @@ These shortcuts work from any view:
 | Key | Action | Description |
 |-----|--------|-------------|
 | `/` | Simple filter | Activate filter input |
+| `f` | Advanced filter | Open advanced filter bar |
 | `Ctrl+F` | Global search | Search across all entity types (all data views) |
 | `ESC` | Exit filter | Clear filter and exit filter mode |
 
@@ -213,6 +219,7 @@ These shortcuts work from any view:
 | Key | Action | Description |
 |-----|--------|-------------|
 | `/` | Simple filter | Activate filter input |
+| `f` | Advanced filter | Open advanced filter bar |
 | `Ctrl+F` | Global search | Search across all entity types (all data views) |
 | `ESC` | Exit filter | Clear filter and exit filter mode |
 
@@ -234,9 +241,10 @@ These shortcuts work from any view:
 | Key | Action | Description |
 |-----|--------|-------------|
 | `/` | Simple filter | Activate filter input |
+| `f` | Advanced filter | Open advanced filter bar |
 | `Ctrl+F` | Global search | Search across all entity types (all data views) |
 | `a/A` | Toggle active | Show active reservations only |
-| `f/F` | Toggle future | Show future reservations only |
+| `t/T` | Toggle future | Show future reservations only |
 | `ESC` | Exit filter | Clear filter and exit filter mode |
 
 ### Data Management

--- a/docs/user-guide/navigation.md
+++ b/docs/user-guide/navigation.md
@@ -71,7 +71,9 @@ These shortcuts work across all views:
 | `v` | Multi-Select | Toggle multi-select mode |
 | `m` | Auto Refresh | Toggle auto-refresh |
 | `/` | Filter | Filter jobs |
+| `f` | Advanced Filter | Open advanced filter bar |
 | `Ctrl+F` | Search | Global search across all entity types |
+| `x` | Actions Menu | Open actions menu for selected job |
 | `S` | Sort | Open sort modal |
 | `R` | Refresh | Force refresh view |
 
@@ -85,6 +87,7 @@ These shortcuts work across all views:
 | `r` | Resume | Resume drained node |
 | `R` | Refresh | Force refresh view |
 | `/` | Filter | Filter nodes |
+| `f` | Advanced Filter | Open advanced filter bar |
 | `Ctrl+F` | Search | Global search across all entity types |
 | `S` | Sort | Open sort modal |
 | `p` | Partition | Filter by partition |
@@ -102,6 +105,7 @@ These shortcuts work across all views:
 | `A` | Analytics | Show partition analytics |
 | `W` | Wait Times | Show wait time analytics |
 | `/` | Filter | Filter partitions |
+| `f` | Advanced Filter | Open advanced filter bar |
 | `Ctrl+F` | Search | Global search across all entity types |
 | `S` | Sort | Open sort modal |
 | `R` | Refresh | Force refresh view |
@@ -113,6 +117,7 @@ These shortcuts work across all views:
 |-----|--------|-------------|
 | `Enter` | Details | Show QoS details |
 | `/` | Filter | Filter QoS policies |
+| `f` | Advanced Filter | Open advanced filter bar |
 | `Ctrl+F` | Search | Global search across all entity types |
 | `S` | Sort | Open sort modal |
 | `R` | Refresh | Force refresh view |
@@ -125,6 +130,7 @@ These shortcuts work across all views:
 | `Enter` | Details | Show account details |
 | `H` | Hierarchy | Show account hierarchy |
 | `/` | Filter | Filter accounts |
+| `f` | Advanced Filter | Open advanced filter bar |
 | `Ctrl+F` | Search | Global search across all entity types |
 | `S` | Sort | Open sort modal |
 | `R` | Refresh | Force refresh view |
@@ -137,6 +143,7 @@ These shortcuts work across all views:
 | `Enter` | Details | Show user details |
 | `a` | Toggle Filter | Show admin users / all users |
 | `/` | Filter | Filter users |
+| `f` | Advanced Filter | Open advanced filter bar |
 | `Ctrl+F` | Search | Global search across all entity types |
 | `S` | Sort | Open sort modal |
 | `R` | Refresh | Force refresh view |
@@ -148,8 +155,9 @@ These shortcuts work across all views:
 |-----|--------|-------------|
 | `Enter` | Details | Show reservation details |
 | `a` | Active Only | Filter active reservations |
-| `f` | Future Only | Filter future reservations |
+| `t` | Future Only | Filter future reservations |
 | `/` | Filter | Filter reservations |
+| `f` | Advanced Filter | Open advanced filter bar |
 | `Ctrl+F` | Search | Global search across all entity types |
 | `S` | Sort | Open sort modal |
 | `R` | Refresh | Force refresh view |
@@ -190,7 +198,7 @@ Enter filter mode with `/` in any view:
 
 ### Advanced Filter
 
-The advanced filter bar supports field-specific filtering with operators (equals, contains, greater than, less than) and multiple filter conditions. Note that the global `F3` key opens Preferences, which takes priority over view-level filter bindings.
+The advanced filter bar supports field-specific filtering with operators (equals, contains, greater than, less than) and multiple filter conditions. Press `f` in any data view to open the advanced filter bar.
 
 ### Global Search
 

--- a/docs/user-guide/views/jobs.md
+++ b/docs/user-guide/views/jobs.md
@@ -266,10 +266,12 @@ When disabled, use `R` for manual refresh.
 | Key | Action |
 |-----|--------|
 | `/` | Simple filter |
+| `f` | Advanced filter |
 | `Ctrl+F` | Global search |
 | `a/A` | Filter all states |
 | `p/P` | Filter pending |
 | `u/U` | Filter by user |
+| `x` | Actions menu |
 | `ESC` | Exit filter mode |
 
 ### Data Management

--- a/internal/views/accounts.go
+++ b/internal/views/accounts.go
@@ -179,7 +179,7 @@ func (v *AccountsView) Hints() []string {
 	hints := []string{
 		"[yellow]Enter[white] Details",
 		"[yellow]/[white] Filter",
-		"[yellow]F3[white] Adv Filter",
+		"[yellow]f[white] Adv Filter",
 		"[yellow]Ctrl+F[white] Search",
 		"[yellow]Click Headers[white] Sort",
 		"[yellow]S[white] Sort",
@@ -237,7 +237,6 @@ func (v *AccountsView) OnKey(event *tcell.EventKey) *tcell.EventKey {
 // accountsKeyHandlers returns a map of function key handlers
 func (v *AccountsView) accountsKeyHandlers() map[tcell.Key]func() {
 	return map[tcell.Key]func(){
-		tcell.KeyF3:    v.showAdvancedFilter,
 		tcell.KeyCtrlF: v.showGlobalSearch,
 		tcell.KeyEnter: v.showAccountDetails,
 	}
@@ -248,6 +247,7 @@ func (v *AccountsView) accountsRuneHandlers() map[rune]func() {
 	return map[rune]func(){
 		'R': func() { go func() { _ = v.Refresh() }() },
 		'/': func() { v.app.SetFocus(v.filterInput) },
+		'f': v.showAdvancedFilter,
 		'H': v.showAccountHierarchy,
 		'S': func() { v.promptSortBy() },
 		'e': func() { v.showExportDialog() },

--- a/internal/views/accounts.go
+++ b/internal/views/accounts.go
@@ -213,10 +213,14 @@ func (v *AccountsView) OnKey(event *tcell.EventKey) *tcell.EventKey {
 		return event
 	}
 
-	// Handle advanced filter mode
-	if v.isAdvancedMode && event.Key() == tcell.KeyEsc {
-		v.closeAdvancedFilter()
-		return nil
+	// Handle advanced filter mode — only intercept ESC, let everything
+	// else pass through to the filter bar's input field
+	if v.isAdvancedMode {
+		if event.Key() == tcell.KeyEsc {
+			v.closeAdvancedFilter()
+			return nil
+		}
+		return event
 	}
 
 	if handler, ok := v.accountsKeyHandlers()[event.Key()]; ok {

--- a/internal/views/jobs.go
+++ b/internal/views/jobs.go
@@ -317,10 +317,14 @@ func (v *JobsView) OnKey(event *tcell.EventKey) *tcell.EventKey {
 		return event // Let modal handle it
 	}
 
-	// Handle advanced filter mode
-	if v.isAdvancedMode && event.Key() == tcell.KeyEsc {
-		v.closeAdvancedFilter()
-		return nil
+	// Handle advanced filter mode — only intercept ESC, let everything
+	// else pass through to the filter bar's input field
+	if v.isAdvancedMode {
+		if event.Key() == tcell.KeyEsc {
+			v.closeAdvancedFilter()
+			return nil
+		}
+		return event
 	}
 
 	// Handle by special key first

--- a/internal/views/jobs.go
+++ b/internal/views/jobs.go
@@ -279,6 +279,8 @@ func (v *JobsView) Hints() []string {
 		"[yellow]/[white] Filter",
 		"[yellow]Ctrl+F[white] Search",
 		"[yellow]v[white] Multi-Select",
+		"[yellow]f[white] Adv Filter",
+		"[yellow]x[white] Actions",
 		"[yellow]S[white] Sort",
 		"[yellow]R[white] Refresh",
 		"[yellow]e[white] Export",
@@ -391,6 +393,9 @@ func (v *JobsView) jobsRuneHandlers() map[rune]func(*JobsView, *tcell.EventKey) 
 		'V': func(v *JobsView, _ *tcell.EventKey) *tcell.EventKey { v.toggleMultiSelectMode(); return nil },
 		'e': func(v *JobsView, _ *tcell.EventKey) *tcell.EventKey { v.showExportDialog(); return nil },
 		'E': func(v *JobsView, _ *tcell.EventKey) *tcell.EventKey { v.showExportDialog(); return nil },
+		'f': func(v *JobsView, _ *tcell.EventKey) *tcell.EventKey { v.showAdvancedFilter(); return nil },
+		'x': func(v *JobsView, _ *tcell.EventKey) *tcell.EventKey { v.showJobActions(); return nil },
+		'X': func(v *JobsView, _ *tcell.EventKey) *tcell.EventKey { v.showJobActions(); return nil },
 	}
 }
 
@@ -1155,8 +1160,7 @@ func (v *JobsView) showJobSubmissionForm() {
 }
 
 // showJobActions shows an action menu for the selected job
-// TODO: wire to a uniform key binding across all views
-func (v *JobsView) showJobActions() { //nolint:unused // will be wired in a follow-up PR
+func (v *JobsView) showJobActions() {
 	data := v.table.GetSelectedData()
 	if len(data) == 0 {
 		// Note: Status bar update removed since individual view status bars are no longer used
@@ -1212,7 +1216,7 @@ func (v *JobsView) showJobActions() { //nolint:unused // will be wired in a foll
 }
 
 // buildJobActions builds the list of available actions based on job state
-func (v *JobsView) buildJobActions(state string) ([]string, []func()) { //nolint:unused // used by showJobActions
+func (v *JobsView) buildJobActions(state string) ([]string, []func()) {
 	var actions []string
 	var handlers []func()
 
@@ -1694,8 +1698,7 @@ func (v *JobsView) batchReleaseSelected() {
 */
 
 // showAdvancedFilter shows the advanced filter bar
-// TODO: wire to a uniform key binding across all views
-func (v *JobsView) showAdvancedFilter() { //nolint:unused // will be wired in a follow-up PR
+func (v *JobsView) showAdvancedFilter() {
 	if v.filterBar == nil || v.pages == nil {
 		return
 	}

--- a/internal/views/nodes.go
+++ b/internal/views/nodes.go
@@ -215,7 +215,7 @@ func (v *NodesView) Hints() []string {
 		"[yellow]r[white] Resume",
 		"[yellow]s[white] SSH",
 		"[yellow]/[white] Filter",
-		"[yellow]F3[white] Adv Filter",
+		"[yellow]f[white] Adv Filter",
 		"[yellow]Ctrl+F[white] Search",
 		"[yellow]S[white] Sort",
 		"[yellow]R[white] Refresh",
@@ -283,7 +283,6 @@ func (v *NodesView) handleNodesViewRune(event *tcell.EventKey) *tcell.EventKey {
 // nodesKeyHandlers returns a map of special keys to their handlers
 func (v *NodesView) nodesKeyHandlers() map[tcell.Key]func(*NodesView, *tcell.EventKey) *tcell.EventKey {
 	return map[tcell.Key]func(*NodesView, *tcell.EventKey) *tcell.EventKey{
-		tcell.KeyF3:    func(v *NodesView, _ *tcell.EventKey) *tcell.EventKey { v.showAdvancedFilter(); return nil },
 		tcell.KeyCtrlF: func(v *NodesView, _ *tcell.EventKey) *tcell.EventKey { v.showGlobalSearch(); return nil },
 		tcell.KeyEnter: func(v *NodesView, _ *tcell.EventKey) *tcell.EventKey { v.showNodeDetails(); return nil },
 	}
@@ -292,6 +291,7 @@ func (v *NodesView) nodesKeyHandlers() map[tcell.Key]func(*NodesView, *tcell.Eve
 // nodesRuneHandlers returns a map of rune keys to their handlers
 func (v *NodesView) nodesRuneHandlers() map[rune]func(*NodesView, *tcell.EventKey) *tcell.EventKey {
 	return map[rune]func(*NodesView, *tcell.EventKey) *tcell.EventKey{
+		'f': func(v *NodesView, _ *tcell.EventKey) *tcell.EventKey { v.showAdvancedFilter(); return nil },
 		'd': func(v *NodesView, _ *tcell.EventKey) *tcell.EventKey { v.drainSelectedNode(); return nil },
 		'D': func(v *NodesView, _ *tcell.EventKey) *tcell.EventKey { v.drainSelectedNode(); return nil },
 		'r': func(v *NodesView, _ *tcell.EventKey) *tcell.EventKey { v.resumeSelectedNode(); return nil },

--- a/internal/views/nodes.go
+++ b/internal/views/nodes.go
@@ -252,10 +252,14 @@ func (v *NodesView) OnKey(event *tcell.EventKey) *tcell.EventKey {
 		return event // Let modal handle it
 	}
 
-	// Handle advanced filter mode
-	if v.isAdvancedMode && event.Key() == tcell.KeyEsc {
-		v.closeAdvancedFilter()
-		return nil
+	// Handle advanced filter mode — only intercept ESC, let everything
+	// else pass through to the filter bar's input field
+	if v.isAdvancedMode {
+		if event.Key() == tcell.KeyEsc {
+			v.closeAdvancedFilter()
+			return nil
+		}
+		return event
 	}
 
 	// Handle by special key first

--- a/internal/views/partitions.go
+++ b/internal/views/partitions.go
@@ -320,10 +320,14 @@ func (v *PartitionsView) isModalOpen() bool {
 // handlePartitionKey handles non-filter keyboard events
 // Returns nil if the key was handled (consumed), or the event if not handled
 func (v *PartitionsView) handlePartitionKey(event *tcell.EventKey) *tcell.EventKey {
-	// Handle advanced filter mode ESC
-	if v.isAdvancedMode && event.Key() == tcell.KeyEsc {
-		v.closeAdvancedFilter()
-		return nil
+	// Handle advanced filter mode — only intercept ESC, let everything
+	// else pass through to the filter bar's input field
+	if v.isAdvancedMode {
+		if event.Key() == tcell.KeyEsc {
+			v.closeAdvancedFilter()
+			return nil
+		}
+		return event
 	}
 
 	// Handle mapped key handlers

--- a/internal/views/partitions.go
+++ b/internal/views/partitions.go
@@ -274,7 +274,7 @@ func (v *PartitionsView) Hints() []string {
 		"[yellow]A[white] Analytics",
 		"[yellow]W[white] Wait Times",
 		"[yellow]/[white] Filter",
-		"[yellow]F3[white] Adv Filter",
+		"[yellow]f[white] Adv Filter",
 		"[yellow]Ctrl+F[white] Search",
 		"[yellow]Click Headers[white] Sort",
 		"[yellow]S[white] Sort",
@@ -344,7 +344,6 @@ func (v *PartitionsView) handlePartitionKey(event *tcell.EventKey) *tcell.EventK
 // partitionsKeyHandlers returns a map of function key handlers
 func (v *PartitionsView) partitionsKeyHandlers() map[tcell.Key]func() {
 	return map[tcell.Key]func(){
-		tcell.KeyF3:    v.showAdvancedFilter,
 		tcell.KeyCtrlF: v.showGlobalSearch,
 		tcell.KeyEnter: v.showPartitionDetails,
 	}
@@ -372,6 +371,9 @@ func (v *PartitionsView) handleRuneCommand(r rune) bool {
 		return true
 	case '/':
 		v.app.SetFocus(v.filterInput)
+		return true
+	case 'f':
+		v.showAdvancedFilter()
 		return true
 	case 'e', 'E':
 		v.showExportDialog()

--- a/internal/views/qos.go
+++ b/internal/views/qos.go
@@ -178,7 +178,7 @@ func (v *QoSView) Hints() []string {
 	hints := []string{
 		"[yellow]Enter[white] Details",
 		"[yellow]/[white] Filter",
-		"[yellow]F3[white] Adv Filter",
+		"[yellow]f[white] Adv Filter",
 		"[yellow]Ctrl+F[white] Search",
 		"[yellow]Click Headers[white] Sort",
 		"[yellow]S[white] Sort",
@@ -235,7 +235,6 @@ func (v *QoSView) OnKey(event *tcell.EventKey) *tcell.EventKey {
 // qosKeyHandlers returns a map of function key handlers
 func (v *QoSView) qosKeyHandlers() map[tcell.Key]func() {
 	return map[tcell.Key]func(){
-		tcell.KeyF3:    v.showAdvancedFilter,
 		tcell.KeyCtrlF: v.showGlobalSearch,
 		tcell.KeyEnter: v.showQoSDetails,
 	}
@@ -246,6 +245,7 @@ func (v *QoSView) qosRuneHandlers() map[rune]func() {
 	return map[rune]func(){
 		'R': func() { go func() { _ = v.Refresh() }() },
 		'/': func() { v.app.SetFocus(v.filterInput) },
+		'f': v.showAdvancedFilter,
 		'S': func() { v.promptSortBy() },
 		'e': func() { v.showExportDialog() },
 		'E': func() { v.showExportDialog() },

--- a/internal/views/qos.go
+++ b/internal/views/qos.go
@@ -211,10 +211,14 @@ func (v *QoSView) OnKey(event *tcell.EventKey) *tcell.EventKey {
 		return event // Let modal handle it
 	}
 
-	// Handle advanced filter mode
-	if v.isAdvancedMode && event.Key() == tcell.KeyEsc {
-		v.closeAdvancedFilter()
-		return nil
+	// Handle advanced filter mode — only intercept ESC, let everything
+	// else pass through to the filter bar's input field
+	if v.isAdvancedMode {
+		if event.Key() == tcell.KeyEsc {
+			v.closeAdvancedFilter()
+			return nil
+		}
+		return event
 	}
 
 	if handler, ok := v.qosKeyHandlers()[event.Key()]; ok {

--- a/internal/views/reservations.go
+++ b/internal/views/reservations.go
@@ -227,10 +227,14 @@ func (v *ReservationsView) OnKey(event *tcell.EventKey) *tcell.EventKey {
 		return event // Let modal handle it
 	}
 
-	// Handle advanced filter mode
-	if v.isAdvancedMode && event.Key() == tcell.KeyEsc {
-		v.closeAdvancedFilter()
-		return nil
+	// Handle advanced filter mode — only intercept ESC, let everything
+	// else pass through to the filter bar's input field
+	if v.isAdvancedMode {
+		if event.Key() == tcell.KeyEsc {
+			v.closeAdvancedFilter()
+			return nil
+		}
+		return event
 	}
 
 	if handler, ok := v.reservationsKeyHandlers()[event.Key()]; ok {

--- a/internal/views/reservations.go
+++ b/internal/views/reservations.go
@@ -180,7 +180,7 @@ func (v *ReservationsView) Hints() []string {
 	hints := []string{
 		"[yellow]Enter[white] Details",
 		"[yellow]/[white] Filter",
-		"[yellow]F3[white] Adv Filter",
+		"[yellow]f[white] Adv Filter",
 		"[yellow]Ctrl+F[white] Search",
 		"[yellow]Click Headers[white] Sort",
 		"[yellow]S[white] Sort",
@@ -197,9 +197,9 @@ func (v *ReservationsView) Hints() []string {
 
 	// Show future filter status
 	if v.futureFilterEnabled {
-		hints = append(hints, "[yellow]f[green]✓[white] Future Only")
+		hints = append(hints, "[yellow]t[green]✓[white] Future Only")
 	} else {
-		hints = append(hints, "[yellow]f[white] Future Only")
+		hints = append(hints, "[yellow]t[white] Future Only")
 	}
 
 	if v.isAdvancedMode {
@@ -251,7 +251,6 @@ func (v *ReservationsView) OnKey(event *tcell.EventKey) *tcell.EventKey {
 // reservationsKeyHandlers returns a map of function key handlers
 func (v *ReservationsView) reservationsKeyHandlers() map[tcell.Key]func() {
 	return map[tcell.Key]func(){
-		tcell.KeyF3:    v.showAdvancedFilter,
 		tcell.KeyCtrlF: v.showGlobalSearch,
 		tcell.KeyEnter: v.showReservationDetails,
 	}
@@ -264,8 +263,9 @@ func (v *ReservationsView) reservationsRuneHandlers() map[rune]func() {
 		'/': func() { v.app.SetFocus(v.filterInput) },
 		'a': v.toggleActiveFilter,
 		'A': v.toggleActiveFilter,
-		'f': v.toggleFutureFilter,
-		'F': v.toggleFutureFilter,
+		'f': v.showAdvancedFilter,
+		't': v.toggleFutureFilter,
+		'T': v.toggleFutureFilter,
 		'S': func() { v.promptSortBy() },
 		'e': func() { v.showExportDialog() },
 		'E': func() { v.showExportDialog() },

--- a/internal/views/reservations_test.go
+++ b/internal/views/reservations_test.go
@@ -263,7 +263,7 @@ func TestHintsShowFilterStatus(t *testing.T) {
 		if hint == "[yellow]a[white] Active Only" {
 			hasActiveHint = true
 		}
-		if hint == "[yellow]f[white] Future Only" {
+		if hint == "[yellow]t[white] Future Only" {
 			hasFutureHint = true
 		}
 	}
@@ -292,7 +292,7 @@ func TestHintsShowFilterStatus(t *testing.T) {
 	hints = v.Hints()
 	hasCheckedFuture := false
 	for _, hint := range hints {
-		if hint == "[yellow]f[green]✓[white] Future Only" {
+		if hint == "[yellow]t[green]✓[white] Future Only" {
 			hasCheckedFuture = true
 		}
 	}

--- a/internal/views/users.go
+++ b/internal/views/users.go
@@ -190,7 +190,7 @@ func (v *UsersView) Hints() []string {
 	hints := []string{
 		"[yellow]Enter[white] Details",
 		"[yellow]/[white] Filter",
-		"[yellow]F3[white] Adv Filter",
+		"[yellow]f[white] Adv Filter",
 		"[yellow]Ctrl+F[white] Search",
 		"[yellow]Click Headers[white] Sort",
 		"[yellow]S[white] Sort",
@@ -248,7 +248,6 @@ func (v *UsersView) OnKey(event *tcell.EventKey) *tcell.EventKey {
 // usersKeyHandlers returns a map of function key handlers
 func (v *UsersView) usersKeyHandlers() map[tcell.Key]func() {
 	return map[tcell.Key]func(){
-		tcell.KeyF3:    v.showAdvancedFilter,
 		tcell.KeyCtrlF: v.showGlobalSearch,
 		tcell.KeyEnter: v.showUserDetails,
 	}
@@ -259,6 +258,7 @@ func (v *UsersView) usersRuneHandlers() map[rune]func() {
 	return map[rune]func(){
 		'R': func() { go func() { _ = v.Refresh() }() },
 		'/': func() { v.app.SetFocus(v.filterInput) },
+		'f': v.showAdvancedFilter,
 		'a': v.toggleAdminFilter,
 		'A': v.toggleAdminFilter,
 		'S': func() { v.promptSortBy() },

--- a/internal/views/users.go
+++ b/internal/views/users.go
@@ -224,10 +224,14 @@ func (v *UsersView) OnKey(event *tcell.EventKey) *tcell.EventKey {
 		return event // Let modal handle it
 	}
 
-	// Handle advanced filter mode
-	if v.isAdvancedMode && event.Key() == tcell.KeyEsc {
-		v.closeAdvancedFilter()
-		return nil
+	// Handle advanced filter mode — only intercept ESC, let everything
+	// else pass through to the filter bar's input field
+	if v.isAdvancedMode {
+		if event.Key() == tcell.KeyEsc {
+			v.closeAdvancedFilter()
+			return nil
+		}
+		return event
 	}
 
 	if handler, ok := v.usersKeyHandlers()[event.Key()]; ok {


### PR DESCRIPTION
## Summary

- Add `f` for advanced filter across all 7 data views (jobs, nodes, accounts, partitions, qos, reservations, users), replacing the unreachable F3 handler that was globally intercepted by preferences
- Add `x`/`X` for the actions menu in the jobs view
- Remap reservations future filter from `f`/`F` to `t`/`T`
- Fix advanced filter input stealing: when filter bar is open, view shortcuts no longer intercept keystrokes meant for the filter input field
- Update docs to reflect all key binding changes

## Test plan

- [ ] `go test ./internal/...` passes
- [ ] In any data view, press `f` to open advanced filter
- [ ] While advanced filter is open, typing letters goes into the filter input (not triggering view actions)
- [ ] Press `ESC` to close advanced filter
- [ ] In jobs view, press `x` to open actions menu
- [ ] In reservations view, `t` toggles future filter
- [ ] `F3` opens preferences from any view (no longer intercepted)