### PR TITLE
chore: prepare v0.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-03-30
+
 ### Added
 
 - **`s9s update` command** — check for and install new versions directly from the terminal. Supports `--check` (dry run), `--force` (skip confirmation), `--pre-release` (include pre-release versions), and `--target VERSION` (pin to a specific version, including downgrades with a warning)
@@ -14,14 +16,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Auto-install mode** — set `update.autoInstall: true` to automatically download and replace the binary on startup when a newer version is available (default: false, notify only)
 - **Update state caching** — last check result persisted to `~/.s9s/update-state.json` to avoid redundant GitHub API calls
 - **Self-update via GitHub Releases** — binary replacement with SHA256 checksum verification, platform-aware asset selection, and atomic file replacement via `go-selfupdate`
+- **Dashboard layout switcher** — press `L` in the Dashboard view to switch between the default 6-panel view and a Monitoring layout (metrics + health side by side). Layout preference persists across sessions
+- **Uniform `f` key for advanced filter** — opens the advanced filter bar in all 7 data views (jobs, nodes, accounts, partitions, qos, reservations, users). Replaces the unreachable F3 handler
+- **`x` key for actions menu in Jobs view** — context-sensitive action menu based on job state (cancel, hold, release, requeue, view details/output/dependencies)
+- **Contextual help modal** — `?` and `F1` now show Global Keys, Commands, Common View Keys, and the current view's specific shortcuts
+- **Tab completion on empty command prompt** — press Tab on an empty `:` prompt to browse all available commands
+- **View Settings wired to runtime** — Max Jobs, Show Only Active, and Group Nodes By from config now apply on startup
 
 ### Changed
 
 - **Go module minimum version** — bumped to Go 1.25.0 (required by `golang.org/x/mod` v0.34.0)
+- **Keyboard shortcut reorganization**:
+  - `L` opens layout switcher in Dashboard (was F4 globally)
+  - `f` opens advanced filter in all data views (was F3, which was intercepted by Preferences)
+  - `t`/`T` toggles future filter in Reservations (was `f`/`F`, freed for advanced filter)
+  - `s` is the only way to submit jobs (F2 Templates removed, was duplicate)
+  - F2 now consistently opens system alerts across all views
+- **Hint bar decluttered** — shows only view-specific shortcuts with a `?:All shortcuts` nudge. Common keys (/, R, S, e, Ctrl+F) moved to the help modal
+- **Header simplified** — shows `Tab:Switch Views  Enter:Details  ?:Help`
+- **Configuration modal (F10) consolidated** — 2 groups: General and View Settings. Removed placeholder groups (UI, Features, Clusters, Shortcuts, Aliases, Plugins)
+- **Config save rewritten** — uses `yaml.Marshal` with proper yaml struct tags (preserves field casing), smart merge with existing file (prevents viper-injected default pollution), saves to the correct file when using `--config` flag
 
 ### Fixed
 
