### PR TITLE
docs: update refresh-rate docs for global ticker + F6 toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ clusters:
       token: "${SLURM_DEV_TOKEN}"
       apiVersion: v0.0.43
 
-refreshRate: 2s
+refreshRate: 10s
 ```
 
 ## 🎮 Key Bindings
@@ -177,6 +177,7 @@ refreshRate: 2s
 | `Ctrl+K` | Switch cluster |
 | `F2` | System alerts |
 | `F5` | Force refresh |
+| `F6` | Pause/resume global auto-refresh |
 | `F10` | Configuration settings |
 | `R` | Refresh current view |
 | `S` | Sort by column |
@@ -197,7 +198,6 @@ refreshRate: 2s
 | `d` | Show dependencies |
 | `b` | Batch operations |
 | `v` | Multi-select mode |
-| `m` | Toggle auto-refresh |
 
 ### Job Output Viewer (press `o`)
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,8 +1,12 @@
 # S9S Configuration Example
 # Copy this file to ~/.s9s/config.yaml and modify as needed
 
-# Refresh rate for automatic updates
-refreshRate: 2s
+# Refresh rate for automatic updates.
+# Applies to the currently focused view only; all views share this
+# single cadence (default: 10s). Set to an empty string ("") to
+# disable auto-refresh entirely — F5 and R still work for manual
+# refresh. F6 pauses/resumes at runtime without touching config.
+refreshRate: 10s
 
 # Maximum retries for API calls
 maxRetries: 3

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -148,7 +148,7 @@ The following schema reflects the actual `Config` struct in the codebase. All fi
 
 ```yaml
 # General settings
-refreshRate: duration        # Auto-refresh interval (default: 2s)
+refreshRate: duration        # Auto-refresh interval (default: 10s; "" disables)
 maxRetries: integer          # Max API retry attempts (default: 3)
 defaultCluster: string       # Active cluster name (default: "default")
 useMockClient: boolean       # Enable mock SLURM client (default: false)
@@ -292,7 +292,7 @@ ui:
   noIcons: false             # Disable icons
   enableMouse: true          # Enable mouse support
 
-refreshRate: 2s              # Auto-refresh interval
+refreshRate: 10s             # Auto-refresh interval (default: 10s; "" disables)
 ```
 
 ### Column Configuration
@@ -450,6 +450,42 @@ ui:
   skin: "default"
 ```
 
+### Refresh Rate
+
+`refreshRate` controls how often the currently focused view refreshes its
+data from slurmrestd. A single global cadence applies to every view — jobs,
+nodes, partitions, dashboard, health, performance, and the rest. The default
+is `10s`, which is a reasonable balance for most clusters.
+
+```yaml
+refreshRate: 10s   # default — applies to all views
+```
+
+**Disabling auto-refresh**: set `refreshRate` to an empty string:
+
+```yaml
+refreshRate: ""    # auto-refresh disabled; F5 and R still work for manual refresh
+```
+
+This is a deliberate, meaningful state — the validator will not rewrite it
+to a default. Useful on bandwidth-constrained links or slow schedulers where
+polling every few seconds is unwelcome.
+
+**Runtime toggle**: press `F6` at any time to pause or resume auto-refresh
+globally without touching your config file. The status bar shows the current
+state. Manual refresh (`F5` or `R`) always works regardless of the toggle.
+
+**Changing the rate live**: edit `refreshRate` via the F10 configuration
+modal and click Save — the ticker re-arms at the new cadence immediately,
+no restart required. Saving an invalid duration format will be rejected by
+validation.
+
+**Choosing a value**: values below `1s` are allowed but generate a warning
+because they put noticeable load on `slurmctld`. Values above `10m`
+generate a warning in the other direction because they'll show stale data.
+For production clusters with many concurrent s9s users, `15s`–`30s` is a
+courteous choice.
+
 ## Advanced Configuration
 
 ### Multiple Clusters
