### PR TITLE
chore: prepare 0.9.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,22 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-04-08
+
 ### Added
 
 - **Job output streaming** — press `o` to view job output, `t` for real-time tail-f streaming, `s` to switch stdout/stderr, `e` to export (#157)
 - **Array job output patterns** — `%A` (array master ID) and `%a` (array task ID) now expanded in output file paths (#158)
 - **Enriched job detail modal** — shows TRES requested/allocated, GRES detail with GPU index, batch host, cluster, memory, CPUs, tasks, submit command line, and 22 additional SLURM API fields. State icons and organized sections (#159)
 - **GRES submission fix** — `gres: gpu:1` correctly mapped to `tres_per_node: gres/gpu:1` for SLURM REST API (#159)
+- **Global auto-refresh toggle (F6)** — pause or resume the global auto-refresh ticker from any view. Manual refresh (`R`, `F5`) still works while paused (#189)
+- **Live reconfiguration of `refreshRate`** — edit `refreshRate` in the F10 configuration modal, click Save, and the running ticker re-arms at the new cadence immediately. No restart required (#189)
+- **`j`/`k` scrolling in the F1 help modal** — advertised in the footer but was never wired; now works (#189)
 - **Dependabot** for dependency scanning, replacing Trivy (#163)
 - **gofmt gate in CI** — formatting enforced in lint job (#180)
 
 ### Changed
 
-- **Go minimum version** — bumped to Go 1.25 (Go 1.24 no longer receives security patches)
+- **`refreshRate` applies consistently across every view** — previously, views like Jobs, Health, and Performance ignored the user-configured `refreshRate` and used their own hardcoded cadences (30s, 10s, 5s respectively). All views now share a single global auto-refresh ticker driven by `refreshRate` (#189)
+- **Default `refreshRate` changed from `2s` to `10s`** — the old 2s default was too aggressive for shared clusters now that a single global ticker drives all views. Users with an explicit value in their config are unaffected (#189)
+- **Empty `refreshRate` is now a preserved state** — set `refreshRate: ""` to disable auto-refresh entirely. The validator no longer rewrites empty values to a default (#189)
+- **Go minimum version** — bumped to Go 1.25 (Go 1.24 no longer receives security patches) (#183)
 - **CI test matrix** — tests Go 1.25 and 1.26 (was 1.23 and 1.24)
+
+### Removed
+
+- **Per-view `m/M` auto-refresh toggle on Jobs view** — replaced by the global F6 toggle (#189)
+- **Per-view `R` auto-refresh toggle on Performance view** — replaced by the global F6 toggle (#189)
+- **Dead per-view refresh timers** — removed hardcoded `time.AfterFunc` tickers and dead `refreshTimer` fields from jobs, nodes, partitions, users, accounts, qos, reservations, dashboard, health, and performance views (#189)
 
 ### Fixed
 
+- **`refreshRate` never took effect** — the F10 modal saved to disk but the running ticker continued at its startup cadence (literal `TODO: Apply configuration changes to running components` in the code). Now wired through a new `ApplyConfig` method (#189)
+- **Data race on auto-refresh state** — `isRunning` and `autoRefresh` were written from the UI goroutine and read from the refresh goroutine without synchronization; now both use `atomic.Bool` (#189)
 - **Dashboard Analytics and Health Check modals** not responding to ESC/R (#160)
 - **Node operations when grouped** — Enter/drain/resume/SSH now work on indented nodes; Enter on group header toggles expansion (#161)
 - **Sort breaks grouping** — sort and group are now mutually exclusive (#161)
@@ -574,7 +590,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Note**: Versions prior to 0.1.0 were in active development and did not follow semantic versioning.
 
-[Unreleased]: https://github.com/jontk/s9s/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/jontk/s9s/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/jontk/s9s/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/jontk/s9s/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/jontk/s9s/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/jontk/s9s/compare/v0.6.3...v0.7.0

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -6,16 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Recent Changes
 
-### Post-0.8.0 (Unreleased)
+### Version 0.9.0 (2026-04-08)
 
-Job output viewer, enriched job details, and grouped node fixes:
+Refresh-rate consistency, job output viewer, enriched job details, and grouped node fixes:
 
+- **Unified Auto-Refresh**: All views now share a single refresh cadence driven by `refreshRate` in config. Previously, Jobs (30s), Health (10s), and Performance (5s) used hardcoded intervals that ignored the config. The per-view `m/M` toggle on Jobs and `R` toggle on Performance are removed in favor of a new global **F6** pause/resume
+- **Live Reconfiguration**: Editing `refreshRate` in the F10 modal re-arms the running ticker immediately — no restart required. Empty string (`refreshRate: ""`) is now a deliberate "auto-refresh disabled" state
+- **Default Refresh Rate**: Bumped from `2s` to `10s` — saner for shared clusters now that a single ticker drives all views
+- **Data Race Fix**: Auto-refresh state is now accessed via `atomic.Bool`, fixing a real cross-goroutine race
 - **Job Output Streaming**: Press `o` to view job output, `t` for real-time tail-f streaming, `s` to switch stdout/stderr, `e` to export
 - **Array Job Output Patterns**: `%A` and `%a` expanded in output file paths
 - **Enriched Job Detail Modal**: TRES requested/allocated, GRES with GPU index, batch host, cluster, memory, submit command line, and 22 additional SLURM fields
 - **GRES Submission Fix**: `gres: gpu:1` correctly mapped to `tres_per_node: gres/gpu:1`
-- **Go 1.25 Minimum**: Go 1.24 no longer receives security patches; CI tests Go 1.25 and 1.26
-- **Bug Fixes**: Dashboard modal ESC/R, node operations when grouped, sort/group mutual exclusivity, health checks stable ordering
+- **Go 1.25 Minimum**: Go 1.24 no longer receives security patches; source builds require Go 1.25+. Prebuilt binaries unaffected
+- **Bug Fixes**: Dashboard modal ESC/R, node operations when grouped, sort/group mutual exclusivity, health checks stable ordering, F1 help modal `j`/`k` scrolling
 - **Dependabot**: Replaces Trivy for dependency scanning
 - **gofmt CI Gate**: Formatting enforced in lint job
 
@@ -146,7 +150,8 @@ For a complete list of all changes, features, and fixes across all versions, ref
 
 ## Version History
 
-- [v0.8.0](../../CHANGELOG.md#080---2026-03-30) - Latest release
+- [v0.9.0](../../CHANGELOG.md#090---2026-04-08) - Latest release
+- [v0.8.0](../../CHANGELOG.md#080---2026-03-30) - Layouts, self-update, config overhaul
 - [v0.7.1](../../CHANGELOG.md#071---2026-03-21) - SLURM username config
 - [v0.7.0](../../CHANGELOG.md#070---2026-03-16) - Job templates
 - [v0.6.3](../../CHANGELOG.md#063---2026-03-14) - Performance and responsiveness

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -31,31 +31,31 @@ Download pre-built binaries from our [releases page](https://github.com/jontk/s9
 
 ```bash
 # Linux (x86_64)
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.8.0_Linux_x86_64.tar.gz
-tar -xzf s9s_0.8.0_Linux_x86_64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.9.0_Linux_x86_64.tar.gz
+tar -xzf s9s_0.9.0_Linux_x86_64.tar.gz
 mkdir -p ~/.local/bin
 mv s9s ~/.local/bin/
 
 # Linux (ARM64)
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.8.0_Linux_arm64.tar.gz
-tar -xzf s9s_0.8.0_Linux_arm64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.9.0_Linux_arm64.tar.gz
+tar -xzf s9s_0.9.0_Linux_arm64.tar.gz
 mkdir -p ~/.local/bin
 mv s9s ~/.local/bin/
 
 # macOS (Apple Silicon)
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.8.0_Darwin_arm64.tar.gz
-tar -xzf s9s_0.8.0_Darwin_arm64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.9.0_Darwin_arm64.tar.gz
+tar -xzf s9s_0.9.0_Darwin_arm64.tar.gz
 mkdir -p ~/.local/bin
 mv s9s ~/.local/bin/
 
 # macOS (Intel)
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.8.0_Darwin_x86_64.tar.gz
-tar -xzf s9s_0.8.0_Darwin_x86_64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.9.0_Darwin_x86_64.tar.gz
+tar -xzf s9s_0.9.0_Darwin_x86_64.tar.gz
 mkdir -p ~/.local/bin
 mv s9s ~/.local/bin/
 ```
 
-> **Note:** Replace `0.8.0` with the latest version from the [releases page](https://github.com/jontk/s9s/releases).
+> **Note:** Replace `0.9.0` with the latest version from the [releases page](https://github.com/jontk/s9s/releases).
 
 ### 3. Using Go Install
 
@@ -102,7 +102,7 @@ s9s --version
 
 You should see output like:
 ```
-S9S - SLURM Terminal UI version 0.8.0
+S9S - SLURM Terminal UI version 0.9.0
 ```
 
 ### 2. Initial Configuration
@@ -262,10 +262,10 @@ On Linux, if you get "cannot execute binary file":
 uname -m
 
 # For x86_64/AMD64
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.8.0_Linux_x86_64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.9.0_Linux_x86_64.tar.gz
 
 # For ARM64/aarch64
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.8.0_Linux_arm64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.9.0_Linux_arm64.tar.gz
 ```
 
 ## Upgrading
@@ -316,8 +316,8 @@ Or disable checks entirely via environment variable: `S9S_UPDATE_ENABLED=false`.
 curl -sSL https://get.s9s.dev | bash
 
 # If installed via binary download (replace version and arch as needed)
-curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.8.0_Linux_x86_64.tar.gz
-tar -xzf s9s_0.8.0_Linux_x86_64.tar.gz
+curl -LO https://github.com/jontk/s9s/releases/latest/download/s9s_0.9.0_Linux_x86_64.tar.gz
+tar -xzf s9s_0.9.0_Linux_x86_64.tar.gz
 mkdir -p ~/.local/bin
 mv s9s ~/.local/bin/
 


### PR DESCRIPTION
## Summary

Release prep for v0.9.0. Promotes the Unreleased section in both changelogs to 0.9.0, adds the #189 refresh-rate refactor entries, and bumps pinned version references in the installation docs.

Historically this project updates docs first and then tags the release; merging this lets us push the tag cleanly.

## Changes

### \`CHANGELOG.md\`
- Rename \`[Unreleased]\` section to \`[0.9.0] - 2026-04-08\` and add a fresh empty Unreleased section above
- Add new entries for #189 under Added, Changed, Removed, and Fixed:
  - **Added**: F6 global auto-refresh toggle, live reconfiguration of refreshRate via F10, j/k scrolling in F1 help modal
  - **Changed**: refreshRate now applies to every view, default 2s → 10s, empty refreshRate preserved as disabled
  - **Removed**: per-view m/M (Jobs) and R (Performance) auto-refresh toggles; dead per-view timer code
  - **Fixed**: refreshRate edits via F10 never taking effect (TODO removed), data race on isRunning/autoRefresh
- Add \`[0.9.0]\` link ref at the bottom

### \`docs/about/changelog.md\`
- Rename \`Post-0.8.0 (Unreleased)\` section to \`Version 0.9.0 (2026-04-08)\`
- Rewrite the summary to lead on the refresh-rate consistency work (the most user-visible change)
- Update the Version History list to promote 0.9.0 to latest

### \`docs/getting-started/installation.md\`
- Bump pinned binary version from \`0.8.0\` to \`0.9.0\` in the curl examples (6 occurrences)

## Test plan

- [ ] \`grep -rn \"v0\\.8\\.0\\|0\\.8\\.0\" docs/ README.md\` returns only historical/changelog references
- [ ] CHANGELOG.md link at the bottom resolves once the tag is pushed
- [ ] Rendered Markdown for docs/about/changelog.md looks right

## After merge

Once this is on \`main\`, re-tag \`v0.9.0\` on the merge commit and push:

\`\`\`
git tag -a v0.9.0 -m \"...\"
git push origin v0.9.0
\`\`\`

The release workflow will trigger goreleaser, which builds binaries and publishes the GitHub release. The release body will be enriched post-hoc with a richer narrative (Go 1.25 bump, refresh-rate story, known follow-ups linking #187, #190, #191).

## Context

The tag was originally pushed on \`ca213e6\` before I realized the changelogs were still on \"Post-0.8.0 (Unreleased)\". The tag and workflow were cancelled and deleted; this PR redoes it properly.