+- **Layout deadlock** — `SetCurrentLayout` caused RLock re-entrancy deadlock when switching layouts (#148)
+- **Layout switcher non-deterministic ordering** — map iteration produced random layout order each time the switcher opened
+- **Command line stealing modal focus** — `:layout` and other modal-opening commands left the modal unresponsive because `hideCommandLine` restored focus to the view
+- **Advanced filter input stealing** — view shortcuts (c, r, d, etc.) intercepted keystrokes meant for the filter bar input field
+- **Config modal navigation** — Tab now moves between form fields (was toggling sidebar/form), Escape goes form→sidebar→close (was immediately closing)
+- **Config fields showing empty** — form was built before config was loaded
+- **Save & Exit not saving** — was calling `GetCurrentConfig()` (a getter) instead of saving
+- **Reset/Cancel freezing** — focus was lost after form rebuild
+- **Config saving to wrong path** — always saved to `~/.s9s/config.yaml` even with `--config` flag
+- **Config field casing** — `defaultCluster` became `defaultcluster`, `apiVersion` became `apiversion` (viper lowercasing)
+- **Config default pollution** — viper-injected defaults (UI, Features, Plugins, etc.) written to config file
+- **Nil panic on missing config file** — F10 crashed when `~/.s9s/config.yaml` didn't exist
+- **Stale hints persisting** — switching to views with no shortcuts showed the previous view's hints
+
 ### Removed
+
+- **Preferences modal (F3)** — entirely removed. `save()` was a no-op, only 1 of ~80 fields was used. `UserPreferences` stripped to `Layouts.CurrentLayout` only (-1,344 lines)
+- **Stub widget implementations** — QuickStart, Terminal, Logs, Clock, Status, Alerts widgets removed (hardcoded/mock data, never functional)
+- **F4 global layout shortcut** — replaced by `L` in Dashboard view only
+- **F2 Templates in Jobs view** — duplicate of `s` Submit Job
+- **Dead F1/F3 handlers in Jobs view** — globally intercepted before reaching the view
+- **J/N/P shortcuts in Dashboard** — view switching via number keys is sufficient
+- **Configuration placeholder groups** — UI settings, Features, Keyboard Shortcuts, Command Aliases, Plugins, Cluster Contexts (all showed "Implementation pending" or were never applied)
 
 ## [0.7.1] - 2026-03-21
 
@@ -513,7 +553,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Note**: Versions prior to 0.1.0 were in active development and did not follow semantic versioning.
 
-[Unreleased]: https://github.com/jontk/s9s/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/jontk/s9s/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/jontk/s9s/compare/v0.7.1...v0.8.0
+[0.7.1]: https://github.com/jontk/s9s/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/jontk/s9s/compare/v0.6.3...v0.7.0
 [0.6.3]: https://github.com/jontk/s9s/compare/v0.6.2...v0.6.3
 [0.6.2]: https://github.com/jontk/s9s/compare/v0.6.1...v0.6.2

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -6,14 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Recent Changes
 
-### Unreleased
+### Version 0.8.0 (2026-03-30)
 
-Self-update and auto-update checking:
+Keyboard shortcut overhaul, layout system, and configuration consolidation:
 
-- **`s9s update` Command**: Check for and install new versions directly from the terminal — supports `--check`, `--force`, `--pre-release`, and `--target VERSION` (pin to specific version)
-- **Auto-Update Checks**: Background version check on TUI startup notifies via status bar when a newer release is available; respects configurable interval (default 24h)
-- **Update Configuration**: New `update` config section with `enabled`, `checkInterval`, and `preRelease` options
-- **Self-Update**: Binary replacement with SHA256 checksum verification via GitHub Releases
+- **Dashboard Layout Switcher**: Press `L` to toggle between default 6-panel view and Monitoring layout (metrics + health)
+- **Uniform Keyboard Shortcuts**: `f` for advanced filter (all views), `x` for actions menu (jobs), `t` for future filter (reservations)
+- **Contextual Help**: `?` and `F1` show global keys, commands, and the current view's shortcuts
+- **Tab Completion**: Press Tab on empty `:` prompt to browse all available commands
+- **Self-Update**: `s9s update` command with auto-update checks, SHA256 verification, and GitHub Releases
+- **Configuration Overhaul**: F10 modal consolidated to General + View Settings; saves correctly with proper field casing
+- **View Settings Applied**: Max Jobs, Show Only Active, Group Nodes By from config take effect on startup
+- **Dead Code Removed**: Preferences modal (F3), stub widgets, placeholder config groups (-1,500+ lines)
+- **Bug Fixes**: Layout deadlock, command line focus stealing, config save path, hint bar stale hints
 
 ### Version 0.7.1 (2026-03-21)
 
@@ -128,7 +133,9 @@ For a complete list of all changes, features, and fixes across all versions, ref
 
 ## Version History
 
-- [v0.7.0](../../CHANGELOG.md#070---2026-03-16) - Latest release
+- [v0.8.0](../../CHANGELOG.md#080---2026-03-30) - Latest release
+- [v0.7.1](../../CHANGELOG.md#071---2026-03-21) - SLURM username config
+- [v0.7.0](../../CHANGELOG.md#070---2026-03-16) - Job templates
 - [v0.6.3](../../CHANGELOG.md#063---2026-03-14) - Performance and responsiveness
 - [v0.6.2](../../CHANGELOG.md#062---2026-03-10) - Setup wizard fixes
 - [v0.6.1](../../CHANGELOG.md#061---2026-03-09) - Node metrics, job times, dashboard fixes

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -31,31 +31,31 @@ Download pre-built binaries from our [releases page](https://github.com/jontk/s9
 
 ```bash
 # Linux (x86_64)
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.7.1_Linux_x86_64.tar.gz
-tar -xzf s9s_0.7.1_Linux_x86_64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.8.0_Linux_x86_64.tar.gz
+tar -xzf s9s_0.8.0_Linux_x86_64.tar.gz
 mkdir -p ~/.local/bin
 mv s9s ~/.local/bin/
 
 # Linux (ARM64)
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.7.1_Linux_arm64.tar.gz
-tar -xzf s9s_0.7.1_Linux_arm64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.8.0_Linux_arm64.tar.gz
+tar -xzf s9s_0.8.0_Linux_arm64.tar.gz
 mkdir -p ~/.local/bin
 mv s9s ~/.local/bin/
 
 # macOS (Apple Silicon)
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.7.1_Darwin_arm64.tar.gz
-tar -xzf s9s_0.7.1_Darwin_arm64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.8.0_Darwin_arm64.tar.gz
+tar -xzf s9s_0.8.0_Darwin_arm64.tar.gz
 mkdir -p ~/.local/bin
 mv s9s ~/.local/bin/
 
 # macOS (Intel)
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.7.1_Darwin_x86_64.tar.gz
-tar -xzf s9s_0.7.1_Darwin_x86_64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.8.0_Darwin_x86_64.tar.gz
+tar -xzf s9s_0.8.0_Darwin_x86_64.tar.gz
 mkdir -p ~/.local/bin
 mv s9s ~/.local/bin/
 ```
 
-> **Note:** Replace `0.7.1` with the latest version from the [releases page](https://github.com/jontk/s9s/releases).
+> **Note:** Replace `0.8.0` with the latest version from the [releases page](https://github.com/jontk/s9s/releases).
 
 ### 3. Using Go Install
 
@@ -102,7 +102,7 @@ s9s --version
 
 You should see output like:
 ```
-S9S - SLURM Terminal UI version 0.7.1
+S9S - SLURM Terminal UI version 0.8.0
 ```
 
 ### 2. Initial Configuration
@@ -262,10 +262,10 @@ On Linux, if you get "cannot execute binary file":
 uname -m
 
 # For x86_64/AMD64
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.7.1_Linux_x86_64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.8.0_Linux_x86_64.tar.gz
 
 # For ARM64/aarch64
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.7.1_Linux_arm64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.8.0_Linux_arm64.tar.gz
 ```
 
 ## Upgrading
@@ -316,8 +316,8 @@ Or disable checks entirely via environment variable: `S9S_UPDATE_ENABLED=false`.
 curl -sSL https://get.s9s.dev | bash
 
 # If installed via binary download (replace version and arch as needed)
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.7.1_Linux_x86_64.tar.gz
-tar -xzf s9s_0.7.1_Linux_x86_64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.8.0_Linux_x86_64.tar.gz
+tar -xzf s9s_0.8.0_Linux_x86_64.tar.gz
 mkdir -p ~/.local/bin
 mv s9s ~/.local/bin/
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -83,11 +83,11 @@ Check for and install new versions of s9s directly from the terminal.
 
 **Example output of `s9s update --check`:**
 ```
-Current version: 0.7.1
-Latest version:  0.8.0
-Release:         https://github.com/jontk/s9s/releases/tag/v0.8.0
+Current version: 0.8.0
+Latest version:  0.9.0
+Release:         https://github.com/jontk/s9s/releases/tag/v0.9.0
 
-A new version is available: 0.7.1 -> 0.8.0
+A new version is available: 0.8.0 -> 0.9.0
 ```
 
 **Notes:**

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -315,8 +315,8 @@ update:
 
 The background check runs in a goroutine with a 3-second timeout and caches results to `~/.s9s/update-state.json`. Behavior depends on `autoInstall`:
 
-- **`autoInstall: false`** (default) — shows a status bar notification: `Update available: 0.7.1 -> 0.8.0 (run 's9s update')`
-- **`autoInstall: true`** — downloads and replaces the binary, then shows: `Updated to 0.8.0 — restart s9s to use the new version`. If the auto-install fails (e.g., permissions), falls back to the notification.
+- **`autoInstall: false`** (default) — shows a status bar notification: `Update available: 0.8.0 -> 0.9.0 (run 's9s update')`
+- **`autoInstall: true`** — downloads and replaces the binary, then shows: `Updated to 0.9.0 — restart s9s to use the new version`. If the auto-install fails (e.g., permissions), falls back to the notification.
 
 To update manually, use `s9s update`. See the [Installation Guide](../getting-started/installation.md#upgrading) for details.
 


### PR DESCRIPTION
## Summary

Update CHANGELOG.md and docs for v0.8.0 release.

### CHANGELOG.md
- Move Unreleased section to v0.8.0 with date 2026-03-30
- Add all changes since v0.7.1 organized by Added/Changed/Fixed/Removed
- Update version comparison links

### Docs
- `docs/about/changelog.md` — add v0.8.0 summary, update version history
- `docs/getting-started/installation.md` — update download URLs from 0.7.1 to 0.8.0
- `docs/reference/commands.md` — update example version output
- `docs/reference/configuration.md` — update example version in auto-update docs

## Test plan

- [x] No code changes, docs only
- [x] Version references are consistent (0.8.0 everywhere)
- [x] Changelog links point to correct version comparisons