@@ -542,7 +578,7 @@ clusters:
       timeout: 60s
       insecure: false
 
-refreshRate: 2s
+refreshRate: 10s
 maxRetries: 5
 
 ui:
@@ -565,7 +601,7 @@ clusters:
       endpoint: https://slurm-dev.example.com:6820
       token: ${SLURM_JWT}
 
-refreshRate: 2s
+refreshRate: 5s
 
 ui:
   skin: default

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -184,8 +184,10 @@ echo $SLURM_JWT
 1. **Adjust refresh rate**:
    Change the `refreshRate` setting in your configuration file (`~/.s9s/config.yaml`):
    ```yaml
-   refreshRate: "10s"  # Slower refresh (default is 2s)
+   refreshRate: "30s"  # Slower refresh (default is 10s)
    ```
+   Or press `F6` at runtime to pause auto-refresh entirely; `F5` and `R`
+   still work for manual refresh.
 
 2. **Customize visible columns**:
    Configure columns in your configuration file:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -18,7 +18,7 @@ S9S uses a hierarchical configuration system with the following precedence (high
 The in-app Configuration modal is opened with `F10` or the `:config` command. It contains two setting groups:
 
 ### General
-- **Refresh Rate** (`refreshRate`) -- auto-refresh interval
+- **Refresh Rate** (`refreshRate`) -- global auto-refresh interval applied to every view (default: `10s`). Edits to this field are re-applied live: click Save and the running ticker immediately re-arms at the new cadence. Set to an empty string to disable auto-refresh entirely; `F5` and `R` still work for manual refresh, and `F6` toggles the pause at runtime without touching the config file.
 - **Default Cluster** (`defaultCluster`) -- which cluster to connect to on startup
 
 ### View Settings
@@ -39,7 +39,7 @@ All other configuration options (UI settings, feature flags, keyboard shortcuts,
 # ~/.s9s/config.yaml
 
 # General settings
-refreshRate: "2s"
+refreshRate: "10s"
 maxRetries: 3
 defaultCluster: "default"
 
@@ -279,8 +279,10 @@ aliases:
 ## General Settings
 
 ```yaml
-# Auto-refresh interval (default: 2s)
-refreshRate: "2s"
+# Auto-refresh interval applied to every view (default: 10s).
+# Set to "" to disable auto-refresh; F5/R still work for manual refresh,
+# and F6 toggles the pause at runtime without touching the config file.
+refreshRate: "10s"
 
 # Maximum API retries (default: 3)
 maxRetries: 3

--- a/docs/user-guide/filtering.md
+++ b/docs/user-guide/filtering.md
@@ -169,7 +169,7 @@ In the Nodes view:
 
 ### Auto-Refresh
 
-When auto-refresh is enabled (toggle with `m`/`M` in Jobs view), filters remain active as data refreshes. The filtered view updates automatically with each refresh cycle.
+Filters remain active as data refreshes on the global auto-refresh ticker. The filtered view updates automatically with each refresh cycle. Press `F6` to pause the global ticker if you want to freeze the view while reading; filters are preserved across pause/resume.
 
 ### Context-Aware Fields
 

--- a/docs/user-guide/job-management.md
+++ b/docs/user-guide/job-management.md
@@ -335,7 +335,7 @@ For more details, see the [Jobs View Guide](./views/jobs.md).
 | `d`/`D` | Dependencies | View job dependencies |
 | `p`/`P` | Toggle Pending | Toggle pending state filter |
 | `e`/`E` | Export | Open export dialog |
-| `m`/`M` | Auto-refresh | Toggle auto-refresh |
+| `F6` | Auto-refresh | Global pause/resume (applies to all views) |
 
 ### Batch Operations
 

--- a/docs/user-guide/keyboard-shortcuts.md
+++ b/docs/user-guide/keyboard-shortcuts.md
@@ -17,7 +17,8 @@ These shortcuts work from any view:
 | `l` | Next view | Move to next view |
 | `F1` | Help | Show help modal |
 | `F2` | Alerts | Show system alerts |
-| `F5` | Force refresh | Refresh current view data |
+| `F5` | Force refresh | Refresh current view data (always works) |
+| `F6` | Toggle auto-refresh | Pause or resume the global auto-refresh ticker |
 | `F10` | Configuration | Show configuration |
 | `Ctrl+K` | Switch cluster | Switch between configured clusters |
 | `Ctrl+C` | Exit application | Exit s9s entirely |
@@ -107,9 +108,11 @@ These shortcuts work from any view:
 | Key | Action | Description |
 |-----|--------|-------------|
 | `R` | Manual refresh | Refresh jobs data |
-| `m/M` | Toggle auto-refresh | Enable/disable auto-refresh (30s) |
 | `S` | Sort modal | Open interactive sorting dialog |
 | `e/E` | Export | Export job list to CSV/JSON/Text/Markdown/HTML |
+
+> Auto-refresh is now global: press `F6` from any view to pause or resume it.
+> The cadence is controlled by `refreshRate` in config (default `10s`).
 
 ## Nodes View
 
@@ -385,9 +388,11 @@ Works in Jobs and Nodes views.
 3. Makes large node lists easier to navigate
 
 ### Refresh Strategies
-- Three views auto-refresh: Jobs (30s), Health (10s), Performance (5s)
-- Use `R` for immediate manual refresh
-- Jobs view: `m/M` toggles auto-refresh on/off
+- All views share a single auto-refresh cadence controlled by `refreshRate` in config (default `10s`)
+- Only the currently focused view is refreshed by the global ticker — background views keep their last snapshot until you switch to them
+- Use `R` or `F5` for immediate manual refresh (always works, even when auto-refresh is paused)
+- Press `F6` to pause or resume auto-refresh globally without editing the config
+- Set `refreshRate: ""` in config to disable auto-refresh entirely
 
 ### Help When Stuck
 - Press `?` for context-sensitive help

--- a/docs/user-guide/navigation.md
+++ b/docs/user-guide/navigation.md
@@ -68,7 +68,6 @@ These shortcuts work across all views:
 | `d` | Dependencies | Show job dependencies |
 | `b` | Batch Ops | Enter batch operations mode |
 | `v` | Multi-Select | Toggle multi-select mode |
-| `m` | Auto Refresh | Toggle auto-refresh |
 | `/` | Filter | Filter jobs |
 | `f` | Advanced Filter | Open advanced filter bar |
 | `Ctrl+F` | Search | Global search across all entity types |

--- a/docs/user-guide/views/health.md
+++ b/docs/user-guide/views/health.md
@@ -304,7 +304,15 @@ Auto-refresh occurs every 10 seconds.
 
 ## Auto-Refresh
 
-Health view auto-refreshes every **10 seconds** to provide real-time monitoring.
+The Health view refreshes on the global auto-refresh ticker, controlled by
+`refreshRate` in config (default **10 seconds**). All views share this
+single cadence. Press `F6` to pause or resume auto-refresh globally, or
+`R`/`F5` for manual refresh.
+
+Note: the underlying `HealthMonitor` runs its own independent 30-second
+health-check cycle regardless of `refreshRate` — the UI refresh controls
+how often the view re-renders the current health state, not how often
+health is re-evaluated.
 
 ## Alert Example
 

--- a/docs/user-guide/views/index.md
+++ b/docs/user-guide/views/index.md
@@ -72,8 +72,8 @@ The following capabilities are available in all table-based data views (Jobs, No
 ### Refresh
 - **`R`** - Manual refresh
 - **`F5`** - Manual refresh (global)
-- **`m/M`** - Toggle auto-refresh (Jobs view)
-- Auto-refresh varies by view: Jobs (30s), Health (10s), Performance (5s). Other views (including Dashboard) use manual refresh with `R`.
+- **`F6`** - Pause/resume global auto-refresh (applies to every view)
+- All views share a single auto-refresh cadence controlled by `refreshRate` in config (default `10s`). Set to `""` to disable, or edit in the F10 modal to change it live.
 
 ### Help
 - **`?`** - Show help and keyboard shortcuts

--- a/docs/user-guide/views/jobs.md
+++ b/docs/user-guide/views/jobs.md
@@ -246,11 +246,17 @@ Press `S` to open the interactive sort modal. Select a column and sort direction
 
 ## Auto-Refresh
 
-Jobs view auto-refreshes every **30 seconds** by default.
+The Jobs view refreshes on the global auto-refresh ticker, controlled by
+`refreshRate` in config (default **10 seconds**). All views share this
+single cadence — editing `refreshRate` in the F10 modal re-arms the ticker
+live.
 
-**Toggle auto-refresh**: `m/M`
+**Toggle globally**: `F6` pauses or resumes auto-refresh across all views.
 
-When disabled, use `R` for manual refresh.
+**Manual refresh**: `R` or `F5` — always works, even when auto-refresh is
+paused.
+
+**Disable entirely**: set `refreshRate: ""` in config.
 
 ## Keyboard Shortcuts Reference
 
@@ -290,7 +296,8 @@ When disabled, use `R` for manual refresh.
 | Key | Action |
 |-----|--------|
 | `R` | Manual refresh |
-| `m/M` | Toggle auto-refresh |
+| `F5` | Manual refresh (global) |
+| `F6` | Pause/resume global auto-refresh |
 | `e/E` | Export view data |
 | `F1` | Help (global) |
 | `S` | Sort modal |
@@ -335,5 +342,5 @@ See [Job Management](../job-management.md) for detailed submission guide.
 - Use `p:name` syntax in simple filter for quick partition filtering
 - Check job output with `o/O` to debug issues
 - Use `d/D` to understand job dependencies before canceling
-- Enable auto-refresh (`m/M`) for monitoring active jobs
+- Lower `refreshRate` in F10 or press `F6` to toggle auto-refresh while monitoring active jobs
 - Press `?` when unsure what actions are available for a job

--- a/docs/user-guide/views/performance.md
+++ b/docs/user-guide/views/performance.md
@@ -4,7 +4,7 @@ The Performance view provides real-time cluster-wide metrics and utilization sta
 
 ![Performance Demo](/assets/demos/performance.gif)
 
-*Performance view showing cluster-wide job, node, and resource metrics with auto-refresh*
+*Performance view showing cluster-wide job, node, and resource metrics*
 
 ## Overview
 
@@ -69,16 +69,19 @@ Shows aggregate cluster utilization:
 
 | Key | Action |
 |-----|--------|
-| `R` | Toggle auto-refresh on/off |
 | `F5` | Manual refresh |
+| `F6` | Pause/resume global auto-refresh |
 
 ## Auto-Refresh
 
-The Performance view automatically refreshes every **5 seconds** by default when auto-refresh is enabled.
+The Performance view refreshes on the global auto-refresh ticker,
+controlled by `refreshRate` in config (default **10 seconds**). All views
+share this single cadence.
 
-- **Enable/Disable**: Press `R` to toggle
-- **Manual Refresh**: Press `F5` to update immediately
-- **Status Indicator**: Control bar shows auto-refresh state
+- **Manual refresh**: Press `F5` to update immediately
+- **Pause/resume globally**: Press `F6` — applies to every view, not just Performance
+- **Change cadence**: Edit `refreshRate` in the F10 configuration modal; changes apply live
+- **Disable entirely**: Set `refreshRate: ""` in config
 
 ## Interpretation Guide
 


### PR DESCRIPTION
## Summary

Follow-up to #189. That PR made `refreshRate` the single source of truth for auto-refresh cadence across every view, added `F6` as a global pause/resume toggle, bumped the default from `2s` to `10s`, and removed the per-view `m/M` toggle (and the performance view's `R` toggle). The docs still described the old world.

This PR brings every doc reference in line with the new behavior.

## Changes

### Default value updates (2s → 10s)
- \`README.md\`
- \`config.example.yaml\`
- \`docs/getting-started/configuration.md\` (four occurrences)
- \`docs/guides/troubleshooting.md\`
- \`docs/reference/configuration.md\` (three occurrences)

### Removed per-view cadence claims
Previously docs said things like *\"Jobs view auto-refreshes every **30 seconds** by default\"* and *\"Three views auto-refresh: Jobs (30s), Health (10s), Performance (5s)\"* — both inaccurate after #189. Updated:
- \`docs/user-guide/views/jobs.md\`
- \`docs/user-guide/views/performance.md\`
- \`docs/user-guide/views/health.md\`
- \`docs/user-guide/keyboard-shortcuts.md\`
- \`docs/user-guide/views/index.md\`

Each now explains that the global ticker drives every view at a single configurable cadence (default 10s), and that only the currently focused view is actually refreshed per tick (the existing behavior, just newly documented).

### Removed `m/M` and `R` per-view auto-refresh toggles
Those keys were removed in #189 in favor of the global `F6` toggle, but they still appeared in the keyboard reference tables:
- \`docs/user-guide/keyboard-shortcuts.md\`
- \`docs/user-guide/navigation.md\`
- \`docs/user-guide/job-management.md\`
- \`docs/user-guide/views/jobs.md\`
- \`docs/user-guide/views/performance.md\`
- \`docs/user-guide/views/index.md\`
- \`docs/user-guide/filtering.md\`
- \`README.md\`

### New documentation: F6 global toggle
Added to the Global Shortcuts table in \`docs/user-guide/keyboard-shortcuts.md\`, the README key-bindings table, and the refresh sections of every view doc that previously mentioned per-view toggles.

### New documentation: empty-string-disables semantics
\`refreshRate: \"\"\` is a deliberate, user-preserved state meaning \"auto-refresh off\" — documented in the Configuration Guide and the example config, along with the note that the validator will not rewrite it.

### New subsection: Refresh Rate in the Configuration Guide
\`docs/getting-started/configuration.md\` gains a dedicated \"Refresh Rate\" subsection under UI and Display Configuration covering:
- The default and that it applies to all views
- Disabling auto-refresh via empty string
- Runtime pause/resume via F6
- Live reconfiguration via the F10 modal (saves re-arm the ticker immediately)
- Rate-of-thumb guidance: < 1s generates a warning, > 10m generates a stale-data warning, 15–30s is courteous on shared clusters

### Note on Health view's dual cadence
\`docs/user-guide/views/health.md\` now explicitly calls out that the underlying \`HealthMonitor\` runs its own independent 30s check cycle separate from the UI refresh — this was already the case in code but never documented, and is easy to misread after the refresh-rate consolidation.

## Test plan

- [ ] Spot-check the rendered Markdown in GitHub for broken table alignment in the files that had rows removed
- [ ] \`grep -rn \"m/M.*auto.refresh\\|2s.*default\\|30 seconds.*default\\|5 seconds.*default\" docs/ README.md config.example.yaml\` returns empty (verified locally)
- [ ] Read through the new Refresh Rate subsection for tone consistency with the rest of the Configuration Guide

## Related

- Refactor that necessitated this: #189
- Follow-ups that may produce further doc updates:
  - #190 — if/when we copy config before ApplyConfig, no docs change needed
  - #191 — will likely add a section listing which fields apply live vs require restart
  - #188 — F1 help modal refactor, will likely need its own docs pass

## Notes for the release

This PR should merge before tagging 0.9.0. The README claiming a 2s default and documenting a non-existent keybinding is the kind of first-impression bug that generates confused issues from new users.