### PR TITLE
fix: add testing.Short() skips so tests pass without external services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ GOMOD=$(GOCMD) mod
 TEST_TIMEOUT=30m
 INTEGRATION_TEST_TIMEOUT=45m
 
-.PHONY: all build clean test test-unit test-integration test-performance test-ssh test-streaming coverage bench lint fmt vet tidy deps install uninstall run dev version help
+.PHONY: all build clean test test-local test-unit test-integration test-performance test-ssh test-streaming coverage bench lint fmt vet tidy deps install uninstall run dev version help
 
 # Default target
 all: clean deps test build
@@ -69,6 +69,11 @@ deps-update:
 
 # Run all tests
 test: test-unit test-integration
+
+# Run tests locally (skips tests needing external services like SSH agent)
+test-local:
+	@echo "Running tests in short mode (no external services required)..."
+	$(GOTEST) -short -timeout $(TEST_TIMEOUT) ./...
 
 # Run unit tests only
 test-unit:

--- a/test/ssh/key_manager_test.go
+++ b/test/ssh/key_manager_test.go
@@ -12,6 +12,10 @@ import (
 )
 
 func TestKeyManager(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSH test in short mode")
+	}
+
 	// Create temporary SSH directory
 	tempDir := t.TempDir()
 	sshDir := filepath.Join(tempDir, ".ssh")
@@ -253,6 +257,10 @@ func TestKeyManager(t *testing.T) {
 }
 
 func TestKeyManagerWithAgent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSH test in short mode")
