### PR TITLE
feat: show view-specific shortcuts in help modal

### DIFF
--- a/internal/app/app_keyboard.go
+++ b/internal/app/app_keyboard.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/gdamore/tcell/v2"
-	"github.com/jontk/s9s/internal/views"
 	"github.com/rivo/tview"
 )
 
@@ -165,7 +164,7 @@ func (s *S9s) handleClusterSwitch(_ *S9s, _ *tcell.EventKey) *tcell.EventKey {
 }
 
 func (s *S9s) handleF1Help(_ *S9s, _ *tcell.EventKey) *tcell.EventKey {
-	views.ShowHelpModal(s.pages)
+	s.showHelp()
 	return nil
 }
 

--- a/internal/app/app_modals.go
+++ b/internal/app/app_modals.go
@@ -32,6 +32,15 @@ func (s *S9s) showHelp() {
   [yellow]?[white]          Show this help
   [yellow]Ctrl+K[white]     Switch cluster
   [yellow]q, Ctrl+C[white]  Quit
+
+[teal]Commands:[white]
+  [yellow]:jobs, :j[white]      Jobs view       [yellow]:accounts[white]      Accounts view
+  [yellow]:nodes, :n[white]     Nodes view      [yellow]:users[white]         Users view
+  [yellow]:partitions, :p[white] Partitions     [yellow]:dashboard[white]     Dashboard view
+  [yellow]:reservations[white]  Reservations    [yellow]:health[white]        Health view
+  [yellow]:qos[white]           QoS view        [yellow]:performance[white]   Performance view
+  [yellow]:refresh, :r[white]   Refresh         [yellow]:layout[white]        Layout switcher
+  [yellow]:quit, :q[white]      Quit            [yellow]:help, :h[white]      Help
 `
 
 	// Append current view shortcuts

--- a/internal/app/app_modals.go
+++ b/internal/app/app_modals.go
@@ -41,6 +41,9 @@ func (s *S9s) showHelp() {
   [yellow]:qos[white]           QoS view        [yellow]:performance[white]   Performance view
   [yellow]:refresh, :r[white]   Refresh         [yellow]:layout[white]        Layout switcher
   [yellow]:quit, :q[white]      Quit            [yellow]:help, :h[white]      Help
+
+[teal]Common View Keys:[white] [gray](available in all data views)[white]
+  [yellow]/[white] Filter    [yellow]f[white] Adv Filter    [yellow]Ctrl+F[white] Search    [yellow]S[white] Sort    [yellow]R[white] Refresh    [yellow]e[white] Export
 `
 
 	// Append current view shortcuts

--- a/internal/app/app_modals.go
+++ b/internal/app/app_modals.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/gdamore/tcell/v2"
@@ -20,39 +21,38 @@ func (s *S9s) showHelp() {
 	helpText := `[yellow]S9S - SLURM Terminal UI Help[white]
 
 [teal]Global Keys:[white]
-  [yellow]1-0[white]         Switch to Jobs/Nodes/Partitions/Reservations/QoS/Accounts/Users/Dashboard/Health/Performance view
-  [yellow]Tab/Shift+Tab[white] Switch between views
+  [yellow]1-0[white]         Switch views (Jobs/Nodes/Partitions/Reservations/QoS/Accounts/Users/Dashboard/Health/Performance)
+  [yellow]Tab/Shift+Tab[white] Cycle between views
   [yellow]F1[white]         Show help
   [yellow]F2[white]         Show system alerts
+  [yellow]F3[white]         Preferences
   [yellow]F5[white]         Refresh current view
   [yellow]F10[white]        Configuration settings
-  [yellow]:[white]          Enter command mode
+  [yellow]:[white]          Command mode (Tab to browse commands)
   [yellow]?[white]          Show this help
-  [yellow]Ctrl+K[white]     Switch cluster (when multiple configured)
-  [yellow]q, Ctrl+C[white]  Quit application
+  [yellow]Ctrl+K[white]     Switch cluster
+  [yellow]q, Ctrl+C[white]  Quit
+`
 
-[teal]Commands:[white]
-  [yellow]:jobs, :j[white]      Switch to Jobs view
-  [yellow]:nodes, :n[white]     Switch to Nodes view
-  [yellow]:partitions, :p[white] Switch to Partitions view
-  [yellow]:reservations[white]  Switch to Reservations view
-  [yellow]:qos[white]           Switch to QoS view
-  [yellow]:accounts[white]      Switch to Accounts view
-  [yellow]:users[white]         Switch to Users view
-  [yellow]:dashboard[white]     Switch to Dashboard view
-  [yellow]:health[white]        Switch to Health Monitor view
-  [yellow]:performance[white]   Switch to Performance Monitor view
-  [yellow]:refresh, :r[white]   Refresh current view
-  [yellow]:quit, :q[white]      Quit application
-  [yellow]:help, :h[white]      Show this help
+	// Append current view shortcuts
+	if currentView, err := s.viewMgr.GetCurrentView(); err == nil {
+		viewName := currentView.Name()
+		hints := currentView.Hints()
+		if len(hints) > 0 {
+			helpText += fmt.Sprintf("\n[teal]%s View:[white]\n", s.formatViewName(viewName))
+			for _, hint := range hints {
+				helpText += fmt.Sprintf("  %s\n", hint)
+			}
+		}
+	}
 
-[teal]View-specific keys vary by view.[white]
-Press [yellow]ESC[white] to close this help.`
+	helpText += "\nPress [yellow]ESC[white] to close this help."
 
 	modal := tview.NewTextView().
 		SetDynamicColors(true).
 		SetText(helpText).
-		SetTextAlign(tview.AlignLeft)
+		SetTextAlign(tview.AlignLeft).
+		SetScrollable(true)
 
 	modal.SetBorder(true).
 		SetTitle(" Help ").
@@ -68,6 +68,14 @@ Press [yellow]ESC[white] to close this help.`
 	})
 
 	s.pages.AddPage("help", modal, true, true)
