### PR TITLE
fix: job output reading and real-time streaming

### DIFF
--- a/docs/guides/job-streaming.md
+++ b/docs/guides/job-streaming.md
@@ -11,16 +11,9 @@ s9s supports real-time job output streaming, allowing you to watch stdout and st
 
 Output appears in real time as the job writes to its log files.
 
-## Enabling Streaming
+## How It Works
 
-Streaming is enabled by default. You can toggle it in your configuration file:
-
-```yaml
-features:
-  streaming: true
-```
-
-Or set the default in `config.example.yaml`. When disabled, the Job Output Viewer still works for loading output on demand (press `r` to refresh), but real-time streaming is unavailable.
+Streaming uses `fsnotify` to watch the job's output file for changes (similar to `tail -f`). When new content is written, it appears in the viewer automatically. The output file path is resolved from the SLURM API, with support for custom output patterns like `job_%j.out`.
 
 ## Job Output Viewer
 

--- a/docs/user-guide/job-management.md
+++ b/docs/user-guide/job-management.md
@@ -310,12 +310,13 @@ Press `d` to view job dependencies (not details).
 View job output in real-time:
 
 1. Select job and press `o`
-2. Choose output type:
-   - Standard output (stdout)
-   - Standard error (stderr)
+2. Output opens showing stdout by default
 3. Options:
-   - `f` - Follow/tail output
+   - `t` - Toggle real-time streaming (tail -f style)
    - `s` - Switch between stdout/stderr
+   - `r` - Refresh output
+   - `a` - Toggle auto-scroll
+   - `e` - Export output to file (text, JSON, CSV, markdown)
    - `Esc` - Exit viewer
 
 For more details, see the [Jobs View Guide](./views/jobs.md).

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jontk/s9s/internal/notifications"
 	"github.com/jontk/s9s/internal/plugins"
 	"github.com/jontk/s9s/internal/preferences"
+	"github.com/jontk/s9s/internal/streaming"
 	"github.com/jontk/s9s/internal/ui/components"
 	"github.com/jontk/s9s/internal/views"
 	"github.com/jontk/s9s/pkg/slurm"
@@ -54,8 +55,9 @@ type S9s struct {
 	alertsBadge     *components.AlertsBadge
 	notificationMgr *notifications.NotificationManager
 
-	userPrefs     *preferences.UserPreferences
-	layoutManager *layouts.LayoutManager
+	userPrefs      *preferences.UserPreferences
+	layoutManager  *layouts.LayoutManager
+	streamManager  *streaming.StreamManager
 
 	// Main layout
 	mainLayout   *tview.Flex
@@ -118,6 +120,13 @@ func NewWithScreen(ctx context.Context, cfg *config.Config, screen tcell.Screen)
 
 	// Initialize layout manager
 	s9s.layoutManager = layouts.NewLayoutManager(app)
+
+	// Initialize stream manager for job output streaming (non-fatal)
+	if streamMgr, err := streaming.NewStreamManager(s9s.client, nil, nil, nil); err == nil {
+		s9s.streamManager = streamMgr
+	} else {
+		s9s.logger.Warn().Err(err).Msg("Failed to create stream manager, streaming disabled")
+	}
 
 	// Initialize UI and views
 	if err := s9s.initUI(); err != nil {
@@ -263,6 +272,11 @@ func (s *S9s) Stop() error {
 
 	// Stop all views
 	_ = s.viewMgr.StopAll()
+
+	// Stop stream manager
+	if s.streamManager != nil {
+		_ = s.streamManager.Close()
+	}
 
 	// Stop the tview application
 	s.app.Stop()

--- a/internal/app/app_views.go
+++ b/internal/app/app_views.go
@@ -51,6 +51,9 @@ func (s *S9s) registerJobsView() error {
 	view.SetSubmissionConfig(&s.config.Views.Jobs.Submission)
 	view.SetViewConfig(&s.config.Views.Jobs)
 	view.SetSlurmUser(s.config.ResolveSlurmUser())
+	if s.streamManager != nil {
+		view.SetStreamManager(s.streamManager)
+	}
 	return s.addViewToApp("jobs", view)
 }
 

--- a/internal/dao/slurm_adapter.go
+++ b/internal/dao/slurm_adapter.go
@@ -959,6 +959,13 @@ func parseDurationUnit(n int, unit string) time.Duration {
 
 // pointer helpers for JobCreate fields
 func ptrString(s string) *string { return &s }
+
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
 func ptrInt32(i int32) *int32    { return &i }
 func ptrUint32(i uint32) *uint32 { return &i }
 func ptrUint64(i uint64) *uint64 { return &i }
@@ -1509,8 +1516,8 @@ func convertJob(job *slurm.Job) *Job {
 		NodeList:   nodeList,
 		Command:    command,
 		WorkingDir: workingDir,
-		StdOut:     "", // Not available in basic Job struct
-		StdErr:     "", // Not available in basic Job struct
+		StdOut:     derefString(job.StandardOutput),
+		StdErr:     derefString(job.StandardError),
 		ExitCode:   exitCode,
 	}
 }

--- a/internal/dao/slurm_adapter_submit_test.go
+++ b/internal/dao/slurm_adapter_submit_test.go
@@ -8,13 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// helper to dereference pointer or return zero value
-func derefString(p *string) string {
-	if p == nil {
-		return ""
-	}
-	return *p
-}
+// derefString is now in slurm_adapter.go
 
 func derefInt32(p *int32) int32 {
 	if p == nil {

--- a/internal/output/job_output_reader.go
+++ b/internal/output/job_output_reader.go
@@ -89,15 +89,13 @@ func (r *JobOutputReader) ReadPartial(ctx context.Context, jobID, outputType str
 
 // readContent applies the local-first strategy: try local filesystem, fall back to SSH
 func (r *JobOutputReader) readContent(ctx context.Context, filePath, nodeID string, opts ReadOptions) (string, *FileMetadata, string, error) {
+	// Try local first — shared filesystems (NFS/Lustre) are the common case
 	localMeta, localErr := r.localReader.GetFileInfo(filePath)
-	if localErr != nil {
-		return "", nil, "", fmt.Errorf("failed to check local file: %w", localErr)
-	}
-
-	if localMeta.Exists {
+	if localErr == nil && localMeta.Exists {
 		return r.readLocalContent(ctx, filePath, opts)
 	}
 
+	// Fall back to remote node via SSH
 	if nodeID != "" && r.remoteReader.HasSSHClient() {
 		return r.readRemoteContent(ctx, nodeID, filePath, opts)
 	}

--- a/internal/streaming/manager.go
+++ b/internal/streaming/manager.go
@@ -406,7 +406,7 @@ func (sm *StreamManager) handleFileEvent(event fsnotify.Event) {
 		return
 	}
 
-	sm.mu.RLock()
+	sm.mu.Lock()
 	var relevantStream *JobStream
 	for _, stream := range sm.activeStreams {
 		if stream.FilePath == event.Name && stream.IsActive && !stream.IsRemote {
@@ -414,23 +414,28 @@ func (sm *StreamManager) handleFileEvent(event fsnotify.Event) {
 			break
 		}
 	}
-	sm.mu.RUnlock()
 
 	if relevantStream == nil {
+		sm.mu.Unlock()
 		return
 	}
 
-	// Read new content
+	// Read new content while holding the lock to prevent concurrent
+	// reads from the same offset
 	content, offset, err := sm.readFileFromOffset(relevantStream.FilePath, relevantStream.LastOffset)
 	if err != nil {
+		sm.mu.Unlock()
 		sm.emitError(relevantStream, err)
 		return
 	}
 
 	if len(content) > 0 {
-		sm.emitNewContent(relevantStream, content, offset)
 		relevantStream.LastOffset = offset
 		relevantStream.LastUpdate = GetCurrentTime()
+		sm.mu.Unlock()
+		sm.emitNewContent(relevantStream, content, offset)
+	} else {
+		sm.mu.Unlock()
 	}
 }
 

--- a/internal/streaming/manager.go
+++ b/internal/streaming/manager.go
@@ -75,12 +75,19 @@ func (sm *StreamManager) StartStream(jobID, outputType string) error {
 	}
 
 	// Create new job stream
+	// Start from the current end of file so we only stream new content.
+	// The caller already has the existing content from loadOutput().
+	var initialOffset int64
+	if info, err := os.Stat(filePath); err == nil {
+		initialOffset = info.Size()
+	}
+
 	stream := &JobStream{
 		JobID:       jobID,
 		OutputType:  outputType,
 		Buffer:      NewCircularBuffer(sm.slurmConfig.BufferSize),
 		FilePath:    filePath,
-		LastOffset:  0,
+		LastOffset:  initialOffset,
 		IsActive:    true,
 		IsRemote:    isRemote,
 		NodeID:      nodeID,

--- a/internal/streaming/manager.go
+++ b/internal/streaming/manager.go
@@ -413,37 +413,48 @@ func (sm *StreamManager) handleFileEvent(event fsnotify.Event) {
 		return
 	}
 
+	stream, content, offset, err := sm.readNewContent(event.Name)
+	if stream == nil {
+		return
+	}
+	if err != nil {
+		sm.emitError(stream, err)
+		return
+	}
+	if len(content) > 0 {
+		sm.emitNewContent(stream, content, offset)
+	}
+}
+
+// readNewContent finds the stream for a file path and reads any new content.
+// The lock is held during the read-and-offset-update to prevent concurrent
+// reads from the same offset.
+func (sm *StreamManager) readNewContent(filePath string) (*JobStream, string, int64, error) {
 	sm.mu.Lock()
-	var relevantStream *JobStream
-	for _, stream := range sm.activeStreams {
-		if stream.FilePath == event.Name && stream.IsActive && !stream.IsRemote {
-			relevantStream = stream
+	defer sm.mu.Unlock()
+
+	var stream *JobStream
+	for _, s := range sm.activeStreams {
+		if s.FilePath == filePath && s.IsActive && !s.IsRemote {
+			stream = s
 			break
 		}
 	}
-
-	if relevantStream == nil {
-		sm.mu.Unlock()
-		return
+	if stream == nil {
+		return nil, "", 0, nil
 	}
 
-	// Read new content while holding the lock to prevent concurrent
-	// reads from the same offset
-	content, offset, err := sm.readFileFromOffset(relevantStream.FilePath, relevantStream.LastOffset)
+	content, offset, err := sm.readFileFromOffset(stream.FilePath, stream.LastOffset)
 	if err != nil {
-		sm.mu.Unlock()
-		sm.emitError(relevantStream, err)
-		return
+		return stream, "", 0, err
 	}
 
 	if len(content) > 0 {
-		relevantStream.LastOffset = offset
-		relevantStream.LastUpdate = GetCurrentTime()
-		sm.mu.Unlock()
-		sm.emitNewContent(relevantStream, content, offset)
-	} else {
-		sm.mu.Unlock()
+		stream.LastOffset = offset
+		stream.LastUpdate = GetCurrentTime()
 	}
+
+	return stream, content, offset, nil
 }
 
 // handleFileError processes file watcher errors

--- a/internal/streaming/pathresolver.go
+++ b/internal/streaming/pathresolver.go
@@ -8,6 +8,24 @@ import (
 	"github.com/jontk/s9s/internal/dao"
 )
 
+// expandSlurmPattern replaces SLURM filename patterns with actual values.
+// Common patterns: %j=jobID, %x=jobName, %u=user, %N=nodelist, %%=literal %
+func expandSlurmPattern(pattern string, job *dao.Job) string {
+	if !strings.Contains(pattern, "%") {
+		return pattern
+	}
+
+	r := strings.NewReplacer(
+		"%j", job.ID,
+		"%J", job.ID,
+		"%x", job.Name,
+		"%u", job.User,
+		"%N", job.NodeList,
+		"%%", "%",
+	)
+	return r.Replace(pattern)
+}
+
 // PathResolver resolves SLURM job output file paths using SLURM API data
 type PathResolver struct {
 	slurmConfig *SlurmConfig
@@ -54,7 +72,7 @@ func (pr *PathResolver) ResolveOutputPath(jobID, outputType string) (string, boo
 func (pr *PathResolver) resolveStdoutPath(job *dao.Job) string {
 	// Use stdout path provided by SLURM API via slurm-client
 	if job.StdOut != "" && job.StdOut != "/dev/null" {
-		return job.StdOut // Direct path from SLURM API
+		return expandSlurmPattern(job.StdOut, job)
 	}
 
 	// Use working directory from SLURM API if available
@@ -72,7 +90,7 @@ func (pr *PathResolver) resolveStdoutPath(job *dao.Job) string {
 func (pr *PathResolver) resolveStderrPath(job *dao.Job) string {
 	// Use stderr path provided by SLURM API via slurm-client
 	if job.StdErr != "" && job.StdErr != "/dev/null" {
-		return job.StdErr // Direct path from SLURM API
+		return expandSlurmPattern(job.StdErr, job)
 	}
 
 	// Use working directory from SLURM API if available

--- a/internal/streaming/pathresolver.go
+++ b/internal/streaming/pathresolver.go
@@ -70,38 +70,43 @@ func (pr *PathResolver) ResolveOutputPath(jobID, outputType string) (string, boo
 
 // resolveStdoutPath resolves the stdout file path using SLURM API data
 func (pr *PathResolver) resolveStdoutPath(job *dao.Job) string {
-	// Use stdout path provided by SLURM API via slurm-client
 	if job.StdOut != "" && job.StdOut != "/dev/null" {
-		return expandSlurmPattern(job.StdOut, job)
+		return pr.makeAbsolute(expandSlurmPattern(job.StdOut, job), job.WorkingDir)
 	}
 
-	// Use working directory from SLURM API if available
 	if job.WorkingDir != "" {
 		return filepath.Join(job.WorkingDir,
 			fmt.Sprintf(pr.slurmConfig.FilePattern, job.ID))
 	}
 
-	// Fallback to SLURM spool directory
 	return filepath.Join(pr.slurmConfig.OutputDir,
 		fmt.Sprintf(pr.slurmConfig.FilePattern, job.ID))
 }
 
 // resolveStderrPath resolves the stderr file path using SLURM API data
 func (pr *PathResolver) resolveStderrPath(job *dao.Job) string {
-	// Use stderr path provided by SLURM API via slurm-client
 	if job.StdErr != "" && job.StdErr != "/dev/null" {
-		return expandSlurmPattern(job.StdErr, job)
+		return pr.makeAbsolute(expandSlurmPattern(job.StdErr, job), job.WorkingDir)
 	}
 
-	// Use working directory from SLURM API if available
 	if job.WorkingDir != "" {
 		return filepath.Join(job.WorkingDir,
 			fmt.Sprintf(pr.slurmConfig.ErrorPattern, job.ID))
 	}
 
-	// Fallback to SLURM spool directory
 	return filepath.Join(pr.slurmConfig.ErrorDir,
 		fmt.Sprintf(pr.slurmConfig.ErrorPattern, job.ID))
+}
+
+// makeAbsolute prepends the working directory if the path is relative
+func (pr *PathResolver) makeAbsolute(path, workingDir string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+	if workingDir != "" {
+		return filepath.Join(workingDir, path)
+	}
+	return path
 }
 
 // isRemoteNode determines if the job is running on remote nodes

--- a/internal/views/job_output.go
+++ b/internal/views/job_output.go
@@ -2,8 +2,10 @@ package views
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -269,8 +271,9 @@ func (v *JobOutputView) getJobOutput() (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Read job output with default options
+	// Read job output, bypassing cache to get current content
 	opts := output.DefaultReadOptions()
+	opts.ForceRefresh = true
 	content, err := v.outputReader.ReadPartial(ctx, v.jobID, v.outputType, opts)
 	if err != nil {
 		return "", fmt.Errorf("failed to read job output: %w", err)
@@ -429,7 +432,8 @@ func (v *JobOutputView) showExportDialog() {
 		export.FormatMarkdown: "Markdown format with code blocks",
 	}
 
-	for _, format := range formats {
+	for _, f := range formats {
+		format := f // capture for closure
 		desc := formatDescriptions[format]
 		list.AddItem(
 			fmt.Sprintf("%s (.%s)", strings.ToUpper(string(format)), string(format)),
@@ -486,8 +490,8 @@ func (v *JobOutputView) performExport(format export.ExportFormat) {
 		ContentSize: len(content),
 	}
 
-	// Perform export
-	filePath, err := v.exporter.ExportJobOutput(exportData.JobID, exportData.JobName, exportData.OutputType, exportData.Content)
+	// Perform export using the selected format
+	result, err := v.exporter.Export(&exportData, format, "")
 	if err != nil {
 		v.showNotification(fmt.Sprintf("Export failed: %v", err))
 		return
@@ -495,11 +499,11 @@ func (v *JobOutputView) performExport(format export.ExportFormat) {
 
 	// Show success notification
 	message := fmt.Sprintf("Export successful!\n\nFile: %s\nFormat: %s\nSize: %d bytes",
-		filePath,
+		result.FilePath,
 		strings.ToUpper(string(format)),
-		len(exportData.Content))
+		result.Size)
 
-	v.showExportResult(message, filePath)
+	v.showExportResult(message, result.FilePath)
 }
 
 // showExportResult shows export success with options
@@ -520,18 +524,19 @@ func (v *JobOutputView) showExportResult(message, filePath string) {
 	v.pages.AddPage("export-result", modal, true, true)
 }
 
-// openExportFolder opens the folder containing the exported file
-func (v *JobOutputView) openExportFolder(_ string) {
-	// This is a platform-specific operation
-	// For now, just show the path
-	v.showNotification(fmt.Sprintf("Export folder:\n%s", v.exporter.GetDefaultPath()))
+// openExportFolder copies the export folder path to clipboard
+func (v *JobOutputView) openExportFolder(filePath string) {
+	dir := filepath.Dir(filePath)
+	encoded := base64.StdEncoding.EncodeToString([]byte(dir))
+	fmt.Fprintf(os.Stderr, "\033]52;c;%s\a", encoded)
+	v.showNotification(fmt.Sprintf("Folder path copied to clipboard:\n%s", dir))
 }
 
-// copyPathToClipboard copies the file path to clipboard
+// copyPathToClipboard copies the file path to clipboard via OSC 52
 func (v *JobOutputView) copyPathToClipboard(filePath string) {
-	// This would require a clipboard library
-	// For now, just show the path
-	v.showNotification(fmt.Sprintf("File path:\n%s\n\n(Copy this path manually)", filePath))
+	encoded := base64.StdEncoding.EncodeToString([]byte(filePath))
+	fmt.Fprintf(os.Stderr, "\033]52;c;%s\a", encoded)
+	v.showNotification("Path copied to clipboard!")
 }
 
 /*
@@ -603,10 +608,15 @@ func (v *JobOutputView) startStreaming() {
 		return
 	}
 
-	// Seed the stream content with what loadOutput already displayed,
-	// so we don't lose historical output when streaming starts
+	// Re-read the full file to catch any lines written since loadOutput
 	v.streamContent.Reset()
-	v.streamContent.WriteString(v.textView.GetText(false))
+	if content, err := v.getJobOutput(); err == nil {
+		v.streamContent.WriteString(content)
+		v.textView.SetText(content)
+	} else {
+		// Fall back to whatever is currently displayed
+		v.streamContent.WriteString(v.textView.GetText(false))
+	}
 
 	// Start the stream
 	err := v.streamManager.StartStream(v.jobID, v.outputType)

--- a/internal/views/job_output.go
+++ b/internal/views/job_output.go
@@ -524,7 +524,7 @@ func (v *JobOutputView) showExportResult(message, filePath string) {
 	v.pages.AddPage("export-result", modal, true, true)
 }
 
-// openExportFolder copies the export folder path to clipboard
+// openExportFolder copies the export folder path to clipboard via OSC 52
 func (v *JobOutputView) openExportFolder(filePath string) {
 	dir := filepath.Dir(filePath)
 	encoded := base64.StdEncoding.EncodeToString([]byte(dir))
@@ -532,7 +532,9 @@ func (v *JobOutputView) openExportFolder(filePath string) {
 	v.showNotification(fmt.Sprintf("Folder path copied to clipboard:\n%s", dir))
 }
 
-// copyPathToClipboard copies the file path to clipboard via OSC 52
+// copyPathToClipboard copies the file path to clipboard via OSC 52.
+// Writes to stderr to bypass tview's screen — the terminal emulator
+// intercepts the escape sequence before it reaches the display.
 func (v *JobOutputView) copyPathToClipboard(filePath string) {
 	encoded := base64.StdEncoding.EncodeToString([]byte(filePath))
 	fmt.Fprintf(os.Stderr, "\033]52;c;%s\a", encoded)

--- a/internal/views/job_output.go
+++ b/internal/views/job_output.go
@@ -595,6 +595,9 @@ func (v *JobOutputView) startStreaming() {
 		return
 	}
 
+	// Clear existing content — the stream will re-emit from the beginning
+	v.textView.SetText("")
+
 	// Start the stream
 	err := v.streamManager.StartStream(v.jobID, v.outputType)
 	if err != nil {

--- a/internal/views/job_output.go
+++ b/internal/views/job_output.go
@@ -39,6 +39,7 @@ type JobOutputView struct {
 	autoScroll    bool
 	streamChannel <-chan streaming.StreamEvent
 	streamStatus  string
+	streamContent strings.Builder // accumulates streamed content
 	outputBuffer  *streaming.CircularBuffer
 	streamToggle  *tview.Button
 	scrollToggle  *tview.Button
@@ -597,6 +598,7 @@ func (v *JobOutputView) startStreaming() {
 
 	// Clear existing content — the stream will re-emit from the beginning
 	v.textView.SetText("")
+	v.streamContent.Reset()
 
 	// Start the stream
 	err := v.streamManager.StartStream(v.jobID, v.outputType)
@@ -673,8 +675,10 @@ func (v *JobOutputView) handleStreamEvent(event *streaming.StreamEvent) {
 	v.app.QueueUpdateDraw(func() {
 		switch event.EventType {
 		case streaming.StreamEventNewOutput:
-			// Append new content directly to the text view
-			fmt.Fprint(v.textView, event.Content)
+			// Accumulate content in our own builder to preserve newlines,
+			// then set the full text (avoids tview's Write/GetText quirks)
+			v.streamContent.WriteString(event.Content)
+			v.textView.SetText(v.streamContent.String())
 
 			// Auto-scroll if enabled
 			if v.autoScroll {

--- a/internal/views/job_output.go
+++ b/internal/views/job_output.go
@@ -673,10 +673,9 @@ func (v *JobOutputView) handleStreamEvent(event *streaming.StreamEvent) {
 	v.app.QueueUpdateDraw(func() {
 		switch event.EventType {
 		case streaming.StreamEventNewOutput:
-			// Append new content
-			currentText := v.textView.GetText(false)
-			newText := currentText + event.Content
-			v.textView.SetText(newText)
+			// Append new content using Write (avoids GetText/SetText round-trip
+			// which can lose trailing newlines)
+			fmt.Fprint(v.textView, event.Content)
 
 			// Auto-scroll if enabled
 			if v.autoScroll {

--- a/internal/views/job_output.go
+++ b/internal/views/job_output.go
@@ -383,6 +383,12 @@ func (v *JobOutputView) stopAutoRefresh() {
 
 // switchOutputType switches between stdout and stderr
 func (v *JobOutputView) switchOutputType() {
+	// Stop any active stream before switching
+	if v.isStreaming {
+		v.stopStreaming()
+	}
+	v.streamContent.Reset()
+
 	if v.outputType == "stdout" {
 		v.outputType = "stderr"
 	} else {
@@ -390,6 +396,7 @@ func (v *JobOutputView) switchOutputType() {
 	}
 
 	v.textView.SetTitle(fmt.Sprintf(" Job %s - %s (%s) ", v.jobID, v.jobName, strings.ToUpper(v.outputType)))
+	v.updateStreamingUI()
 	v.loadOutput()
 }
 

--- a/internal/views/job_output.go
+++ b/internal/views/job_output.go
@@ -596,9 +596,10 @@ func (v *JobOutputView) startStreaming() {
 		return
 	}
 
-	// Clear existing content — the stream will re-emit from the beginning
-	v.textView.SetText("")
+	// Seed the stream content with what loadOutput already displayed,
+	// so we don't lose historical output when streaming starts
 	v.streamContent.Reset()
+	v.streamContent.WriteString(v.textView.GetText(false))
 
 	// Start the stream
 	err := v.streamManager.StartStream(v.jobID, v.outputType)

--- a/internal/views/job_output.go
+++ b/internal/views/job_output.go
@@ -165,9 +165,9 @@ func (v *JobOutputView) buildStreamingControls() {
 	v.streamToggle.SetSelectedFunc(v.toggleStreaming)
 
 	// Auto-scroll toggle button
-	scrollText := "↓ Auto-scroll: ON"
+	scrollText := "Auto-scroll: ✓"
 	if !v.autoScroll {
-		scrollText = "↓ Auto-scroll: OFF"
+		scrollText = "Auto-scroll: ✗"
 	}
 	v.scrollToggle = tview.NewButton(scrollText)
 	v.scrollToggle.SetSelectedFunc(v.toggleAutoScroll)
@@ -748,9 +748,9 @@ func (v *JobOutputView) updateStreamingUI() {
 
 	if v.scrollToggle != nil {
 		if v.autoScroll {
-			v.scrollToggle.SetLabel("↓ Auto-scroll: ON")
+			v.scrollToggle.SetLabel("Auto-scroll: ✓")
 		} else {
-			v.scrollToggle.SetLabel("↓ Auto-scroll: OFF")
+			v.scrollToggle.SetLabel("Auto-scroll: ✗")
 		}
 	}
 

--- a/internal/views/job_output.go
+++ b/internal/views/job_output.go
@@ -673,8 +673,7 @@ func (v *JobOutputView) handleStreamEvent(event *streaming.StreamEvent) {
 	v.app.QueueUpdateDraw(func() {
 		switch event.EventType {
 		case streaming.StreamEventNewOutput:
-			// Append new content using Write (avoids GetText/SetText round-trip
-			// which can lose trailing newlines)
+			// Append new content directly to the text view
 			fmt.Fprint(v.textView, event.Content)
 
 			// Auto-scroll if enabled

--- a/internal/views/jobs.go
+++ b/internal/views/jobs.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jontk/s9s/internal/dao"
 	"github.com/jontk/s9s/internal/debug"
 	"github.com/jontk/s9s/internal/export"
+	"github.com/jontk/s9s/internal/streaming"
 	"github.com/jontk/s9s/internal/ui/components"
 	"github.com/jontk/s9s/internal/ui/filters"
 	"github.com/jontk/s9s/internal/ui/styles"
@@ -69,6 +70,13 @@ func (v *JobsView) SetViewConfig(cfg *config.JobsViewConfig) {
 // SetSlurmUser sets the resolved SLURM username for the job submission wizard
 func (v *JobsView) SetSlurmUser(user string) {
 	v.slurmUser = user
+}
+
+// SetStreamManager sets the stream manager for job output streaming
+func (v *JobsView) SetStreamManager(sm *streaming.StreamManager) {
+	if v.jobOutputView != nil {
+		v.jobOutputView.SetStreamManager(sm)
+	}
 }
 
 // SetPages sets the pages reference for modal handling

--- a/internal/views/jobs.go
+++ b/internal/views/jobs.go
@@ -52,6 +52,7 @@ type JobsView struct {
 	submissionConfig    *config.JobSubmissionConfig
 	viewConfig          *config.JobsViewConfig
 	slurmUser           string
+	streamMgr           *streaming.StreamManager
 }
 
 // SetSubmissionConfig sets the job submission configuration
@@ -74,6 +75,7 @@ func (v *JobsView) SetSlurmUser(user string) {
 
 // SetStreamManager sets the stream manager for job output streaming
 func (v *JobsView) SetStreamManager(sm *streaming.StreamManager) {
+	v.streamMgr = sm
 	if v.jobOutputView != nil {
 		v.jobOutputView.SetStreamManager(sm)
 	}
@@ -112,6 +114,9 @@ func (v *JobsView) SetApp(app *tview.Application) {
 	v.jobOutputView = NewJobOutputView(v.client, app)
 	if v.pages != nil {
 		v.jobOutputView.SetPages(v.pages)
+	}
+	if v.streamMgr != nil {
+		v.jobOutputView.SetStreamManager(v.streamMgr)
 	}
 
 	// Create batch operations view


### PR DESCRIPTION
## Summary

Fix job output reading to work with real SLURM output files, wire up the existing StreamManager for real-time streaming, and fix export/clipboard operations.

### Job output path fixes
- Map `StandardOutput`/`StandardError` from SLURM API into the DAO Job struct (was hardcoded to empty strings)
- Expand SLURM filename patterns (`%j`=jobID, `%x`=jobName, `%u`=user, `%N`=nodelist) before resolving paths
- Prepend job's `WorkingDir` when the API returns a relative path (e.g., `job_%j.out` → `/home/user/job_28.out`)
- Try local file read first, fall back to remote gracefully (was failing immediately on local stat error)

### Real-time streaming
- Instantiate StreamManager at app level with fsnotify file watcher
- Wire to JobOutputView through JobsView (persists across view recreation)
- Stream only new content from end-of-file (preserves existing output)
- Re-read full file when starting stream to close gap between initial load and stream start
- Fix concurrent file read race in StreamManager (RLock → Lock for offset updates)
- Fix newline loss by accumulating stream content in strings.Builder
- Stop streaming and reset state when switching between stdout/stderr
- Bypass output reader cache so switching/refreshing always shows current content

### Export and clipboard
- Fix export format selection (closure capture bug + hardcoded FormatText)
- Copy Path uses OSC 52 to copy to system clipboard (was showing "copy manually" placeholder)
- Open Folder copies directory path to clipboard via OSC 52

### UI improvements
- Auto-scroll button shows ✓/✗ instead of ON/OFF (both truncated to "O")

## Test plan

- [x] `go test ./internal/...` passes
- [x] Submit job with custom output path → `o` reads from correct file
- [x] Press `t` → streaming starts, new lines appear in real-time
- [x] Press `t` again → streaming stops
- [x] Press `s` → switch stdout/stderr cleanly (no mixed content)
- [x] Press `s` back → shows full current content (no gaps)
- [x] Wait, then press `t` → no gap between loaded and streamed content
- [x] Press `e` → select JSON → file has .json extension and JSON format
- [x] Press `e` → select Markdown → file has .md extension and markdown formatting
- [x] Copy Path → path is in system clipboard
- [x] Open Folder → folder path is in system clipboard