### PR TITLE
chore: run gofmt and gate formatting in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,15 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
 
+    - name: Check formatting
+      run: |
+        unformatted=$(gofmt -l ./internal/ ./cmd/ ./pkg/ 2>/dev/null)
+        if [ -n "$unformatted" ]; then
+          echo "::error::The following files are not formatted. Run 'gofmt -w ./internal/ ./cmd/ ./pkg/' to fix."
+          echo "$unformatted"
+          exit 1
+        fi
+
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v9
       with:

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -55,9 +55,9 @@ type S9s struct {
 	alertsBadge     *components.AlertsBadge
 	notificationMgr *notifications.NotificationManager
 
-	userPrefs      *preferences.UserPreferences
-	layoutManager  *layouts.LayoutManager
-	streamManager  *streaming.StreamManager
+	userPrefs     *preferences.UserPreferences
+	layoutManager *layouts.LayoutManager
+	streamManager *streaming.StreamManager
 
 	// Main layout
 	mainLayout   *tview.Flex

--- a/internal/dao/slurm_adapter.go
+++ b/internal/dao/slurm_adapter.go
@@ -441,7 +441,6 @@ func convertJobSubmissionToJobCreate(job *JobSubmission) *slurm.JobCreate {
 		jc.TasksPerNode = ptrInt32(int32(job.NTasksPerNode))
 	}
 
-
 	// Hold
 	if job.Hold {
 		jc.Hold = ptrBool(true)
@@ -1559,30 +1558,30 @@ func convertJob(job *slurm.Job) *Job {
 	}
 
 	return &Job{
-		ID:         jobID,
-		Name:       name,
-		User:       username,
-		Account:    derefString(job.Account),
-		Partition:  partition,
-		State:      state,
-		Priority:   priority,
-		QOS:        derefString(job.QoS),
-		NodeCount:  nodeCount,
-		TimeLimit:  timeLimit,
-		TimeUsed:   "",
-		SubmitTime: job.SubmitTime,
-		StartTime:  startTime,
-		EndTime:    endTime,
-		NodeList:   nodeList,
-		Command:    command,
-		WorkingDir: workingDir,
-		StdOut:      derefString(job.StandardOutput),
-		StdErr:      derefString(job.StandardError),
-		ArrayJobID:  derefUint32String(job.ArrayJobID),
-		ArrayTaskID: derefUint32String(job.ArrayTaskID),
-		TRESReq:     derefString(job.TRESReqStr),
-		TRESAlloc:   derefString(job.TRESAllocStr),
-		TRESPerNode: derefString(job.TRESPerNode),
+		ID:             jobID,
+		Name:           name,
+		User:           username,
+		Account:        derefString(job.Account),
+		Partition:      partition,
+		State:          state,
+		Priority:       priority,
+		QOS:            derefString(job.QoS),
+		NodeCount:      nodeCount,
+		TimeLimit:      timeLimit,
+		TimeUsed:       "",
+		SubmitTime:     job.SubmitTime,
+		StartTime:      startTime,
+		EndTime:        endTime,
+		NodeList:       nodeList,
+		Command:        command,
+		WorkingDir:     workingDir,
+		StdOut:         derefString(job.StandardOutput),
+		StdErr:         derefString(job.StandardError),
+		ArrayJobID:     derefUint32String(job.ArrayJobID),
+		ArrayTaskID:    derefUint32String(job.ArrayTaskID),
+		TRESReq:        derefString(job.TRESReqStr),
+		TRESAlloc:      derefString(job.TRESAllocStr),
+		TRESPerNode:    derefString(job.TRESPerNode),
 		GRESDetail:     strings.Join(job.GRESDetail, ", "),
 		ExitCode:       exitCode,
 		BatchHost:      derefString(job.BatchHost),

--- a/internal/dao/types.go
+++ b/internal/dao/types.go
@@ -7,32 +7,32 @@ import (
 
 // Job represents a SLURM job
 type Job struct {
-	ID         string
-	Name       string
-	User       string
-	Account    string
-	Partition  string
-	State      string
-	Priority   float64
-	QOS        string
-	NodeCount  int
-	TimeLimit  string
-	TimeUsed   string
-	SubmitTime time.Time
-	StartTime  *time.Time
-	EndTime    *time.Time
-	NodeList   string
-	Command    string
-	WorkingDir string
-	StdOut       string
-	StdErr       string
-	ArrayJobID   string // Master job ID for array jobs (empty if not array)
-	ArrayTaskID  string // Task ID within the array (empty if not array)
-	TRESReq      string // Requested TRES (e.g., "cpu=1,mem=2G,gres/gpu=1")
-	TRESAlloc    string // Allocated TRES
-	TRESPerNode  string // TRES per node (e.g., "gres/gpu:1")
-	GRESDetail   string // GRES detail (e.g., "gpu:1(IDX:0)")
-	ExitCode     *int
+	ID          string
+	Name        string
+	User        string
+	Account     string
+	Partition   string
+	State       string
+	Priority    float64
+	QOS         string
+	NodeCount   int
+	TimeLimit   string
+	TimeUsed    string
+	SubmitTime  time.Time
+	StartTime   *time.Time
+	EndTime     *time.Time
+	NodeList    string
+	Command     string
+	WorkingDir  string
+	StdOut      string
+	StdErr      string
+	ArrayJobID  string // Master job ID for array jobs (empty if not array)
+	ArrayTaskID string // Task ID within the array (empty if not array)
+	TRESReq     string // Requested TRES (e.g., "cpu=1,mem=2G,gres/gpu=1")
+	TRESAlloc   string // Allocated TRES
+	TRESPerNode string // TRES per node (e.g., "gres/gpu:1")
+	GRESDetail  string // GRES detail (e.g., "gpu:1(IDX:0)")
+	ExitCode    *int
 
 	// Additional detail fields (populated from SLURM API)
 	BatchHost      string // Node running the batch script

--- a/internal/layouts/layout_manager_test.go
+++ b/internal/layouts/layout_manager_test.go
@@ -113,17 +113,17 @@ func newStubWidget(id string) *stubWidget {
 	return &stubWidget{id: id, prim: tview.NewBox()}
 }
 
-func (w *stubWidget) ID() string                  { return w.id }
-func (w *stubWidget) Name() string                { return w.id }
-func (w *stubWidget) Description() string          { return "" }
-func (w *stubWidget) Type() WidgetType             { return "test" }
-func (w *stubWidget) Render() tview.Primitive      { return w.prim }
-func (w *stubWidget) Update() error                { return nil }
-func (w *stubWidget) Configure() error             { return nil }
-func (w *stubWidget) MinSize() (int, int)          { return 0, 0 }
-func (w *stubWidget) MaxSize() (int, int)          { return 0, 0 }
-func (w *stubWidget) OnResize(_, _ int)            {}
-func (w *stubWidget) OnFocus(_ bool)               {}
+func (w *stubWidget) ID() string              { return w.id }
+func (w *stubWidget) Name() string            { return w.id }
+func (w *stubWidget) Description() string     { return "" }
+func (w *stubWidget) Type() WidgetType        { return "test" }
+func (w *stubWidget) Render() tview.Primitive { return w.prim }
+func (w *stubWidget) Update() error           { return nil }
+func (w *stubWidget) Configure() error        { return nil }
+func (w *stubWidget) MinSize() (int, int)     { return 0, 0 }
+func (w *stubWidget) MaxSize() (int, int)     { return 0, 0 }
+func (w *stubWidget) OnResize(_, _ int)       {}
+func (w *stubWidget) OnFocus(_ bool)          {}
 
 func TestBuildBandFlex_SingleWidget(t *testing.T) {
 	lm := NewLayoutManager(tview.NewApplication())

--- a/internal/layouts/widgets.go
+++ b/internal/layouts/widgets.go
@@ -192,4 +192,3 @@ func (w *MetricsWidget) startAutoUpdate() {
 		}
 	}()
 }
-

--- a/internal/preferences/preferences.go
+++ b/internal/preferences/preferences.go
@@ -31,7 +31,7 @@ func NewUserPreferences(configPath string) (*UserPreferences, error) {
 	up := &UserPreferences{
 		mu:         &sync.RWMutex{},
 		configPath: configPath,
-		onChange:    make([]func(), 0),
+		onChange:   make([]func(), 0),
 	}
 
 	// Set defaults

--- a/internal/ui/widgets/config_manager.go
+++ b/internal/ui/widgets/config_manager.go
@@ -880,4 +880,3 @@ func (cm *ConfigManager) HasChanges() bool {
 func (cm *ConfigManager) IsSidebarFocused() bool {
 	return cm.sidebar.HasFocus()
 }
-

--- a/internal/update/updater.go
+++ b/internal/update/updater.go
@@ -148,9 +148,9 @@ func (u *Updater) newSelfUpdater(opts UpdateOptions) (*selfupdate.Updater, error
 
 	updater, err := selfupdate.NewUpdater(selfupdate.Config{
 		Source:     source,
-		Filters:   nil, // go-selfupdate matches goreleaser archive names automatically
-		OS:        runtime.GOOS,
-		Arch:      runtime.GOARCH,
+		Filters:    nil, // go-selfupdate matches goreleaser archive names automatically
+		OS:         runtime.GOOS,
+		Arch:       runtime.GOARCH,
 		Prerelease: opts.PreRelease,
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary

Format 8 files that had formatting drift and add a gofmt check to the CI lint job.

The check runs before golangci-lint and fails the build with a clear error listing unformatted files.

## Test plan

- [ ] CI lint job passes (all files already formatted)
- [ ] Submit a PR with unformatted Go code → lint job fails with file list