+}
+
+// formatViewName capitalizes a view name for display
+func (s *S9s) formatViewName(name string) string {
+	if name == "" {
+		return ""
+	}
+	return strings.ToUpper(name[:1]) + name[1:]
 }
 
 // showAlertsModal displays the alerts modal

--- a/internal/ui/components/header.go
+++ b/internal/ui/components/header.go
@@ -137,8 +137,8 @@ func (h *Header) appendTitleLine(content *strings.Builder) {
 
 	h.appendAlertsBadge(content)
 
-	// Navigation hints
-	content.WriteString(" | [white]Tab[gray]:Switch Views  [white]Enter[gray]:Details  [white]/[gray]:Filter  [white]R[gray]:Refresh  [white]?[gray]:Help[white]")
+	// Navigation hints (keep short to avoid wrapping on narrow terminals)
+	content.WriteString(" | [white]Tab[gray]:Switch Views  [white]Enter[gray]:Details  [white]?[gray]:Help[white]")
 	content.WriteString("\n")
 }
 

--- a/internal/ui/components/header.go
+++ b/internal/ui/components/header.go
@@ -138,7 +138,7 @@ func (h *Header) appendTitleLine(content *strings.Builder) {
 	h.appendAlertsBadge(content)
 
 	// Navigation hints
-	content.WriteString(" | [white]Tab[gray]:Switch Views  [white]Enter[gray]:Details  [white]?[gray]:Help[white]")
+	content.WriteString(" | [white]Tab[gray]:Switch Views  [white]Enter[gray]:Details  [white]/[gray]:Filter  [white]R[gray]:Refresh  [white]?[gray]:Help[white]")
 	content.WriteString("\n")
 }
 

--- a/internal/ui/components/statusbar.go
+++ b/internal/ui/components/statusbar.go
@@ -40,14 +40,10 @@ func NewStatusBar() *StatusBar {
 
 // SetHints sets the keyboard hints to display
 func (s *StatusBar) SetHints(hints []string) {
-	// Only update hints if new hints are provided
-	// This prevents accidental clearing of hints
-	if len(hints) > 0 {
-		s.mu.Lock()
-		s.hints = hints
-		s.mu.Unlock()
-		s.updateDisplay()
-	}
+	s.mu.Lock()
+	s.hints = hints
+	s.mu.Unlock()
+	s.updateDisplay()
 }
 
 // SetMessage sets a temporary message with optional expiry

--- a/internal/ui/components/statusbar.go
+++ b/internal/ui/components/statusbar.go
@@ -162,11 +162,11 @@ func (s *StatusBar) updateDisplay() {
 // formatHints formats the keyboard hints for display
 func (s *StatusBar) formatHints(hints []string) string {
 	if len(hints) == 0 {
-		return ""
+		return "[gray]?:All shortcuts[white]"
 	}
 
-	// Join hints with separators
-	return strings.Join(hints, "  ")
+	// Join hints with separators, append help nudge
+	return strings.Join(hints, "  ") + "  [gray]?:All shortcuts[white]"
 }
 
 // getColorName returns the color name for tview markup

--- a/internal/ui/components/statusbar_test.go
+++ b/internal/ui/components/statusbar_test.go
@@ -6,6 +6,8 @@ import (
 	"time"
 )
 
+const helpNudge = "  [gray]?:All shortcuts[white]"
+
 func TestStatusBar_SetHints(t *testing.T) {
 	statusBar := NewStatusBar()
 
@@ -14,7 +16,7 @@ func TestStatusBar_SetHints(t *testing.T) {
 
 	// Should display hints when no message is present
 	text := statusBar.GetText(false)
-	expected := "F1 Help  F2 Alerts  Tab Switch"
+	expected := "F1 Help  F2 Alerts  Tab Switch" + helpNudge
 	if text != expected {
 		t.Errorf("Expected hints '%s', got '%s'", expected, text)
 	}
@@ -56,7 +58,7 @@ func TestStatusBar_HintsReturnAfterMessageExpires(t *testing.T) {
 
 	// Should show hints again
 	text := statusBar.GetText(false)
-	expected := "F1 Help  F2 Alerts"
+	expected := "F1 Help  F2 Alerts" + helpNudge
 	if text != expected {
 		t.Errorf("Expected hints to return after message expires, got '%s'", text)
 	}
@@ -73,8 +75,22 @@ func TestStatusBar_NoConflictWithMultipleCalls(t *testing.T) {
 
 	// Should show the last set of hints
 	text := statusBar.GetText(false)
-	expected := "View 9  F1 Help"
+	expected := "View 9  F1 Help" + helpNudge
 	if text != expected {
-		t.Errorf("Expected latest hints, got '%s'", text)
+		t.Errorf("Expected latest hints '%s', got '%s'", expected, text)
+	}
+}
+
+func TestStatusBar_EmptyHintsShowNudgeOnly(t *testing.T) {
+	statusBar := NewStatusBar()
+
+	// Set hints then clear by showing empty view
+	statusBar.SetHints([]string{"something"})
+
+	// formatHints with empty should show just the nudge
+	text := statusBar.formatHints(nil)
+	expected := "[gray]?:All shortcuts[white]"
+	if text != expected {
+		t.Errorf("Expected nudge only, got '%s'", text)
 	}
 }

--- a/internal/views/accounts.go
+++ b/internal/views/accounts.go
@@ -177,15 +177,7 @@ func (v *AccountsView) Stop() error {
 // Hints returns keyboard hints
 func (v *AccountsView) Hints() []string {
 	hints := []string{
-		"[yellow]Enter[white] Details",
-		"[yellow]/[white] Filter",
-		"[yellow]f[white] Adv Filter",
-		"[yellow]Ctrl+F[white] Search",
-		"[yellow]Click Headers[white] Sort",
-		"[yellow]S[white] Sort",
-		"[yellow]R[white] Refresh",
 		"[yellow]H[white] Show Hierarchy",
-		"[yellow]e[white] Export",
 	}
 
 	if v.isAdvancedMode {

--- a/internal/views/dashboard.go
+++ b/internal/views/dashboard.go
@@ -258,7 +258,6 @@ func (v *DashboardView) Hints() []string {
 	return []string{
 		"[yellow]L[white] Switch Layout",
 		"[yellow]A[white] Analytics",
-		"[yellow]R[white] Refresh",
 		"[yellow]H[white] Health Check",
 	}
 }

--- a/internal/views/health.go
+++ b/internal/views/health.go
@@ -142,11 +142,9 @@ func (v *HealthView) Stop() error {
 // Hints returns keyboard hints
 func (v *HealthView) Hints() []string {
 	return []string{
-		"[yellow]Enter[white] Alert Details",
 		"[yellow]a[white] Acknowledge Alert",
 		"[yellow]r[white] Resolve Alert",
 		"[yellow]c[white] Clear Resolved",
-		"[yellow]R[white] Refresh",
 		"[yellow]H[white] Health Details",
 		"[yellow]s[white] Health Stats",
 	}

--- a/internal/views/health_test.go
+++ b/internal/views/health_test.go
@@ -501,7 +501,7 @@ func TestHealthViewHints(t *testing.T) {
 	assert.NotEmpty(t, hints, "View should have keyboard hints")
 
 	// Verify essential hints are present
-	essentialHints := []string{"Enter", "Refresh"}
+	essentialHints := []string{"Acknowledge", "Resolve"}
 	for _, essential := range essentialHints {
 		found := false
 		for _, hint := range hints {

--- a/internal/views/jobs.go
+++ b/internal/views/jobs.go
@@ -266,7 +266,6 @@ func (v *JobsView) Stop() error {
 // Hints returns keyboard hints
 func (v *JobsView) Hints() []string {
 	hints := []string{
-		"[yellow]Enter[white] Details",
 		"[yellow]s[white] Submit Job",
 		"[yellow]c[white] Cancel",
 		"[yellow]H[white] Hold",
@@ -274,16 +273,10 @@ func (v *JobsView) Hints() []string {
 		"[yellow]o[white] Output",
 		"[yellow]d[white] Dependencies",
 		"[yellow]q[white] Requeue",
-		"[yellow]b[white] Batch Ops",
-		"[yellow]m[white] Auto Refresh",
-		"[yellow]/[white] Filter",
-		"[yellow]Ctrl+F[white] Search",
-		"[yellow]v[white] Multi-Select",
-		"[yellow]f[white] Adv Filter",
 		"[yellow]x[white] Actions",
-		"[yellow]S[white] Sort",
-		"[yellow]R[white] Refresh",
-		"[yellow]e[white] Export",
+		"[yellow]b[white] Batch Ops",
+		"[yellow]v[white] Multi-Select",
+		"[yellow]m[white] Auto Refresh",
 	}
 
 	if v.isAdvancedMode {

--- a/internal/views/nodes.go
+++ b/internal/views/nodes.go
@@ -210,20 +210,13 @@ func (v *NodesView) Stop() error {
 // Hints returns keyboard hints
 func (v *NodesView) Hints() []string {
 	hints := []string{
-		"[yellow]Enter[white] Details",
 		"[yellow]d[white] Drain",
 		"[yellow]r[white] Resume",
 		"[yellow]s[white] SSH",
-		"[yellow]/[white] Filter",
-		"[yellow]f[white] Adv Filter",
-		"[yellow]Ctrl+F[white] Search",
-		"[yellow]S[white] Sort",
-		"[yellow]R[white] Refresh",
 		"[yellow]p[white] Partition",
 		"[yellow]a[white] All States",
 		"[yellow]g[white] Group By",
 		"[yellow]Space[white] Toggle Group",
-		"[yellow]e[white] Export",
 		"Bar: █=Used ▒=Alloc ▱=Free",
 	}
 

--- a/internal/views/partitions.go
+++ b/internal/views/partitions.go
@@ -268,18 +268,10 @@ func (v *PartitionsView) Stop() error {
 // Hints returns keyboard hints
 func (v *PartitionsView) Hints() []string {
 	hints := []string{
-		"[yellow]Enter[white] Details",
 		"[yellow]J[white] Jobs",
 		"[yellow]N[white] Nodes",
 		"[yellow]A[white] Analytics",
 		"[yellow]W[white] Wait Times",
-		"[yellow]/[white] Filter",
-		"[yellow]f[white] Adv Filter",
-		"[yellow]Ctrl+F[white] Search",
-		"[yellow]Click Headers[white] Sort",
-		"[yellow]S[white] Sort",
-		"[yellow]R[white] Refresh",
-		"[yellow]e[white] Export",
 	}
 
 	if v.isAdvancedMode {

--- a/internal/views/qos.go
+++ b/internal/views/qos.go
@@ -175,16 +175,7 @@ func (v *QoSView) Stop() error {
 
 // Hints returns keyboard hints
 func (v *QoSView) Hints() []string {
-	hints := []string{
-		"[yellow]Enter[white] Details",
-		"[yellow]/[white] Filter",
-		"[yellow]f[white] Adv Filter",
-		"[yellow]Ctrl+F[white] Search",
-		"[yellow]Click Headers[white] Sort",
-		"[yellow]S[white] Sort",
-		"[yellow]R[white] Refresh",
-		"[yellow]e[white] Export",
-	}
+	hints := []string{}
 
 	if v.isAdvancedMode {
 		hints = append([]string{"[yellow]ESC[white] Exit Adv Filter"}, hints...)

--- a/internal/views/reservations.go
+++ b/internal/views/reservations.go
@@ -177,16 +177,7 @@ func (v *ReservationsView) Stop() error {
 
 // Hints returns keyboard hints
 func (v *ReservationsView) Hints() []string {
-	hints := []string{
-		"[yellow]Enter[white] Details",
-		"[yellow]/[white] Filter",
-		"[yellow]f[white] Adv Filter",
-		"[yellow]Ctrl+F[white] Search",
-		"[yellow]Click Headers[white] Sort",
-		"[yellow]S[white] Sort",
-		"[yellow]R[white] Refresh",
-		"[yellow]e[white] Export",
-	}
+	hints := []string{}
 
 	// Show active filter status
 	if v.activeFilterEnabled {

--- a/internal/views/users.go
+++ b/internal/views/users.go
@@ -188,15 +188,7 @@ func (v *UsersView) Hints() []string {
 	}
 
 	hints := []string{
-		"[yellow]Enter[white] Details",
-		"[yellow]/[white] Filter",
-		"[yellow]f[white] Adv Filter",
-		"[yellow]Ctrl+F[white] Search",
-		"[yellow]Click Headers[white] Sort",
-		"[yellow]S[white] Sort",
-		"[yellow]R[white] Refresh",
 		adminHint,
-		"[yellow]e[white] Export",
 	}
 
 	if v.isAdvancedMode {


### PR DESCRIPTION
## Summary

The `?` and `F1` help modal now includes a section showing the current view's keyboard shortcuts below the global keys. This makes view-specific shortcuts discoverable without relying on the crowded status bar hints that get truncated on smaller terminals.

- Both `?` and `F1` now show the same contextual help modal
- Help modal is scrollable for views with many shortcuts
- Global keys section streamlined

## Test plan

- [ ] Press `?` in Jobs view — shows global keys + Jobs shortcuts
- [ ] Press `?` in Nodes view — shows global keys + Nodes shortcuts
- [ ] Press `F1` — same contextual help modal
- [ ] Press `ESC` to close help
- [ ] `go test ./internal/...` passes