### PR TITLE
docs: update all documentation for post-v0.8.0 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Job output streaming** — press `o` to view job output, `t` for real-time tail-f streaming, `s` to switch stdout/stderr, `e` to export (#157)
+- **Array job output patterns** — `%A` (array master ID) and `%a` (array task ID) now expanded in output file paths (#158)
+- **Enriched job detail modal** — shows TRES requested/allocated, GRES detail with GPU index, batch host, cluster, memory, CPUs, tasks, submit command line, and 22 additional SLURM API fields. State icons and organized sections (#159)
+- **GRES submission fix** — `gres: gpu:1` correctly mapped to `tres_per_node: gres/gpu:1` for SLURM REST API (#159)
+- **Dependabot** for dependency scanning, replacing Trivy (#163)
+- **gofmt gate in CI** — formatting enforced in lint job (#180)
+
+### Changed
+
+- **Go minimum version** — bumped to Go 1.25 (Go 1.24 no longer receives security patches)
+- **CI test matrix** — tests Go 1.25 and 1.26 (was 1.23 and 1.24)
+
+### Fixed
+
+- **Dashboard Analytics and Health Check modals** not responding to ESC/R (#160)
+- **Node operations when grouped** — Enter/drain/resume/SSH now work on indented nodes; Enter on group header toggles expansion (#161)
+- **Sort breaks grouping** — sort and group are now mutually exclusive (#161)
+- **Health checks random order** — checks display in stable alphabetical order on each refresh (#162)
+
 ## [0.8.0] - 2026-03-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ s9s provides a terminal interface for managing SLURM clusters, inspired by the p
 
 ### Prerequisites
 
-- Go 1.24 or higher
+- Go 1.25 or higher
 - Access to a SLURM cluster (or use mock mode)
 - Terminal with 256 color support
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Recent Changes
 
+### Post-0.8.0 (Unreleased)
+
+Job output viewer, enriched job details, and grouped node fixes:
+
+- **Job Output Streaming**: Press `o` to view job output, `t` for real-time tail-f streaming, `s` to switch stdout/stderr, `e` to export
+- **Array Job Output Patterns**: `%A` and `%a` expanded in output file paths
+- **Enriched Job Detail Modal**: TRES requested/allocated, GRES with GPU index, batch host, cluster, memory, submit command line, and 22 additional SLURM fields
+- **GRES Submission Fix**: `gres: gpu:1` correctly mapped to `tres_per_node: gres/gpu:1`
+- **Go 1.25 Minimum**: Go 1.24 no longer receives security patches; CI tests Go 1.25 and 1.26
+- **Bug Fixes**: Dashboard modal ESC/R, node operations when grouped, sort/group mutual exclusivity, health checks stable ordering
+- **Dependabot**: Replaces Trivy for dependency scanning
+- **gofmt CI Gate**: Formatting enforced in lint job
+
 ### Version 0.8.0 (2026-03-30)
 
 Keyboard shortcut overhaul, layout system, and configuration consolidation:

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -28,7 +28,7 @@ By participating in this project, you agree to abide by our Code of Conduct:
 
 ### Prerequisites
 
-- Go 1.24 or higher
+- Go 1.25 or higher
 - Git
 - Make (optional but recommended)
 - golangci-lint (for linting)

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -13,7 +13,7 @@ This guide covers everything you need to set up your development environment for
 
 ### Go Installation
 
-1. **Go 1.24 or higher**
+1. **Go 1.25 or higher**
    ```bash
    # Check version
    go version
@@ -23,8 +23,8 @@ This guide covers everything you need to set up your development environment for
    brew install go
 
    # Linux
-   wget https://go.dev/dl/go1.24.4.linux-amd64.tar.gz
-   sudo tar -C /usr/local -xzf go1.24.4.linux-amd64.tar.gz
+   wget https://go.dev/dl/go1.25.0.linux-amd64.tar.gz
+   sudo tar -C /usr/local -xzf go1.25.0.linux-amd64.tar.gz
    ```
 
 ### Development Tools

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -5,7 +5,7 @@ s9s can be installed using several methods. Choose the one that best fits your e
 ## System Requirements
 
 - **Operating System**: Linux, macOS, or Windows
-- **Go Version**: 1.24 or higher (for building from source)
+- **Go Version**: 1.25 or higher (for building from source)
 - **Terminal**: 256 color support recommended
 - **SLURM REST API**: A running `slurmrestd` instance — see [Troubleshooting](../guides/troubleshooting.md#cannot-connect-to-slurm-cluster) if connection fails ([mock mode](../guides/mock-mode.md) available for testing without SLURM)
 

--- a/docs/user-guide/keyboard-shortcuts.md
+++ b/docs/user-guide/keyboard-shortcuts.md
@@ -72,6 +72,17 @@ These shortcuts work from any view:
 | `o/O` | View output | View job output/logs |
 | `d/D` | View dependencies | Show job dependency graph |
 
+### Job Output Viewer
+| Key | Action | Description |
+|-----|--------|-------------|
+| `o/O` | Open viewer | Open job output viewer for selected job |
+| `t` | Toggle stream | Start/stop real-time streaming (tail -f) |
+| `s` | Switch output | Toggle between stdout and stderr |
+| `r` | Refresh | Reload output from file |
+| `a` | Auto-scroll | Toggle auto-scroll on new content |
+| `e` | Export | Export output to file (text/JSON/CSV/markdown) |
+| `ESC` | Close | Close the output viewer |
+
 ### Batch Operations
 | Key | Action | Description |
 |-----|--------|-------------|

--- a/docs/user-guide/views/jobs.md
+++ b/docs/user-guide/views/jobs.md
@@ -55,6 +55,12 @@ Shows detailed information about the selected job:
 - Working directory and command
 - Standard output/error paths
 
+The detail modal shows comprehensive job information including:
+- TRES (Trackable Resources) requested and allocated
+- GRES details with GPU index assignments
+- Batch host, cluster, memory, submit command line
+- Expanded output file paths (%j → actual job ID)
+
 ### Submit New Job
 **Shortcut**: `s`
 
@@ -98,6 +104,12 @@ Opens the job output viewer with:
 - Standard output (stdout)
 - Standard error (stderr)
 - Real-time log streaming for running jobs
+
+The output viewer supports:
+- **Real-time streaming** — press `t` to watch output as it's written (like `tail -f`)
+- **Stdout/stderr switching** — press `s` to toggle between output streams
+- **Export** — press `e` to save output in text, JSON, CSV, or markdown format
+- **Auto-scroll** — press `a` to follow new content automatically
 
 See [Job Streaming Guide](../../guides/job-streaming.md) for details.
 

--- a/docs/user-guide/views/nodes.md
+++ b/docs/user-guide/views/nodes.md
@@ -228,6 +228,8 @@ When grouped:
 - Groups show summary counts
 - Expand groups to see individual nodes
 
+> **Note:** Sorting and grouping are mutually exclusive — enabling grouping clears the active sort, and sorting clears the grouping. All node operations (Enter for details, `d` for drain, `r` for resume, `s` for SSH) work correctly when nodes are grouped.
+
 **Example grouped view:**
 ```
 ▼ Partition: gpu [8 nodes]


### PR DESCRIPTION
## Summary

Comprehensive doc update covering all changes since v0.8.0 (14 issues fixed across 9 files).

### Changes
- Go 1.24 → 1.25 in README, installation, setup, contributing docs
- Job Output Viewer keybindings section added to keyboard shortcuts
- Job detail modal TRES/GRES description added to jobs view docs
- Streaming, stdout/stderr switching, export documented for output viewer
- Sort/group mutual exclusivity documented for nodes view
- CHANGELOG.md Unreleased section with all post-v0.8.0 changes
- docs/about/changelog.md summary updated

## Test plan

- [ ] Docs only, no code changes