### PR TITLE
chore: replace Trivy with Dependabot for dependency scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "npm"
+    directory: "/test/e2e"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "ci"
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,21 +143,8 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
-      with:
-        scan-type: 'fs'
-        scan-ref: '.'
-        format: 'sarif'
-        output: 'trivy-results.sarif'
-
-    - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v3
-      with:
-        sarif_file: 'trivy-results.sarif'
-
     - name: Run gosec security scanner
-      uses: securego/gosec@master
+      uses: securego/gosec@v2
       continue-on-error: true  # Allow to fail - issues will be fixed in follow-up PRs
       with:
         args: './...'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
         submodules: recursive
 
     - name: Run gosec security scanner
-      uses: securego/gosec@v2
+      uses: securego/gosec@v2.25.0
       continue-on-error: true  # Allow to fail - issues will be fixed in follow-up PRs
       with:
         args: './...'


### PR DESCRIPTION
## Summary

Replace `aquasecurity/trivy-action@master` with GitHub Dependabot for vulnerability scanning.

### Why
- Trivy action was pinned to `@master` — vulnerable to supply chain attacks (the action was compromised in the March 2025 tj-actions incident)
- Dependabot runs in GitHub's infrastructure with no third-party action exposure
- Covers Go modules, npm, and GitHub Actions versions

### Changes
- Add `.github/dependabot.yml` with weekly scans for gomod, npm, and github-actions
- Remove Trivy scanner and SARIF upload from CI workflow
- Pin gosec from `@master` to `@v2`

### What Dependabot will do
- Auto-create PRs to bump vulnerable dependencies
- Weekly check schedule
- Labels PRs with `dependencies` or `ci`

## Test plan

- [ ] CI passes without Trivy job
- [ ] Dependabot starts creating PRs for known vulnerabilities (x/crypto, mapstructure)
- [ ] gosec still runs in Security Scan job