### PR TITLE
Avoid adding a fictious cluster when the *SLURM_REST_URL environment …

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -397,7 +397,7 @@ func applyEnvironmentOverrides(cfg *Config) {
 	}
 
 	// If endpoint is set in environment, it overrides everything
-	if endpoint != "" {
+	if endpoint != "" && token != "" {
 		// Create or update default context with environment values
 		defaultEntry := ClusterContext{
 			Name: "default",


### PR DESCRIPTION
Avoid adding a fictious cluster when the *SLURM_REST_URL environment variable is set but *SLURM_JWT is not set

# Pull Request

## Description
When SLURM_REST_URL or S9S_SLURM_REST_URL is set, a "cluster" is always added in cfg.Clusters even when the token is not in the environment variables.

Later in the code there is a auto-discovery of the token which adds it in cfg.Cluster but the change is not reflected in the corresponding cfg.Clusters

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test improvement

## Related Issues
Fixes #209 

## Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ X] New and existing unit tests pass locally with my changes
- [ X] I have tested this manually with:
  - [X ] Real SLURM cluster
  - [ ] Mock mode
  - [ ] Different operating systems: Linux / macOS / Windows

## Screenshots (if applicable)
Add screenshots to help explain your changes.

## Code Quality & Linting
- [X] Code passes golangci-lint checks (`make lint`)
- [X] Code is formatted with gofumpt (`make fmt`)
- [X] No new linter warnings introduced (especially revive violations)
- [ X] All exported symbols have godoc comments (package level + public APIs)
- [ X] Pre-commit hooks pass (if installed locally)
- [ X] Nolint directives include specific rule names and justification comments
- [ X] No unused parameters (use `_` if required by interface)

## Checklist
- [ X] My code follows the code style of this project and passes all linters
- [ X] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules

