### PR TITLE
feat: TRES/GRES display, enriched job detail modal, and GRES submission fix

### DIFF
--- a/internal/dao/slurm_adapter.go
+++ b/internal/dao/slurm_adapter.go
@@ -1534,14 +1534,14 @@ func convertJob(job *slurm.Job) *Job {
 		ID:         jobID,
 		Name:       name,
 		User:       username,
-		Account:    "", // Not available in basic Job struct
+		Account:    derefString(job.Account),
 		Partition:  partition,
 		State:      state,
 		Priority:   priority,
-		QOS:        "", // Not available in basic Job struct
+		QOS:        derefString(job.QoS),
 		NodeCount:  nodeCount,
 		TimeLimit:  timeLimit,
-		TimeUsed:   "", // Not available in basic Job struct
+		TimeUsed:   "",
 		SubmitTime: job.SubmitTime,
 		StartTime:  startTime,
 		EndTime:    endTime,

--- a/internal/dao/slurm_adapter.go
+++ b/internal/dao/slurm_adapter.go
@@ -1004,21 +1004,21 @@ func derefBool(p *bool) bool {
 	return *p
 }
 
-func derefUint32(p *uint32) int {
+func derefUint32Int(p *uint32) int {
 	if p == nil {
 		return 0
 	}
 	return int(*p)
 }
 
-func derefUint16(p *uint16) int {
+func derefUint16Int(p *uint16) int {
 	if p == nil {
 		return 0
 	}
 	return int(*p)
 }
 
-func derefUint64(p *uint64) int64 {
+func derefUint64Int64(p *uint64) int64 {
 	if p == nil {
 		return 0
 	}
@@ -1587,12 +1587,12 @@ func convertJob(job *slurm.Job) *Job {
 		ExitCode:       exitCode,
 		BatchHost:      derefString(job.BatchHost),
 		Cluster:        derefString(job.Cluster),
-		CPUs:           derefUint32(job.CPUs),
-		CPUsPerTask:    derefUint16(job.CPUsPerTask),
-		MemoryPerNode:  derefUint64(job.MemoryPerNode),
-		MemoryPerCPU:   derefUint64(job.MemoryPerCPU),
-		Tasks:          derefUint32(job.Tasks),
-		TasksPerNode:   derefUint16(job.TasksPerNode),
+		CPUs:           derefUint32Int(job.CPUs),
+		CPUsPerTask:    derefUint16Int(job.CPUsPerTask),
+		MemoryPerNode:  derefUint64Int64(job.MemoryPerNode),
+		MemoryPerCPU:   derefUint64Int64(job.MemoryPerCPU),
+		Tasks:          derefUint32Int(job.Tasks),
+		TasksPerNode:   derefUint16Int(job.TasksPerNode),
 		TRESPerTask:    derefString(job.TRESPerTask),
 		Requeue:        derefBool(job.Requeue),
 		SubmitLine:     derefString(job.SubmitLine),

--- a/internal/dao/slurm_adapter.go
+++ b/internal/dao/slurm_adapter.go
@@ -383,9 +383,11 @@ func convertJobSubmissionToJobCreate(job *JobSubmission) *slurm.JobCreate {
 		jc.QoS = ptrString(job.QoS)
 	}
 
-	// GPUs → TRESPerNode
-	if job.GPUs > 0 {
-		jc.TRESPerNode = ptrString(fmt.Sprintf("gres/gpu:%d", job.GPUs))
+	// GPUs and Gres → TRESPerNode
+	// The SLURM REST API uses tres_per_node for what sbatch calls --gres.
+	// Each resource needs the "gres/" prefix in TRES notation.
+	if tresPerNode := buildTRESPerNode(job.GPUs, job.Gres); tresPerNode != "" {
+		jc.TRESPerNode = ptrString(tresPerNode)
 	}
 
 	// Output/Error files
@@ -439,10 +441,6 @@ func convertJobSubmissionToJobCreate(job *JobSubmission) *slurm.JobCreate {
 		jc.TasksPerNode = ptrInt32(int32(job.NTasksPerNode))
 	}
 
-	// Gres (generic resources, overrides GPUs if both set)
-	if job.Gres != "" {
-		jc.TRESPerNode = ptrString(job.Gres)
-	}
 
 	// Hold
 	if job.Hold {
@@ -959,6 +957,33 @@ func parseDurationUnit(n int, unit string) time.Duration {
 
 // pointer helpers for JobCreate fields
 func ptrString(s string) *string { return &s }
+
+// buildTRESPerNode constructs the tres_per_node value from GPUs and Gres fields.
+// TRES (Trackable Resources) can include cpu, mem, energy, node, billing, and gres.
+// Only GRES items need the "gres/" prefix — standard TRES like "cpu=4" are passed through.
+// If both GPUs and Gres are set, Gres takes precedence (it's more expressive).
+// Examples: "gres/gpu:1", "gres/gpu:2,gres/shard:4", "cpu=4,gres/gpu:1"
+func buildTRESPerNode(gpus int, gres string) string {
+	if gres != "" {
+		parts := strings.Split(gres, ",")
+		for i, part := range parts {
+			part = strings.TrimSpace(part)
+			// Standard TRES types use "key=value" format (cpu=4, mem=8G)
+			// GRES types use "type:count" format (gpu:1, shard:4)
+			// Only add "gres/" prefix to GRES items that don't already have it
+			if !strings.HasPrefix(part, "gres/") && !strings.Contains(part, "=") {
+				parts[i] = "gres/" + part
+			} else {
+				parts[i] = part
+			}
+		}
+		return strings.Join(parts, ",")
+	}
+	if gpus > 0 {
+		return fmt.Sprintf("gres/gpu:%d", gpus)
+	}
+	return ""
+}
 
 func derefString(s *string) string {
 	if s == nil {
@@ -1527,6 +1552,10 @@ func convertJob(job *slurm.Job) *Job {
 		StdErr:      derefString(job.StandardError),
 		ArrayJobID:  derefUint32String(job.ArrayJobID),
 		ArrayTaskID: derefUint32String(job.ArrayTaskID),
+		TRESReq:     derefString(job.TRESReqStr),
+		TRESAlloc:   derefString(job.TRESAllocStr),
+		TRESPerNode: derefString(job.TRESPerNode),
+		GRESDetail:  strings.Join(job.GRESDetail, ", "),
 		ExitCode:    exitCode,
 	}
 }

--- a/internal/dao/slurm_adapter.go
+++ b/internal/dao/slurm_adapter.go
@@ -997,6 +997,34 @@ func ptrUint64(i uint64) *uint64 { return &i }
 func ptrInt64(i int64) *int64    { return &i }
 func ptrBool(b bool) *bool       { return &b }
 
+func derefBool(p *bool) bool {
+	if p == nil {
+		return false
+	}
+	return *p
+}
+
+func derefUint32(p *uint32) int {
+	if p == nil {
+		return 0
+	}
+	return int(*p)
+}
+
+func derefUint16(p *uint16) int {
+	if p == nil {
+		return 0
+	}
+	return int(*p)
+}
+
+func derefUint64(p *uint64) int64 {
+	if p == nil {
+		return 0
+	}
+	return int64(*p)
+}
+
 func derefUint32String(p *uint32) string {
 	if p == nil || *p == 0 {
 		return ""
@@ -1555,8 +1583,30 @@ func convertJob(job *slurm.Job) *Job {
 		TRESReq:     derefString(job.TRESReqStr),
 		TRESAlloc:   derefString(job.TRESAllocStr),
 		TRESPerNode: derefString(job.TRESPerNode),
-		GRESDetail:  strings.Join(job.GRESDetail, ", "),
-		ExitCode:    exitCode,
+		GRESDetail:     strings.Join(job.GRESDetail, ", "),
+		ExitCode:       exitCode,
+		BatchHost:      derefString(job.BatchHost),
+		Cluster:        derefString(job.Cluster),
+		CPUs:           derefUint32(job.CPUs),
+		CPUsPerTask:    derefUint16(job.CPUsPerTask),
+		MemoryPerNode:  derefUint64(job.MemoryPerNode),
+		MemoryPerCPU:   derefUint64(job.MemoryPerCPU),
+		Tasks:          derefUint32(job.Tasks),
+		TasksPerNode:   derefUint16(job.TasksPerNode),
+		TRESPerTask:    derefString(job.TRESPerTask),
+		Requeue:        derefBool(job.Requeue),
+		SubmitLine:     derefString(job.SubmitLine),
+		StdOutExpanded: derefString(job.StdoutExpanded),
+		StdErrExpanded: derefString(job.StderrExpanded),
+		Dependency:     derefString(job.Dependency),
+		Licenses:       derefString(job.Licenses),
+		Reservation:    derefString(job.ResvName),
+		Features:       derefString(job.Features),
+		Comment:        derefString(job.Comment),
+		AdminComment:   derefString(job.AdminComment),
+		Wckey:          derefString(job.Wckey),
+		MailUser:       derefString(job.MailUser),
+		StateReason:    derefString(job.StateReason),
 	}
 }
 

--- a/internal/dao/slurm_adapter_submit_test.go
+++ b/internal/dao/slurm_adapter_submit_test.go
@@ -10,14 +10,14 @@ import (
 
 // derefString is now in slurm_adapter.go
 
-func derefInt32(p *int32) int32 {
+func testDerefInt32(p *int32) int32 {
 	if p == nil {
 		return 0
 	}
 	return *p
 }
 
-func derefUint32(p *uint32) uint32 {
+func testDerefUint32(p *uint32) uint32 {
 	if p == nil {
 		return 0
 	}
@@ -43,9 +43,9 @@ func TestConvertJobSubmissionToJobCreate_CoreFields(t *testing.T) {
 	assert.Equal(t, "#!/bin/bash\necho hello", derefString(jc.Script))
 	assert.Equal(t, "gpu", derefString(jc.Partition))
 	assert.Equal(t, "research", derefString(jc.Account))
-	assert.Equal(t, int32(4), derefInt32(jc.CPUsPerTask))
-	assert.Equal(t, int32(2), derefInt32(jc.MinimumNodes))
-	assert.Equal(t, uint32(60), derefUint32(jc.TimeLimit))
+	assert.Equal(t, int32(4), testDerefInt32(jc.CPUsPerTask))
+	assert.Equal(t, int32(2), testDerefInt32(jc.MinimumNodes))
+	assert.Equal(t, uint32(60), testDerefUint32(jc.TimeLimit))
 	assert.Equal(t, "/home/user/work", derefString(jc.CurrentWorkingDirectory))
 }
 
@@ -72,7 +72,7 @@ func TestConvertJobSubmissionToJobCreate_TimeParsing(t *testing.T) {
 				TimeLimit: tt.input,
 			}
 			jc := convertJobSubmissionToJobCreate(job)
-			assert.Equal(t, tt.expected, derefUint32(jc.TimeLimit))
+			assert.Equal(t, tt.expected, testDerefUint32(jc.TimeLimit))
 		})
 	}
 }

--- a/internal/dao/types.go
+++ b/internal/dao/types.go
@@ -33,6 +33,30 @@ type Job struct {
 	TRESPerNode  string // TRES per node (e.g., "gres/gpu:1")
 	GRESDetail   string // GRES detail (e.g., "gpu:1(IDX:0)")
 	ExitCode     *int
+
+	// Additional detail fields (populated from SLURM API)
+	BatchHost      string // Node running the batch script
+	Cluster        string // Cluster name
+	CPUs           int    // Total CPUs allocated
+	CPUsPerTask    int    // CPUs per task
+	MemoryPerNode  int64  // Memory per node in MB
+	MemoryPerCPU   int64  // Memory per CPU in MB
+	Tasks          int    // Number of tasks
+	TasksPerNode   int    // Tasks per node
+	TRESPerTask    string // TRES per task
+	Requeue        bool   // Whether job can be requeued
+	SubmitLine     string // Full sbatch command line
+	StdOutExpanded string // SLURM-expanded stdout path
+	StdErrExpanded string // SLURM-expanded stderr path
+	Dependency     string // Job dependencies
+	Licenses       string // Required licenses
+	Reservation    string // Reservation name
+	Features       string // Required node features
+	Comment        string // User comment
+	AdminComment   string // Admin comment
+	Wckey          string // Workload characterization key
+	MailUser       string // Email notification user
+	StateReason    string // Why job is in current state
 }
 
 // JobList represents a list of jobs

--- a/internal/dao/types.go
+++ b/internal/dao/types.go
@@ -28,6 +28,10 @@ type Job struct {
 	StdErr       string
 	ArrayJobID   string // Master job ID for array jobs (empty if not array)
 	ArrayTaskID  string // Task ID within the array (empty if not array)
+	TRESReq      string // Requested TRES (e.g., "cpu=1,mem=2G,gres/gpu=1")
+	TRESAlloc    string // Allocated TRES
+	TRESPerNode  string // TRES per node (e.g., "gres/gpu:1")
+	GRESDetail   string // GRES detail (e.g., "gpu:1(IDX:0)")
 	ExitCode     *int
 }
 

--- a/internal/views/jobs.go
+++ b/internal/views/jobs.go
@@ -1044,7 +1044,7 @@ func (v *JobsView) formatJobDetails(job *dao.Job) string {
 	}
 	v.writeIndentedField(&d, "Time Limit", job.TimeLimit)
 	v.writeIndentedField(&d, "Time Used", job.TimeUsed)
-	if job.StateReason != "" {
+	if job.StateReason != "" && job.StateReason != "None" {
 		stateColor := dao.GetJobStateColor(job.State)
 		v.writeIndentedField(&d, "Reason", fmt.Sprintf("[%s]%s[white]", stateColor, job.StateReason))
 	}

--- a/internal/views/jobs.go
+++ b/internal/views/jobs.go
@@ -1025,12 +1025,12 @@ func (v *JobsView) formatJobDetails(job *dao.Job) string {
 	d.WriteString("[gray]" + strings.Repeat("─", 60) + "[white]\n")
 
 	// Identity
-	v.writeField(&d, "User", job.User)
-	v.writeField(&d, "Account", job.Account)
-	v.writeField(&d, "Partition", job.Partition)
-	v.writeField(&d, "QoS", job.QOS)
-	v.writeField(&d, "Priority", fmt.Sprintf("%.0f", job.Priority))
-	v.writeField(&d, "Cluster", job.Cluster)
+	writeDetailField(&d, "User", job.User)
+	writeDetailField(&d, "Account", job.Account)
+	writeDetailField(&d, "Partition", job.Partition)
+	writeDetailField(&d, "QoS", job.QOS)
+	writeDetailField(&d, "Priority", fmt.Sprintf("%.0f", job.Priority))
+	writeDetailField(&d, "Cluster", job.Cluster)
 	d.WriteString("\n")
 
 	// Scheduling
@@ -1042,83 +1042,83 @@ func (v *JobsView) formatJobDetails(job *dao.Job) string {
 	if job.EndTime != nil {
 		d.WriteString(fmt.Sprintf("  [yellow]End:[white]        %s\n", job.EndTime.Format("2006-01-02 15:04:05")))
 	}
-	v.writeIndentedField(&d, "Time Limit", formatTimeLimitStr(job.TimeLimit))
-	v.writeIndentedField(&d, "Time Used", job.TimeUsed)
+	writeDetailIndented(&d, "Time Limit", formatTimeLimitStr(job.TimeLimit))
+	writeDetailIndented(&d, "Time Used", job.TimeUsed)
 	if job.StateReason != "" && job.StateReason != "None" {
 		stateColor := dao.GetJobStateColor(job.State)
-		v.writeIndentedField(&d, "Reason", fmt.Sprintf("[%s]%s[white]", stateColor, job.StateReason))
+		writeDetailIndented(&d, "Reason", fmt.Sprintf("[%s]%s[white]", stateColor, job.StateReason))
 	}
-	v.writeIndentedField(&d, "Dependency", job.Dependency)
+	writeDetailIndented(&d, "Dependency", job.Dependency)
 	if job.Requeue {
-		v.writeIndentedField(&d, "Requeue", "Yes")
+		writeDetailIndented(&d, "Requeue", "Yes")
 	}
 	d.WriteString("\n")
 
 	// Resources
 	d.WriteString("[teal]Resources[white]\n")
-	v.writeIndentedField(&d, "Nodes", fmt.Sprintf("%d", job.NodeCount))
-	v.writeIndentedField(&d, "Node List", job.NodeList)
-	v.writeIndentedField(&d, "TRES Req", job.TRESReq)
-	v.writeIndentedField(&d, "TRES Alloc", job.TRESAlloc)
-	v.writeIndentedField(&d, "TRES/Node", job.TRESPerNode)
-	v.writeIndentedField(&d, "GRES", job.GRESDetail)
+	writeDetailIndented(&d, "Nodes", fmt.Sprintf("%d", job.NodeCount))
+	writeDetailIndented(&d, "Node List", job.NodeList)
+	writeDetailIndented(&d, "TRES Req", job.TRESReq)
+	writeDetailIndented(&d, "TRES Alloc", job.TRESAlloc)
+	writeDetailIndented(&d, "TRES/Node", job.TRESPerNode)
+	writeDetailIndented(&d, "GRES", job.GRESDetail)
 	if job.CPUs > 0 {
-		v.writeIndentedField(&d, "CPUs", fmt.Sprintf("%d", job.CPUs))
+		writeDetailIndented(&d, "CPUs", fmt.Sprintf("%d", job.CPUs))
 	}
 	if job.CPUsPerTask > 0 {
-		v.writeIndentedField(&d, "CPUs/Task", fmt.Sprintf("%d", job.CPUsPerTask))
+		writeDetailIndented(&d, "CPUs/Task", fmt.Sprintf("%d", job.CPUsPerTask))
 	}
 	if job.Tasks > 0 {
-		v.writeIndentedField(&d, "Tasks", fmt.Sprintf("%d", job.Tasks))
+		writeDetailIndented(&d, "Tasks", fmt.Sprintf("%d", job.Tasks))
 	}
 	if job.TasksPerNode > 0 {
-		v.writeIndentedField(&d, "Tasks/Node", fmt.Sprintf("%d", job.TasksPerNode))
+		writeDetailIndented(&d, "Tasks/Node", fmt.Sprintf("%d", job.TasksPerNode))
 	}
 	if job.MemoryPerNode > 0 {
 		if job.MemoryPerNode >= 1024 && job.MemoryPerNode%1024 == 0 {
-			v.writeIndentedField(&d, "Mem/Node", fmt.Sprintf("%dG", job.MemoryPerNode/1024))
+			writeDetailIndented(&d, "Mem/Node", fmt.Sprintf("%dG", job.MemoryPerNode/1024))
 		} else {
-			v.writeIndentedField(&d, "Mem/Node", fmt.Sprintf("%dM", job.MemoryPerNode))
+			writeDetailIndented(&d, "Mem/Node", fmt.Sprintf("%dM", job.MemoryPerNode))
 		}
 	}
 	if job.MemoryPerCPU > 0 {
 		if job.MemoryPerCPU >= 1024 && job.MemoryPerCPU%1024 == 0 {
-			v.writeIndentedField(&d, "Mem/CPU", fmt.Sprintf("%dG", job.MemoryPerCPU/1024))
+			writeDetailIndented(&d, "Mem/CPU", fmt.Sprintf("%dG", job.MemoryPerCPU/1024))
 		} else {
-			v.writeIndentedField(&d, "Mem/CPU", fmt.Sprintf("%dM", job.MemoryPerCPU))
+			writeDetailIndented(&d, "Mem/CPU", fmt.Sprintf("%dM", job.MemoryPerCPU))
 		}
 	}
-	v.writeIndentedField(&d, "TRES/Task", job.TRESPerTask)
-	v.writeIndentedField(&d, "Batch Host", job.BatchHost)
-	v.writeIndentedField(&d, "Features", job.Features)
-	v.writeIndentedField(&d, "Licenses", job.Licenses)
+	writeDetailIndented(&d, "TRES/Task", job.TRESPerTask)
+	writeDetailIndented(&d, "Batch Host", job.BatchHost)
+	writeDetailIndented(&d, "Features", job.Features)
+	writeDetailIndented(&d, "Licenses", job.Licenses)
 	d.WriteString("\n")
 
 	// Paths
 	d.WriteString("[teal]Paths[white]\n")
-	v.writeIndentedField(&d, "Work Dir", job.WorkingDir)
-	v.writeIndentedField(&d, "Command", job.Command)
+	writeDetailIndented(&d, "Work Dir", job.WorkingDir)
+	writeDetailIndented(&d, "Command", job.Command)
 	if job.StdOutExpanded != "" {
-		v.writeIndentedField(&d, "StdOut", job.StdOutExpanded)
+		writeDetailIndented(&d, "StdOut", job.StdOutExpanded)
 	} else if job.StdOut != "" {
-		v.writeIndentedField(&d, "StdOut", expandJobPattern(job.StdOut, job))
+		writeDetailIndented(&d, "StdOut", expandJobPattern(job.StdOut, job))
 	}
 	if job.StdErrExpanded != "" {
-		v.writeIndentedField(&d, "StdErr", job.StdErrExpanded)
+		writeDetailIndented(&d, "StdErr", job.StdErrExpanded)
 	} else if job.StdErr != "" {
-		v.writeIndentedField(&d, "StdErr", expandJobPattern(job.StdErr, job))
+		writeDetailIndented(&d, "StdErr", expandJobPattern(job.StdErr, job))
 	}
-	v.writeIndentedField(&d, "Submit Line", job.SubmitLine)
+	writeDetailIndented(&d, "Submit Line", job.SubmitLine)
 
 	// Notes
 	if job.Comment != "" || job.AdminComment != "" || job.Wckey != "" || job.MailUser != "" || job.Reservation != "" {
 		d.WriteString("\n")
 		d.WriteString("[teal]Notes[white]\n")
-		v.writeIndentedField(&d, "Comment", job.Comment)
-		v.writeIndentedField(&d, "Admin Note", job.AdminComment)
-		v.writeIndentedField(&d, "Wckey", job.Wckey)
-		v.writeIndentedField(&d, "Mail User", job.MailUser)
-		v.writeIndentedField(&d, "Reservation", job.Reservation)
+		writeDetailIndented(&d, "Comment", job.Comment)
+		writeDetailIndented(&d, "Admin Note", job.AdminComment)
+		writeDetailIndented(&d, "Wckey", job.Wckey)
+		writeDetailIndented(&d, "Mail User", job.MailUser)
+		writeDetailIndented(&d, "Reservation", job.Reservation)
 	}
 
 	// Exit
@@ -1131,14 +1131,14 @@ func (v *JobsView) formatJobDetails(job *dao.Job) string {
 }
 
 // writeField writes a field only if the value is non-empty
-func (v *JobsView) writeField(d *strings.Builder, label, value string) {
-	if value != "" && value != "0" {
+func writeDetailField(d *strings.Builder, label, value string) {
+	if value != "" {
 		fmt.Fprintf(d, "[yellow]%s:[white] %s\n", label, value)
 	}
 }
 
 // writeIndentedField writes an indented field only if the value is non-empty
-func (v *JobsView) writeIndentedField(d *strings.Builder, label, value string) {
+func writeDetailIndented(d *strings.Builder, label, value string) {
 	if value != "" {
 		fmt.Fprintf(d, "  [yellow]%-11s[white] %s\n", label+":", value)
 	}

--- a/internal/views/jobs.go
+++ b/internal/views/jobs.go
@@ -1042,7 +1042,7 @@ func (v *JobsView) formatJobDetails(job *dao.Job) string {
 	if job.EndTime != nil {
 		d.WriteString(fmt.Sprintf("  [yellow]End:[white]        %s\n", job.EndTime.Format("2006-01-02 15:04:05")))
 	}
-	v.writeIndentedField(&d, "Time Limit", job.TimeLimit)
+	v.writeIndentedField(&d, "Time Limit", formatTimeLimitStr(job.TimeLimit))
 	v.writeIndentedField(&d, "Time Used", job.TimeUsed)
 	if job.StateReason != "" && job.StateReason != "None" {
 		stateColor := dao.GetJobStateColor(job.State)
@@ -1142,6 +1142,21 @@ func (v *JobsView) writeIndentedField(d *strings.Builder, label, value string) {
 	if value != "" {
 		fmt.Fprintf(d, "  [yellow]%-11s[white] %s\n", label+":", value)
 	}
+}
+
+// formatTimeLimitStr converts a time limit string (minutes) to human-readable.
+func formatTimeLimitStr(limit string) string {
+	if limit == "" || limit == "0" {
+		return ""
+	}
+	if strings.Contains(limit, ":") || strings.ContainsAny(limit, "dhms") {
+		return limit
+	}
+	var minutes int
+	if _, err := fmt.Sscanf(limit, "%d", &minutes); err == nil && minutes > 0 {
+		return formatTimeLimit(minutes)
+	}
+	return limit
 }
 
 // expandJobPattern expands SLURM filename patterns (%j, %x, etc.) for display

--- a/internal/views/jobs.go
+++ b/internal/views/jobs.go
@@ -1030,6 +1030,7 @@ func (v *JobsView) formatJobDetails(job *dao.Job) string {
 	v.writeField(&d, "Partition", job.Partition)
 	v.writeField(&d, "QoS", job.QOS)
 	v.writeField(&d, "Priority", fmt.Sprintf("%.0f", job.Priority))
+	v.writeField(&d, "Cluster", job.Cluster)
 	d.WriteString("\n")
 
 	// Scheduling
@@ -1043,6 +1044,14 @@ func (v *JobsView) formatJobDetails(job *dao.Job) string {
 	}
 	v.writeIndentedField(&d, "Time Limit", job.TimeLimit)
 	v.writeIndentedField(&d, "Time Used", job.TimeUsed)
+	if job.StateReason != "" {
+		stateColor := dao.GetJobStateColor(job.State)
+		v.writeIndentedField(&d, "Reason", fmt.Sprintf("[%s]%s[white]", stateColor, job.StateReason))
+	}
+	v.writeIndentedField(&d, "Dependency", job.Dependency)
+	if job.Requeue {
+		v.writeIndentedField(&d, "Requeue", "Yes")
+	}
 	d.WriteString("\n")
 
 	// Resources
@@ -1053,17 +1062,63 @@ func (v *JobsView) formatJobDetails(job *dao.Job) string {
 	v.writeIndentedField(&d, "TRES Alloc", job.TRESAlloc)
 	v.writeIndentedField(&d, "TRES/Node", job.TRESPerNode)
 	v.writeIndentedField(&d, "GRES", job.GRESDetail)
+	if job.CPUs > 0 {
+		v.writeIndentedField(&d, "CPUs", fmt.Sprintf("%d", job.CPUs))
+	}
+	if job.CPUsPerTask > 0 {
+		v.writeIndentedField(&d, "CPUs/Task", fmt.Sprintf("%d", job.CPUsPerTask))
+	}
+	if job.Tasks > 0 {
+		v.writeIndentedField(&d, "Tasks", fmt.Sprintf("%d", job.Tasks))
+	}
+	if job.TasksPerNode > 0 {
+		v.writeIndentedField(&d, "Tasks/Node", fmt.Sprintf("%d", job.TasksPerNode))
+	}
+	if job.MemoryPerNode > 0 {
+		if job.MemoryPerNode >= 1024 && job.MemoryPerNode%1024 == 0 {
+			v.writeIndentedField(&d, "Mem/Node", fmt.Sprintf("%dG", job.MemoryPerNode/1024))
+		} else {
+			v.writeIndentedField(&d, "Mem/Node", fmt.Sprintf("%dM", job.MemoryPerNode))
+		}
+	}
+	if job.MemoryPerCPU > 0 {
+		if job.MemoryPerCPU >= 1024 && job.MemoryPerCPU%1024 == 0 {
+			v.writeIndentedField(&d, "Mem/CPU", fmt.Sprintf("%dG", job.MemoryPerCPU/1024))
+		} else {
+			v.writeIndentedField(&d, "Mem/CPU", fmt.Sprintf("%dM", job.MemoryPerCPU))
+		}
+	}
+	v.writeIndentedField(&d, "TRES/Task", job.TRESPerTask)
+	v.writeIndentedField(&d, "Batch Host", job.BatchHost)
+	v.writeIndentedField(&d, "Features", job.Features)
+	v.writeIndentedField(&d, "Licenses", job.Licenses)
 	d.WriteString("\n")
 
 	// Paths
 	d.WriteString("[teal]Paths[white]\n")
 	v.writeIndentedField(&d, "Work Dir", job.WorkingDir)
 	v.writeIndentedField(&d, "Command", job.Command)
-	if job.StdOut != "" {
+	if job.StdOutExpanded != "" {
+		v.writeIndentedField(&d, "StdOut", job.StdOutExpanded)
+	} else if job.StdOut != "" {
 		v.writeIndentedField(&d, "StdOut", expandJobPattern(job.StdOut, job))
 	}
-	if job.StdErr != "" {
+	if job.StdErrExpanded != "" {
+		v.writeIndentedField(&d, "StdErr", job.StdErrExpanded)
+	} else if job.StdErr != "" {
 		v.writeIndentedField(&d, "StdErr", expandJobPattern(job.StdErr, job))
+	}
+	v.writeIndentedField(&d, "Submit Line", job.SubmitLine)
+
+	// Notes
+	if job.Comment != "" || job.AdminComment != "" || job.Wckey != "" || job.MailUser != "" || job.Reservation != "" {
+		d.WriteString("\n")
+		d.WriteString("[teal]Notes[white]\n")
+		v.writeIndentedField(&d, "Comment", job.Comment)
+		v.writeIndentedField(&d, "Admin Note", job.AdminComment)
+		v.writeIndentedField(&d, "Wckey", job.Wckey)
+		v.writeIndentedField(&d, "Mail User", job.MailUser)
+		v.writeIndentedField(&d, "Reservation", job.Reservation)
 	}
 
 	// Exit

--- a/internal/views/jobs.go
+++ b/internal/views/jobs.go
@@ -1133,14 +1133,14 @@ func (v *JobsView) formatJobDetails(job *dao.Job) string {
 // writeField writes a field only if the value is non-empty
 func (v *JobsView) writeField(d *strings.Builder, label, value string) {
 	if value != "" && value != "0" {
-		d.WriteString(fmt.Sprintf("[yellow]%s:[white] %s\n", label, value))
+		fmt.Fprintf(d, "[yellow]%s:[white] %s\n", label, value)
 	}
 }
 
 // writeIndentedField writes an indented field only if the value is non-empty
 func (v *JobsView) writeIndentedField(d *strings.Builder, label, value string) {
 	if value != "" {
-		d.WriteString(fmt.Sprintf("  [yellow]%-11s[white] %s\n", label+":", value))
+		fmt.Fprintf(d, "  [yellow]%-11s[white] %s\n", label+":", value)
 	}
 }
 

--- a/internal/views/jobs.go
+++ b/internal/views/jobs.go
@@ -1002,76 +1002,91 @@ func (v *JobsView) showJobDetails() {
 	}()
 }
 
-// formatJobDetails formats job details for display
+// formatJobDetails formats job details for display with organized sections
 func (v *JobsView) formatJobDetails(job *dao.Job) string {
-	var details strings.Builder
+	var d strings.Builder
 
-	details.WriteString(fmt.Sprintf("[yellow]Job ID:[white] %s\n", job.ID))
-	details.WriteString(fmt.Sprintf("[yellow]Name:[white] %s\n", job.Name))
-	details.WriteString(fmt.Sprintf("[yellow]User:[white] %s\n", job.User))
-	details.WriteString(fmt.Sprintf("[yellow]Account:[white] %s\n", job.Account))
-
+	// Header with state indicator
 	stateColor := dao.GetJobStateColor(job.State)
-	details.WriteString(fmt.Sprintf("[yellow]State:[white] [%s]%s[white]\n", stateColor, job.State))
-
-	details.WriteString(fmt.Sprintf("[yellow]Partition:[white] %s\n", job.Partition))
-	details.WriteString(fmt.Sprintf("[yellow]QOS:[white] %s\n", job.QOS))
-	details.WriteString(fmt.Sprintf("[yellow]Priority:[white] %.0f\n", job.Priority))
-	details.WriteString(fmt.Sprintf("[yellow]Node Count:[white] %d\n", job.NodeCount))
-
-	if job.NodeList != "" {
-		details.WriteString(fmt.Sprintf("[yellow]Node List:[white] %s\n", job.NodeList))
+	stateIcon := "●"
+	switch {
+	case strings.Contains(job.State, "RUNNING"):
+		stateIcon = "▶"
+	case strings.Contains(job.State, "PENDING"):
+		stateIcon = "⏳"
+	case strings.Contains(job.State, "COMPLETED"):
+		stateIcon = "✓"
+	case strings.Contains(job.State, "FAILED"):
+		stateIcon = "✗"
+	case strings.Contains(job.State, "CANCEL"):
+		stateIcon = "⊘"
 	}
+	d.WriteString(fmt.Sprintf("[%s]%s %s[white]  [yellow]%s[white] (%s)\n", stateColor, stateIcon, job.State, job.Name, job.ID))
+	d.WriteString("[gray]" + strings.Repeat("─", 60) + "[white]\n")
 
-	details.WriteString(fmt.Sprintf("[yellow]Time Limit:[white] %s\n", job.TimeLimit))
-	details.WriteString(fmt.Sprintf("[yellow]Time Used:[white] %s\n", job.TimeUsed))
+	// Identity
+	v.writeField(&d, "User", job.User)
+	v.writeField(&d, "Account", job.Account)
+	v.writeField(&d, "Partition", job.Partition)
+	v.writeField(&d, "QoS", job.QOS)
+	v.writeField(&d, "Priority", fmt.Sprintf("%.0f", job.Priority))
+	d.WriteString("\n")
 
-	details.WriteString(fmt.Sprintf("[yellow]Submit Time:[white] %s\n", job.SubmitTime.Format("2006-01-02 15:04:05")))
-
+	// Scheduling
+	d.WriteString("[teal]Scheduling[white]\n")
+	d.WriteString(fmt.Sprintf("  [yellow]Submitted:[white]  %s\n", job.SubmitTime.Format("2006-01-02 15:04:05")))
 	if job.StartTime != nil {
-		details.WriteString(fmt.Sprintf("[yellow]Start Time:[white] %s\n", job.StartTime.Format("2006-01-02 15:04:05")))
+		d.WriteString(fmt.Sprintf("  [yellow]Started:[white]    %s\n", job.StartTime.Format("2006-01-02 15:04:05")))
 	}
-
 	if job.EndTime != nil {
-		details.WriteString(fmt.Sprintf("[yellow]End Time:[white] %s\n", job.EndTime.Format("2006-01-02 15:04:05")))
+		d.WriteString(fmt.Sprintf("  [yellow]End:[white]        %s\n", job.EndTime.Format("2006-01-02 15:04:05")))
 	}
+	v.writeIndentedField(&d, "Time Limit", job.TimeLimit)
+	v.writeIndentedField(&d, "Time Used", job.TimeUsed)
+	d.WriteString("\n")
 
-	details.WriteString(fmt.Sprintf("[yellow]Working Dir:[white] %s\n", job.WorkingDir))
+	// Resources
+	d.WriteString("[teal]Resources[white]\n")
+	v.writeIndentedField(&d, "Nodes", fmt.Sprintf("%d", job.NodeCount))
+	v.writeIndentedField(&d, "Node List", job.NodeList)
+	v.writeIndentedField(&d, "TRES Req", job.TRESReq)
+	v.writeIndentedField(&d, "TRES Alloc", job.TRESAlloc)
+	v.writeIndentedField(&d, "TRES/Node", job.TRESPerNode)
+	v.writeIndentedField(&d, "GRES", job.GRESDetail)
+	d.WriteString("\n")
 
-	// Note: SLURM API doesn't return the actual command/script, only job metadata
-	// For job details, see StdOut file path below
-	if job.Command != "" {
-		details.WriteString(fmt.Sprintf("[yellow]Command:[white] %s\n", job.Command))
-	}
-
-	if job.TRESReq != "" {
-		details.WriteString(fmt.Sprintf("[yellow]TRES Requested:[white] %s\n", job.TRESReq))
-	}
-	if job.TRESAlloc != "" {
-		details.WriteString(fmt.Sprintf("[yellow]TRES Allocated:[white] %s\n", job.TRESAlloc))
-	}
-	if job.TRESPerNode != "" {
-		details.WriteString(fmt.Sprintf("[yellow]TRES/Node:[white] %s\n", job.TRESPerNode))
-	}
-	if job.GRESDetail != "" {
-		details.WriteString(fmt.Sprintf("[yellow]GRES Detail:[white] %s\n", job.GRESDetail))
-	}
-
+	// Paths
+	d.WriteString("[teal]Paths[white]\n")
+	v.writeIndentedField(&d, "Work Dir", job.WorkingDir)
+	v.writeIndentedField(&d, "Command", job.Command)
 	if job.StdOut != "" {
-		stdout := expandJobPattern(job.StdOut, job)
-		details.WriteString(fmt.Sprintf("[yellow]StdOut:[white] %s\n", stdout))
+		v.writeIndentedField(&d, "StdOut", expandJobPattern(job.StdOut, job))
 	}
-
 	if job.StdErr != "" {
-		stderr := expandJobPattern(job.StdErr, job)
-		details.WriteString(fmt.Sprintf("[yellow]StdErr:[white] %s\n", stderr))
+		v.writeIndentedField(&d, "StdErr", expandJobPattern(job.StdErr, job))
 	}
 
+	// Exit
 	if job.ExitCode != nil {
-		details.WriteString(fmt.Sprintf("[yellow]Exit Code:[white] %d\n", *job.ExitCode))
+		d.WriteString("\n")
+		d.WriteString(fmt.Sprintf("[yellow]Exit Code:[white] %d\n", *job.ExitCode))
 	}
 
-	return details.String()
+	return d.String()
+}
+
+// writeField writes a field only if the value is non-empty
+func (v *JobsView) writeField(d *strings.Builder, label, value string) {
+	if value != "" && value != "0" {
+		d.WriteString(fmt.Sprintf("[yellow]%s:[white] %s\n", label, value))
+	}
+}
+
+// writeIndentedField writes an indented field only if the value is non-empty
+func (v *JobsView) writeIndentedField(d *strings.Builder, label, value string) {
+	if value != "" {
+		d.WriteString(fmt.Sprintf("  [yellow]%-11s[white] %s\n", label+":", value))
+	}
 }
 
 // expandJobPattern expands SLURM filename patterns (%j, %x, etc.) for display

--- a/internal/views/jobs.go
+++ b/internal/views/jobs.go
@@ -1044,12 +1044,27 @@ func (v *JobsView) formatJobDetails(job *dao.Job) string {
 		details.WriteString(fmt.Sprintf("[yellow]Command:[white] %s\n", job.Command))
 	}
 
+	if job.TRESReq != "" {
+		details.WriteString(fmt.Sprintf("[yellow]TRES Requested:[white] %s\n", job.TRESReq))
+	}
+	if job.TRESAlloc != "" {
+		details.WriteString(fmt.Sprintf("[yellow]TRES Allocated:[white] %s\n", job.TRESAlloc))
+	}
+	if job.TRESPerNode != "" {
+		details.WriteString(fmt.Sprintf("[yellow]TRES/Node:[white] %s\n", job.TRESPerNode))
+	}
+	if job.GRESDetail != "" {
+		details.WriteString(fmt.Sprintf("[yellow]GRES Detail:[white] %s\n", job.GRESDetail))
+	}
+
 	if job.StdOut != "" {
-		details.WriteString(fmt.Sprintf("[yellow]StdOut:[white] %s\n", job.StdOut))
+		stdout := expandJobPattern(job.StdOut, job)
+		details.WriteString(fmt.Sprintf("[yellow]StdOut:[white] %s\n", stdout))
 	}
 
 	if job.StdErr != "" {
-		details.WriteString(fmt.Sprintf("[yellow]StdErr:[white] %s\n", job.StdErr))
+		stderr := expandJobPattern(job.StdErr, job)
+		details.WriteString(fmt.Sprintf("[yellow]StdErr:[white] %s\n", stderr))
 	}
 
 	if job.ExitCode != nil {
@@ -1057,6 +1072,20 @@ func (v *JobsView) formatJobDetails(job *dao.Job) string {
 	}
 
 	return details.String()
+}
+
+// expandJobPattern expands SLURM filename patterns (%j, %x, etc.) for display
+func expandJobPattern(pattern string, job *dao.Job) string {
+	if !strings.Contains(pattern, "%") {
+		return pattern
+	}
+	r := strings.NewReplacer(
+		"%%", "%",
+		"%j", job.ID, "%J", job.ID,
+		"%A", job.ArrayJobID, "%a", job.ArrayTaskID,
+		"%x", job.Name, "%u", job.User, "%N", job.NodeList,
+	)
+	return r.Replace(pattern)
 }
 
 // showJobOutput shows job output logs using the new output viewer


### PR DESCRIPTION
## Summary

Comprehensive overhaul of the job detail modal and GRES handling.

### Job detail modal redesign
Organized into sections with visual separators, state icons, and only populated fields shown:
- **Identity**: user, account, partition, QoS, priority, cluster
- **Scheduling**: submit/start/end times, time limit, state reason (hidden when "None"), dependency, requeue
- **Resources**: nodes, node list, TRES req/alloc/per-node, GRES detail, CPUs, CPUs/task, tasks, tasks/node, memory (formatted as G/M), batch host, features, licenses
- **Paths**: working dir, command, stdout/stderr (uses SLURM's expanded paths with fallback), submit line
- **Notes**: comment, admin comment, wckey, mail user, reservation (section only shown when any populated)
- **Exit**: exit code (when present)

### New Job struct fields (22 added)
BatchHost, Cluster, CPUs, CPUsPerTask, MemoryPerNode, MemoryPerCPU, Tasks, TasksPerNode, TRESPerTask, Requeue, SubmitLine, StdOutExpanded, StdErrExpanded, Dependency, Licenses, Reservation, Features, Comment, AdminComment, Wckey, MailUser, StateReason

### GRES submission fix
- `buildTRESPerNode` correctly adds `gres/` prefix only to GRES items (colon notation like `gpu:1`), not standard TRES (equals notation like `cpu=4`)
- Handles multiple GRES: `gpu:2,shard:4` → `gres/gpu:2,gres/shard:4`
- Consolidates GPUs and Gres field handling

### Other fixes
- Map Account and QoS from SLURM API (were hardcoded to empty strings)
- Use SLURM's `stdout_expanded`/`stderr_expanded` instead of expanding patterns ourselves

## Test plan

- [ ] `go test ./internal/...` passes
- [ ] Press Enter on GPU job → shows all sections with TRES, GRES, memory, batch host
- [ ] Press Enter on non-GPU job → GRES/GPU fields hidden, other sections show
- [ ] Account and QoS display correctly
- [ ] StdOut shows full expanded path
- [ ] StateReason "None" is hidden
- [ ] Submit GPU job via s9s with `gres: gpu:1` → succeeds