### PR TITLE
feat: show all commands on Tab in empty command prompt

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -8,12 +8,14 @@ Press `:` to enter command mode (vim-style). Commands support tab completion for
 
 ### Using Tab Completion
 
+- **Browse all commands**: Press `Tab` on an empty prompt to see all available commands
 - **Command completion**: Type `:req` and press `Tab` to complete to `:requeue`
 - **Argument completion**: Type `:cancel ` and press `Tab` to see available job IDs
 - **Smart suggestions**: Completions are context-aware based on cached view data
 
 **Examples:**
 ```
+:<Tab>              → Shows all available commands
 :req<Tab>           → :requeue
 :requeue <Tab>      → Shows: 12345, 12346, 12347...
 :drain nod<Tab>     → Shows: node01, node02, node03...

--- a/docs/user-guide/keyboard-shortcuts.md
+++ b/docs/user-guide/keyboard-shortcuts.md
@@ -402,6 +402,7 @@ Press `:` to enter vim-style command mode with tab completion support:
 
 ### Command Completion
 ```
+:<Tab>             - Shows all available commands
 :q<Tab>            - Shows: q, qos, quit
 :req<Tab>          - Completes to: requeue
 :dr<Tab>           - Completes to: drain

--- a/docs/user-guide/navigation.md
+++ b/docs/user-guide/navigation.md
@@ -245,6 +245,7 @@ Press `:` to enter vim-style command mode with intelligent tab completion:
 ```
 
 ### Tab Completion
+- Press `Tab` on an empty prompt → shows all available commands
 - Type `:req` and press `Tab` → completes to `:requeue`
 - Type `:cancel ` and press `Tab` → shows available job IDs
 - Type `:drain ` and press `Tab` → shows available node names

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -62,8 +62,9 @@ type S9s struct {
 	contentPages *tview.Pages // Pages widget for stable view switching
 
 	// Command line
-	cmdLine    *tview.InputField
-	cmdVisible bool
+	cmdLine               *tview.InputField
+	cmdVisible            bool
+	cmdShowAllCompletions bool
 
 	// State
 	refreshTicker *time.Ticker

--- a/internal/app/app_completion.go
+++ b/internal/app/app_completion.go
@@ -33,8 +33,11 @@ func (s *S9s) getCompletions(currentText string) []string {
 	// Don't trim - trailing space is significant for argument completion
 	text := currentText
 
-	// Return nil for empty input to avoid showing empty dropdown
+	// Show all commands on empty input only when Tab was pressed
 	if strings.TrimSpace(text) == "" {
+		if s.cmdShowAllCompletions {
+			return s.getCommandCompletions("")
+		}
 		return nil
 	}
 

--- a/internal/app/app_ui.go
+++ b/internal/app/app_ui.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"strings"
+
 	"github.com/gdamore/tcell/v2"
 	"github.com/jontk/s9s/internal/notifications"
 	"github.com/jontk/s9s/internal/ui/components"
@@ -56,7 +58,7 @@ func (s *S9s) initUI() error {
 		SetDoneFunc(s.onCommandDone).
 		SetAutocompleteFunc(s.getCompletions)
 
-	// Handle Esc key and Enter to ensure proper command line hiding
+	// Handle Esc key, Enter, and Tab for command line behavior
 	s.cmdLine.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		if event.Key() == tcell.KeyEscape {
 			s.hideCommandLine()
@@ -70,6 +72,13 @@ func (s *S9s) initUI() error {
 			}
 			s.hideCommandLine()
 			return nil // Consume the event
+		}
+		// Handle Tab on empty input — show all available commands
+		if event.Key() == tcell.KeyTab && strings.TrimSpace(s.cmdLine.GetText()) == "" {
+			s.cmdShowAllCompletions = true
+			s.cmdLine.Autocomplete()
+			s.cmdShowAllCompletions = false
+			return nil
 		}
 		return event
 	})


### PR DESCRIPTION
## Summary

Press `Tab` on an empty `:` prompt to browse all available commands in the autocomplete dropdown. Previously, Tab on an empty prompt did nothing, making commands hard to discover.

Typing still works as before — the dropdown only shows matching commands as characters are entered.

## Test plan

- [ ] Press `:` then `Tab` — dropdown shows all available commands
- [ ] Type `:q` then `Tab` — dropdown shows q, qos, quit (unchanged behavior)
- [ ] Type `:cancel ` then `Tab` — dropdown shows job IDs (unchanged behavior)
- [ ] Press `:` and start typing without Tab — no dropdown on empty input (unchanged behavior)
- [ ] `go test ./internal/...` passes