+	}
+
 	// These tests require an SSH agent - skip if not available
 	if !ssh.IsAgentAvailable() {
 		t.Skip("SSH agent not available")
@@ -329,6 +337,10 @@ func TestKeyManagerWithAgent(t *testing.T) {
 }
 
 func TestAgentOperations(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSH test in short mode")
+	}
+
 	if !ssh.IsAgentAvailable() {
 		t.Skip("SSH agent not available")
 	}

--- a/test/ssh/persistence_test.go
+++ b/test/ssh/persistence_test.go
@@ -11,6 +11,10 @@ import (
 
 // TestSessionPersistence tests session persistence functionality
 func TestSessionPersistence(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSH test in short mode")
+	}
+
 	// Create temporary directory for testing
 	tempDir, err := os.MkdirTemp("", "s9s_ssh_test")
 	if err != nil {
@@ -203,6 +207,10 @@ func TestSessionPersistence(t *testing.T) {
 
 // TestSessionManagerWithPersistence tests session manager persistence integration
 func TestSessionManagerWithPersistence(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSH test in short mode")
+	}
+
 	// Create temporary directory for testing
 	tempDir, err := os.MkdirTemp("", "s9s_ssh_mgr_test")
 	if err != nil {
@@ -282,6 +290,10 @@ func TestSessionManagerWithPersistence(t *testing.T) {
 
 // TestPersistenceEdgeCases tests edge cases
 func TestPersistenceEdgeCases(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSH test in short mode")
+	}
+
 	// Test 1: Default directory
 	t.Run("DefaultDirectory", func(t *testing.T) {
 		persistence, err := ssh.NewSessionPersistence("")

--- a/test/ssh/session_manager_test.go
+++ b/test/ssh/session_manager_test.go
@@ -11,6 +11,10 @@ import (
 
 // TestSessionManager tests the SSH session manager functionality
 func TestSessionManager(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSH test in short mode")
+	}
+
 	// Create custom config for testing
 	config := &ssh.SSHConfig{
 		Username:   "testuser",
@@ -152,6 +156,10 @@ func TestSessionManager(t *testing.T) {
 
 // TestSessionManagerConfig tests configuration handling
 func TestSessionManagerConfig(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSH test in short mode")
+	}
+
 	// Test 1: Default configuration
 	t.Run("DefaultConfig", func(t *testing.T) {
 		manager, err := ssh.NewSessionManager(nil)
@@ -199,6 +207,10 @@ func TestSessionManagerConfig(t *testing.T) {
 
 // TestSessionManagerEdgeCases tests edge cases and error handling
 func TestSessionManagerEdgeCases(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSH test in short mode")
+	}
+
 	manager, err := ssh.NewSessionManager(nil)
 	if err != nil {
 		t.Fatalf("Failed to create session manager: %v", err)
@@ -264,6 +276,10 @@ func TestSessionManagerEdgeCases(t *testing.T) {
 
 // TestSessionManagerConcurrency tests concurrent operations
 func TestSessionManagerConcurrency(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSH test in short mode")
+	}
+
 	manager, err := ssh.NewSessionManager(nil)
 	if err != nil {
 		t.Fatalf("Failed to create session manager: %v", err)
@@ -364,6 +380,10 @@ func TestSessionManagerConcurrency(t *testing.T) {
 
 // TestSSHStates tests SSH session state constants
 func TestSSHStates(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSH test in short mode")
+	}
+
 	states := []ssh.SessionState{
 		ssh.SessionIdle,
 		ssh.SessionConnecting,
@@ -397,6 +417,10 @@ func TestSSHStates(t *testing.T) {
 
 // TestTunnelCreation tests SSH tunnel functionality
 func TestTunnelCreation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSH test in short mode")
+	}
+
 	manager, err := ssh.NewSessionManager(nil)
 	if err != nil {
 		t.Fatalf("Failed to create session manager: %v", err)

--- a/test/ssh/ssh_client_test.go
+++ b/test/ssh/ssh_client_test.go
@@ -10,6 +10,10 @@ import (
 
 // TestSSHClient tests the SSH client functionality
 func TestSSHClient(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSH test in short mode")
+	}
+
 	// Test 1: Create client with default config
 	t.Run("DefaultClient", func(t *testing.T) {
 		client := ssh.NewSSHClient(nil)
@@ -47,6 +51,10 @@ func TestSSHClient(t *testing.T) {
 
 // TestSSHClientArguments tests SSH argument building
 func TestSSHClientArguments(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSH test in short mode")
+	}
+
 	// This would require exposing buildSSHArgs method or testing through ExecuteCommand
 	// For now, we'll test through the public interface
 
@@ -88,6 +96,10 @@ func TestSSHClientArguments(t *testing.T) {
 
 // TestDefaultSSHConfig tests the default configuration
 func TestDefaultSSHConfig(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSH test in short mode")
+	}
+
 	config := ssh.DefaultSSHConfig()
 
 	if config.Port != 22 {
@@ -117,6 +129,10 @@ func TestDefaultSSHConfig(t *testing.T) {
 
 // TestSSHClientEdgeCases tests edge cases
 func TestSSHClientEdgeCases(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSH test in short mode")
+	}
+
 	// Test with various invalid configurations
 	t.Run("EmptyHostname", func(t *testing.T) {
 		client := ssh.NewSSHClient(nil)
@@ -160,6 +176,10 @@ func TestSSHClientEdgeCases(t *testing.T) {
 
 // TestGetNodeInfo tests node information retrieval
 func TestGetNodeInfo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSH test in short mode")
+	}
+
 	client := ssh.NewSSHClient(nil)
 	ctx := context.Background()
 

--- a/test/ssh/terminal_manager_test.go
+++ b/test/ssh/terminal_manager_test.go
@@ -12,6 +12,10 @@ import (
 
 // TestTerminalManager tests the SSH terminal manager functionality
 func TestTerminalManager(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSH test in short mode")
+	}
+
 	// Create a mock app for testing
 	app := tview.NewApplication()
 
@@ -158,6 +162,10 @@ func TestTerminalManager(t *testing.T) {
 
 // TestTerminalManagerEdgeCases tests edge cases
 func TestTerminalManagerEdgeCases(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSH test in short mode")
+	}
+
 	app := tview.NewApplication()
 	manager := ssh.NewTerminalManager(app)
 
@@ -213,6 +221,10 @@ func TestTerminalManagerEdgeCases(t *testing.T) {
 
 // TestTerminalFeatures tests specific terminal features
 func TestTerminalFeatures(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSH test in short mode")
+	}
+
 	app := tview.NewApplication()
 	manager := ssh.NewTerminalManager(app)
 
@@ -363,6 +375,10 @@ func (m *MockTerminal) GetNodeID() string {
 
 // TestSSHConnectionScenarios tests realistic SSH connection scenarios
 func TestSSHConnectionScenarios(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSH test in short mode")
+	}
+
 	app := tview.NewApplication()
 	manager := ssh.NewTerminalManager(app)
 
@@ -459,6 +475,10 @@ func TestSSHConnectionScenarios(t *testing.T) {
 
 // TestTerminalManagerConcurrency tests concurrent operations
 func TestTerminalManagerConcurrency(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSH test in short mode")
+	}
+
 	app := tview.NewApplication()
 	manager := ssh.NewTerminalManager(app)
 


### PR DESCRIPTION
## Summary

SSH tests hang locally when no SSH agent is available. Add `testing.Short()` skip guards to all 22 SSH test functions.

### Usage

```bash
# Local dev (no SSH agent/slurmrestd needed)
make test-local

# Or directly
go test -short ./...

# Full suite (CI, or when services available)
make test
```

### Changes
- Add `testing.Short()` skip to 22 test functions across 5 SSH test files
- Add `make test-local` Makefile target

## Test plan

- [ ] `make test-local` passes locally without SSH agent
- [ ] `go test -short ./...` completes in ~30s
- [ ] CI full suite still runs all tests (no `-short` flag)